### PR TITLE
Fix frontend build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "_frontend"]
 	path = _frontend
-	url = https://github.com/WildbookOrg/wildbook-frontend.git
+	url = https://github.com/WildMeOrg/codex-frontend.git

--- a/scripts/build.frontend.sh
+++ b/scripts/build.frontend.sh
@@ -3,7 +3,8 @@
 
 set -e
 
-if [ ! -d "_frontend" ]; then
+# Look for a previous submodule checkout prior to initializing
+if [ ! -d _frontend/package.json ]; then
     echo "Checking out  submodules..."
     git submodule update --init --recursive
 fi


### PR DESCRIPTION
## Pull Request Overview

- Updates the _frontend submodule remote
- Fixes the `./scripts/build.frontend.sh` by checking for a specific checkout file

This may require developers to blow away their previous build with `rm -rf _frontend`. But that's likely not a bad thing to do anyway, since the changes from #41 updated the checkout point anyway.

---

**Review Notes**

To test this, run either of the following:

```
git clone -b fix-frontend-build git@github.com:WildMeOrg/houston.git
cd houston
./scripts/build.frontend.sh
```
OR
```
git clone -b fix-frontend-build --recursive-submodules git@github.com:WildMeOrg/houston.git
cd houston
./scripts/build.frontend.sh
```

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [x] Ensure that the PR is properly reviewed
