### PR TITLE
Fix invalid version if not installing from git

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,9 @@ MINOR = 1
 MICRO = 0
 REVISION = git_version()
 SUFFIX = REVISION[:8]
-VERSION = '%d.%d.%d.%s' % (MAJOR, MINOR, MICRO, SUFFIX)
+VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
+if SUFFIX:
+    VERSION = '%s.%s' % (VERSION, SUFFIX)
 PACKAGES = ['.']
 
 


### PR DESCRIPTION
If the houston directory is not a git repo (`.git` doesn't exist),
`pip install .` returns an error:

```
Building wheels for collected packages: Houston
  Building wheel for Houston (PEP 517) ... done
  Created wheel for Houston: filename=Houston-0.1.0.-py3-none-any.whl size=8587 sha256=a5afdfce48044345dee663277135bb31bf649e462572b99e4adeac1e7226a6f7
  Stored in directory: /tmp/pip-ephem-wheel-cache-mwho1sd9/wheels/2c/91/06/f2d2f93c2e91eb27eb493240f0cb8ff4b6511d07a0a1f7997d
  WARNING: Built wheel for Houston is invalid: Metadata 1.2 mandates PEP 440 version, but '0.1.0.' is not
Failed to build Houston
ERROR: Could not build wheels for Houston which use PEP 517 and cannot be installed directly
```

(The trailing period at the end of `0.1.0.` is invalid)

After this change, if installing from git:

```
>>> from setup import VERSION
>>> VERSION
'0.1.0.c3a98a04'
```

if not installing from git:

```
>>> from setup import VERSION
fatal: not a git repository (or any of the parent directories): .git
>>> VERSION
'0.1.0'
```

---

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
