### PR TITLE
attempt to fix test_assets failing for me.

### DIFF
--- a/app/modules/assets/resources.py
+++ b/app/modules/assets/resources.py
@@ -43,7 +43,9 @@ class Assets(Resource):
         Returns a list of Asset starting from ``offset`` limited by ``limit``
         parameter.
         """
-        return Asset.query.offset(args['offset']).limit(args['limit'])
+        return (
+            Asset.query.order_by(Asset.guid).offset(args['offset']).limit(args['limit'])
+        )
 
 
 @api.route('/<uuid:asset_guid>')

--- a/app/modules/submissions/models.py
+++ b/app/modules/submissions/models.py
@@ -281,9 +281,10 @@ class Submission(db.Model, HoustonModel):
         files = []
         skipped = []
         errors = []
-        walk_list = list(os.walk(submission_path))
+        walk_list = sorted(list(os.walk(submission_path)))
         print('Walking submission...')
         for root, directories, filenames in tqdm.tqdm(walk_list):
+            filenames = sorted(filenames)
             for filename in filenames:
                 filepath = os.path.join(root, filename)
 

--- a/tests/modules/assets/resources/test_assets.py
+++ b/tests/modules/assets/resources/test_assets.py
@@ -146,16 +146,13 @@ def test_read_all_assets(
         assert admin_response.status_code == 200
         assert admin_response.content_type == 'application/json'
         assert len(admin_response.json) == 2
-        # update: it seems this order received _is not_ deterministic
+        # admin_response.json should now be in lexographical order of guid
+        # still unsure if test_clone_submission_data is deterministic!  but these 2 appear to be also lexographical.
         assert (
-            test_clone_submission_data['asset_uuids'][0] == admin_response.json[0]['guid']
-            or test_clone_submission_data['asset_uuids'][0]
-            == admin_response.json[1]['guid']
+            admin_response.json[0]['guid'] == test_clone_submission_data['asset_uuids'][0]
         )
         assert (
-            test_clone_submission_data['asset_uuids'][1] == admin_response.json[0]['guid']
-            or test_clone_submission_data['asset_uuids'][1]
-            == admin_response.json[1]['guid']
+            admin_response.json[1]['guid'] == test_clone_submission_data['asset_uuids'][1]
         )
         assert regular_response.status_code == 403
 


### PR DESCRIPTION
making this its own PR ... applying [guid-ordering fix suggested](https://github.com/WildMeOrg/houston/pull/30#discussion_r562865749) by @bluemellophone 

note: while this should guarantee order of assets from **GET /api/v1/assets** -- i guess there could still be the chance that the asset order from the cloned submission is non-deterministic!   lets see what others find out.....