### PR TITLE
Simplify PR rebase instructions on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ To submit a pull request (PR) to Houston, we require the following standards to 
 * **Ensure that the PR is properly rebased**
   * We require new feature code to be rebased onto the latest version of the `develop` branch.
   ```
-  git checkout develop
-  git pull --rebase  # Use the following to make this the default: git config pull.rebase true
+  git fetch -p
   git checkout <feature-branch>
-  git pull
-  git rebase develop
+  git diff origin/<feature-branch>..  # Check there's no difference between local branch and remote branch
+  git rebase -i origin/develop  # "Pick" all commits in feature branch
   # Resolve all conflicts
-  git merge develop  # Sanity check
+  git log --graph --oneline --decorate origin/develop HEAD  # feature-branch commits should be on top of origin/develop
+  git show --reverse origin/develop..  # Check the changes in each commit if necessary
   git push --force origin <feature-branch>
   ```
 * **Ensure that the PR uses a consolidated database migration**


### PR DESCRIPTION
Instead of using the local branch "develop", use "origin/develop" and
skip all the steps for maintaining the "develop" branch.

Skip "git pull" in feature branch.  Most of the time there's no one else
pushing to the branch so just assume the local branch is up to date.

Skip "git merge develop" after rebase as it might create a merge commit
if rebase isn't done properly.

Use interactive rebase to allow the user to pick the commits to rebase
instead of just letting git decide.

Add more commands "git log" and "git show" for checking state after
rebase.

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
