### PR TITLE
Add Codecov Support and Coverage Reports to PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,20 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...90"
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: no

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,27 @@
 [run]
-source=app
+branch = True
+source = app
+omit =
+    _db/*
+    local_config.py
+    setup.py
+    migrations/*
+    tasks/*
+    virtualenv/*
+
+[report]
+exclude_lines =
+    pragma: no cover
+    # NOCC
+    raise NotImplementedError
+    if __name__ == .__main__.:
+precision = 1
+ignore_errors = True
+omit =
+    tests/*
+
+[html]
+directory = ./_coverage/html/
+
+[xml]
+output = ./_coverage/coverage.xml

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -47,6 +47,8 @@ $ invoke app.module.task
   - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
 - [ ] Ensure that the PR is properly tested
   - Example: All automated tests are passing
+- [ ] Ensure that the PR is properly covered
+  - Example: The percentage of the code covered by tests has not decreased
 - [ ] Ensure that the PR is properly sanitized
   - Example: No sensitive data or large content was added to this PR
 - [ ] Ensure that the PR is properly reviewed

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -47,7 +47,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         python-version: [3.7]
-
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
     steps:
       # Checkout and env setup
       - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest
+          pip install flake8 pytest pytest-cov
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names
@@ -97,3 +97,17 @@ jobs:
         run: |
           source virtualenv/houston3.7/bin/activate
           pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
+
+      - name: Run Codecov
+        continue-on-error: true
+        run: |
+          source virtualenv/houston3.7/bin/activate
+          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}" --cov=./ --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1.0.7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./_coverage/coverage.xml
+          env_vars: OS,PYTHON
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+_coverage/
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+![Tests](https://github.com/WildMeOrg/houston/workflows/Testing/badge.svg?branch=develop)
+[![Codecov](https://codecov.io/gh/WildMeOrg/houston/branch/develop/graph/badge.svg?token=M8MR14ED6V)](https://codecov.io/gh/WildMeOrg/houston)
+[![Docker Nightly](https://img.shields.io/docker/image-size/wildme/houston/nightly)](https://hub.docker.com/r/wildme/houston)
 
 Wild Me - Houston Backend Server
 ======================================================

--- a/README.md
+++ b/README.md
@@ -54,10 +54,17 @@ To submit a pull request (PR) to Houston, we require the following standards to 
   invoke app.db.heads  # Ensure that there is only one head
   ```
 * **Ensure that the PR is properly tested**
-  * We require new feature code to be tested via Python tests and simulated REST API tests.  We use PyTest (and eventually Coverage) to ensure that your code is working cohesively and that any new functionality is exercised.
+  * We require new feature code to be tested via Python tests and simulated REST API tests.  We use PyTest  to ensure that your code is working cohesively and that any new functionality is exercised.
   * We require new feature code to also be fully compatible with a containerized runtime environment like Docker.
   ```
   pytest
+  ```
+* **Ensure that the PR is properly covered**
+  * We require new feature code to be tested (previous item) and that the percentage of the code covered by tests does not decrease.  We use PyTest Coverage and CodeCov.io to ensure that your code is being properly covered by new tests.
+  * To export a HTML report of the current coverage statistics, run the following:
+  ```
+  pytest -s -v --cov=./ --cov-report=html
+  open _coverage/html/index.html
   ```
 * **Ensure that the PR is properly sanitized**
   * We require the PR to not include large files (images, database files, etc) without using [GitHub Large File Store (LFS)](https://git-lfs.github.com).


### PR DESCRIPTION
## Pull Request Overview

- This PR adds support for [CodeCov](https://codecov.io/gh/WildMeOrg/houston)
- When the tests run in Github, a report is submitted and a comment is added to the PR about the delta coverage of our tests

---

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
- [x] Ensure that the PR is properly rebased
  - The PR is rebased on `develop` (commit: `daea113`)
- [X] Ensure that the PR uses a consolidated database migration
  - None proposed
- [x] Ensure that the PR is properly tested
- [x] Ensure that the PR is properly sanitized
  - A new GitHub secret key was added to this repository as `CODECOV_TOKEN` to authenticate our coverage report uploads to CodeCov
- [x] Ensure that the PR is properly reviewed
