### PR TITLE
Tuning up the container and general installation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,8 +26,7 @@ _frontend/
 clients/
 docs/
 tests/
-# FIXME (5-Feb-12021) punched through so that the `pip install .` may work in the container.
-#       Intending to fix soon.
+# Maintains the requirements file for setup.py logic
 !tests/requirements.txt
 devops/
 virtualenv/

--- a/.dockerignore
+++ b/.dockerignore
@@ -26,6 +26,9 @@ _frontend/
 clients/
 docs/
 tests/
+# FIXME (5-Feb-12021) punched through so that the `pip install .` may work in the container.
+#       Intending to fix soon.
+!tests/requirements.txt
 devops/
 virtualenv/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,4 +38,4 @@ USER nobody
 EXPOSE 5000
 ENV FLASK_CONFIG production
 
-CMD ["invoke", "app.run", "--host", "0.0.0.0" ]
+CMD [ "invoke", "app.run" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,5 @@
 FROM python:3.7
 
-ENV INSTALL_PATH=/opt/houston
-
-WORKDIR "${INSTALL_PATH}"
-
 RUN apt update \
  # && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
  && apt update \
@@ -26,19 +22,19 @@ RUN apt update \
         # nodejs \
  && rm -rf /var/lib/apt/lists/*
 
-COPY . .
+COPY . /code
 
-RUN cd ${INSTALL_PATH} \
- && ./scripts/venv.sh \
- && virtualenv/houston3.7/bin/pip install -U pip \
- && virtualenv/houston3.7/bin/pip install -r app/requirements.txt \
- && virtualenv/houston3.7/bin/pip install -r tasks/requirements.txt \
- && virtualenv/houston3.7/bin/pip install utool ipython \
- && rm -rf ~/.cache/pip \
- && chown -R nobody .
+WORKDIR /code
+
+RUN set -ex \
+ && pip install -e . \
+ #: Install developer tools
+ && pip install utool ipython \
+ #: Remove pip download cache
+ && rm -rf ~/.cache/pip
 
 USER nobody
 EXPOSE 5000
 ENV FLASK_CONFIG production
 
-CMD ["virtualenv/houston3.7/bin/invoke", "app.run", "--host", "0.0.0.0" ]
+CMD ["invoke", "app.run", "--host", "0.0.0.0" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ WORKDIR /code
 
 RUN set -ex \
  && pip install -e . \
+ && invoke app.dependencies.install \
  #: Install developer tools
  && pip install utool ipython \
  #: Remove pip download cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,5 +38,6 @@ RUN cd ${INSTALL_PATH} \
  && chown -R nobody .
 
 USER nobody
+EXPOSE 5000
 
 CMD ["virtualenv/houston3.7/bin/invoke", "app.run", "--host", "0.0.0.0" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,6 @@ RUN cd ${INSTALL_PATH} \
 
 USER nobody
 EXPOSE 5000
+ENV FLASK_CONFIG production
 
 CMD ["virtualenv/houston3.7/bin/invoke", "app.run", "--host", "0.0.0.0" ]

--- a/README.md
+++ b/README.md
@@ -425,13 +425,17 @@ $ cd houston/
 
 It is recommended to use virtualenv or Anaconda/Miniconda to manage Python
 dependencies. Please, learn details yourself.
+For quickstart purposes the following will set up a virtualenv for you:
 
-You will need `invoke` package to work with everything related to this project.
+```bash
+$ ./scripts/venv.sh
+$ source virtualenv/houston3.7/bin/activate
+```
+
+Set up and install the package:
 
 ```bash
 $ tar -zxvf _db.initial.tar.gz
-$ ./scripts/venv.sh
-$ source virtualenv/houston3.7/bin/activate
 $ pip install -r requirements.txt
 $ invoke app.dependencies.install-python-dependencies
 $ invoke app.dependencies.install-swagger-ui

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
--r tasks/requirements.txt
--r app/requirements.txt
--r tests/requirements.txt

--- a/scripts/build.frontend.sh
+++ b/scripts/build.frontend.sh
@@ -55,7 +55,7 @@ fi
 
 # Build dist of the frontend UI
 #  you can alter houston url here if desired
-npm run build -- --houston ""
+npm run build -- --env=houston=relative
 
 # Package
 tar -zcvf dist.${GIT_BRANCH}.${TIMESTAMP}.tar.gz dist/

--- a/scripts/build.frontend.sh
+++ b/scripts/build.frontend.sh
@@ -3,6 +3,11 @@
 
 set -e
 
+if [ ! -d "_frontend" ]; then
+    echo "Checking out  submodules..."
+    git submodule update --init --recursive
+fi
+
 # Build within a Node container
 if [[ "$1" != "--exec" ]]; then
     echo "Running the frontend build within Docker..."
@@ -24,10 +29,6 @@ function parse_datetime() {
 
 # Update code
 cd _frontend/
-
-# git checkout master
-git checkout develop
-git pull
 
 # Get current commit hash
 GIT_BRANCH=$(parse_git_hash)

--- a/scripts/build.frontend.sh
+++ b/scripts/build.frontend.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
+# Assumes it is run from the project root.
 
-# Ubuntu / Debian
-#   curl -sL https://deb.nodesource.com/setup_14.x | sudo -E bash -
-#   sudo apt-get install -y nodejs
-#
-# MacOS
-#   sudo port install nodejs14 npm6
+set -e
+
+# Build within a Node container
+if [[ "$1" != "--exec" ]]; then
+    echo "Running the frontend build within Docker..."
+    docker run -v $(pwd)/:/code -w /code node:latest /bin/bash -c "./scripts/build.frontend.sh --exec"
+    echo "Finished running the build within Docker"
+    exit $?
+fi
+
+set -ex
 
 # Get last commit hash prepended with @ (i.e. @8a323d0)
 function parse_git_hash() {

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -15,3 +15,4 @@ rm -rf wheelhouse
 
 CLEAN_PYTHON='find . -iname __pycache__ -exec rm -rv {} \; && find . -iname *.pyc -delete && find . -iname *.pyo -delete'
 bash -c "$CLEAN_PYTHON"
+python setup.py clean

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,7 +4,6 @@
 
 source virtualenv/houston3.7/bin/activate
 
-pip install -r requirements.txt
-pip install -e .
+pip install -e ".[testing]"
 
 invoke app.dependencies.install

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,4 @@ source virtualenv/houston3.7/bin/activate
 pip install -r requirements.txt
 pip install -e .
 
-invoke app.dependencies.install-python-dependencies
-invoke app.dependencies.install-swagger-ui
 invoke app.dependencies.install

--- a/scripts/run_developer_setup.sh
+++ b/scripts/run_developer_setup.sh
@@ -2,8 +2,4 @@
 
 ./scripts/clean.sh
 
-pip install -r requirements.txt
-
-python setup.py develop
-
-pip install -e .
+pip install -e ".[testing]"

--- a/scripts/run_developer_setup.sh
+++ b/scripts/run_developer_setup.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
 ./scripts/clean.sh
-python setup.py clean
 
 pip install -r requirements.txt
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ single-quotes = true
 
 [tool:pytest]
 minversion = 5.4
-addopts = -v -p no:doctest --xdoctest --xdoctest-style=google --random-order --random-order-bucket=global
+addopts = -v -p no:doctest --xdoctest --xdoctest-style=google --random-order --random-order-bucket=global --cov=./ --cov-report html
 testpaths =
     app
     tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ single-quotes = true
 
 [tool:pytest]
 minversion = 5.4
-addopts = -p no:doctest --xdoctest --xdoctest-style=google --random-order --random-order-bucket=global
+addopts = -v -p no:doctest --xdoctest --xdoctest-style=google --random-order --random-order-bucket=global
 testpaths =
     app
     tests

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,7 @@ from __future__ import absolute_import, print_function, division
 import subprocess
 import os
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
 
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -98,17 +98,95 @@ full_version = '%%(version)s.%%(git_revision)s' %% {
         print(e)
 
 
+def parse_requirements(fname='requirements.txt', with_version=True):
+    """
+    Parse the package dependencies listed in a requirements file but strips
+    specific versioning information.
+
+    Args:
+        fname (str): path to requirements file
+        with_version (bool, default=True): if true include version specs
+
+    Returns:
+        List[str]: list of requirements items
+
+    CommandLine:
+        python -c "import setup; print(setup.parse_requirements())"
+        python -c "import setup; print(chr(10).join(setup.parse_requirements(with_version=True)))"
+    """
+    import re
+    import sys
+    from os.path import exists
+
+    require_fpath = fname
+
+    def parse_line(line):
+        """
+        Parse information from a line in a requirements text file
+        """
+        if line.startswith('-r '):
+            # Allow specifying requirements in other files
+            target = line.split(' ')[1]
+            for info in parse_require_file(target):
+                yield info
+        else:
+            info = {'line': line}
+            if line.startswith('-e '):
+                info['package'] = line.split('#egg=')[1]
+            else:
+                # Remove versioning from the package
+                pat = '(' + '|'.join(['>=', '==', '>']) + ')'
+                parts = re.split(pat, line, maxsplit=1)
+                parts = [p.strip() for p in parts]
+
+                info['package'] = parts[0]
+                if len(parts) > 1:
+                    op, rest = parts[1:]
+                    if ';' in rest:
+                        # Handle platform specific dependencies
+                        # http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-platform-specific-dependencies
+                        version, platform_deps = map(str.strip, rest.split(';'))
+                        info['platform_deps'] = platform_deps
+                    else:
+                        version = rest  # NOQA
+                    info['version'] = (op, version)
+            yield info
+
+    def parse_require_file(fpath):
+        with open(fpath, 'r') as f:
+            for line in f.readlines():
+                line = line.strip()
+                if line and not line.startswith('#'):
+                    for info in parse_line(line):
+                        yield info
+
+    def gen_packages_items():
+        if exists(require_fpath):
+            for info in parse_require_file(require_fpath):
+                parts = [info['package']]
+                if with_version and 'version' in info:
+                    parts.extend(info['version'])
+                if not sys.version.startswith('3.4'):
+                    # apparently package_deps are broken in 3.4
+                    platform_deps = info.get('platform_deps')
+                    if platform_deps is not None:
+                        parts.append(';' + platform_deps)
+                item = ''.join(parts)
+                yield item
+
+    packages = list(gen_packages_items())
+    return packages
+
+
 def do_setup():
-    paths = [
-        'tasks/requirements.txt',
-        'app/requirements.txt',
-        'tests/requirements.txt',
-    ]
+    # Define requirements
     requirements = []
-    for path in paths:
-        with open(os.path.abspath(os.path.join('.', path))) as req_file:
-            requirements_ = req_file.read().splitlines()
-            requirements += requirements_
+    requirements.extend(parse_requirements('tasks/requirements.txt'))
+    requirements.extend(parse_requirements('app/requirements.txt'))
+    # Define optional requirements (e.g. `pip install ".[testing]"`)
+    optional_requirements = {
+        'testing': parse_requirements('tests/requirements.txt'),
+    }
 
     write_version_py()
     setup(
@@ -124,6 +202,7 @@ def do_setup():
         platforms=PLATFORMS,
         packages=PACKAGES,
         install_requires=requirements,
+        extras_require=optional_requirements,
         keywords=CLASSIFIERS.replace('\n', ' ').strip(),
     )
 

--- a/tasks/app/dependencies.py
+++ b/tasks/app/dependencies.py
@@ -24,7 +24,7 @@ def install_python_dependencies(context, force=False):
     Install Python dependencies listed in requirements.txt.
     """
     log.info('Installing project dependencies...')
-    context.run('pip install -r requirements.txt %s' % ('--upgrade' if force else ''))
+    context.run('pip install %s -e .' % ('--upgrade' if force else ''))
     log.info('Project dependencies are installed.')
 
 

--- a/tasks/app/run.py
+++ b/tasks/app/run.py
@@ -23,10 +23,13 @@ from ._utils import app_context_task
 log = logging.getLogger(__name__)
 
 
+DEFAULT_HOST = '0.0.0.0'
+
+
 @app_context_task()
 def warmup(
     context,
-    host='127.0.0.1',
+    host=DEFAULT_HOST,
     flask_config=None,
     install_dependencies=False,
     build_frontend=True,
@@ -35,10 +38,6 @@ def warmup(
     """
     Pre-configure the Houston API Server before running
     """
-    # Automatically use the production config when running a public web server
-    if host in ['0.0.0.0'] and flask_config is None:
-        flask_config = 'production'
-
     if flask_config is not None:
         os.environ['FLASK_CONFIG'] = flask_config
 
@@ -73,7 +72,7 @@ def warmup(
 @task(default=True)
 def run(
     context,
-    host='127.0.0.1',
+    host=DEFAULT_HOST,
     port=5000,
     flask_config=None,
     install_dependencies=False,

--- a/tests/test_app_creation.py
+++ b/tests/test_app_creation.py
@@ -5,6 +5,15 @@ import pytest
 from app import CONFIG_NAME_MAPPER, create_app
 
 
+@pytest.fixture(autouse=True)
+def unset_FLASK_CONFIG(monkeypatch):
+    """Don't allow a globally set ``FLASK_CONFIG`` environ var
+    to influence the testing context
+
+    """
+    monkeypatch.delenv('FLASK_CONFIG', raising=False)
+
+
 def test_create_app():
     try:
         create_app(testing=True)

--- a/tests/test_app_creation.py
+++ b/tests/test_app_creation.py
@@ -29,7 +29,7 @@ def test_create_app_passing_flask_config_name(monkeypatch, flask_config_name):
         from config import ProductionConfig
 
         monkeypatch.setattr(ProductionConfig, 'SQLALCHEMY_DATABASE_URI', 'sqlite://')
-        monkeypatch.setattr(ProductionConfig, 'SECRET_KEY', 'secret')
+        monkeypatch.setattr(ProductionConfig, 'SECRET_KEY', 'secret', raising=False)
     create_app(flask_config_name=flask_config_name, testing=True)
 
 
@@ -40,7 +40,7 @@ def test_create_app_passing_FLASK_CONFIG_env(monkeypatch, flask_config_name):
         from config import ProductionConfig
 
         monkeypatch.setattr(ProductionConfig, 'SQLALCHEMY_DATABASE_URI', 'sqlite://')
-        monkeypatch.setattr(ProductionConfig, 'SECRET_KEY', 'secret')
+        monkeypatch.setattr(ProductionConfig, 'SECRET_KEY', 'secret', raising=False)
     create_app(testing=True)
 
 


### PR DESCRIPTION
## Pull Request Overview

- Enable coverage reporting to html
- Run tests in verbose mode
- Fix app creation tests failing around missing setting
- Unset FLASK_CONFIG in tests incase of external environ var
- Set default host to 0.0.0.0 and don't assume production
- Invoke app.dependencies.install within container
- Seek to use only one installation paradigm
- Remove redundant install commands
- Move clean operation to clean script
- Remove install redunancy
- Checkout the frontend submodule when not existing
- Build the frontend within a container
- Correct frontend build error
- Document the division between venv setup and installation
- Make the testing requirements optional
- Require setuptools for additional dist features
- Drop virtualenv concept from the container
- Assign the default configuration key to use
- Expose default service port in container definition


---

**Review Notes**
Might be best to review the commits one by one. They are fairly encapsulated.

**Invoke CLI Updates**

```
$ invoke app.dependencies.install
```

The behavior of this command has slightly changed. This now also installs the app via pip rather than simply installing it's dependencies. This was done to reduce the ways in which the application can be installed (i.e. pythonic: one and only one way).
