### PR TITLE
Dex164 researcher contributor

### DIFF
--- a/app/modules/encounters/models.py
+++ b/app/modules/encounters/models.py
@@ -67,13 +67,6 @@ class Encounter(db.Model, FeatherModel):
     def is_public(self):
         return self.public
 
-    def has_read_permission(self, obj):
-        # todo, check if the encounter owns the sighting once Colin's sightings code is merged in
-        # if isinstance(obj, Sighting):
-        # check sightings array
-        # else look to see if the object is owned by any sighting
-        return False
-
     def get_assets(self):
         return [ref.asset for ref in self.assets]
 

--- a/app/modules/encounters/parameters.py
+++ b/app/modules/encounters/parameters.py
@@ -4,11 +4,12 @@ Input arguments (Parameters) for Encounters resources RESTful API
 -----------------------------------------------------------
 """
 
-# from flask_marshmallow import base_fields
-from flask_restplus_patched import Parameters, PatchJSONParameters
+from flask_login import current_user
+from flask_restplus_patched import Parameters, PatchJSONParametersWithPassword
 
 from . import schemas
-from .models import Encounter
+
+from app.modules.users.permissions import rules
 
 
 class CreateEncounterParameters(Parameters, schemas.DetailedEncounterSchema):
@@ -16,8 +17,29 @@ class CreateEncounterParameters(Parameters, schemas.DetailedEncounterSchema):
         pass
 
 
-class PatchEncounterDetailsParameters(PatchJSONParameters):
+class PatchEncounterDetailsParameters(PatchJSONParametersWithPassword):
     # pylint: disable=abstract-method,missing-docstring
-    OPERATION_CHOICES = (PatchJSONParameters.OP_REPLACE,)
 
-    PATH_CHOICES = tuple('/%s' % field for field in (Encounter.owner.key,))
+    # Valid options for patching are '/owner'
+    # The '/current_password' and user are not patchable but must be valid fields in the patch so that they can be
+    # present for validation
+    VALID_FIELDS = ['current_password', 'user', 'owner']
+    PATH_CHOICES = tuple('/%s' % field for field in VALID_FIELDS)
+
+    @classmethod
+    def replace(cls, obj, field, value, state):
+        from app.modules.users.models import User
+
+        super(PatchEncounterDetailsParameters, cls).replace(obj, field, value, state)
+        ret_val = False
+        if field == 'owner':
+            # owner is permitted to assign project ownership to another researcher
+            user = User.query.get(value)
+            if (
+                rules.owner_or_privileged(current_user, obj)
+                and user
+                and user.is_researcher
+            ):
+                obj.owner = user
+                ret_val = True
+        return ret_val

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -578,12 +578,8 @@ class User(db.Model, FeatherModel, UserEDMMixin):
         if isinstance(obj, User):
             ret_val = obj == self
         # Submission, Encounters and Projects all have an owner field, check that
-        elif (
-            isinstance(obj, Submission)
-            or isinstance(obj, Encounter)
-            or isinstance(obj, Project)
-        ):
-            ret_val = obj.owner is self
+        elif isinstance(obj, (Submission, Encounter, Project)):
+            ret_val = obj.owner == self
         elif isinstance(obj, Asset):
             # assets are not owned directly by the user but the submission they're in is.
             # todo, need to understand once assets become part of an encounter, do they still have a submission

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -132,7 +132,7 @@ class ModuleActionRule(DenyAbortMixin, Rule):
                 )
 
         elif self._action is AccessOperation.WRITE:
-            if self._is_module((User, Organization, HoustonConfig)):
+            if self._is_module((Organization, HoustonConfig)):
                 has_permission = user.is_admin
             elif self._is_module((Submission, User)):
                 # Any users can submit and write (create) a user
@@ -207,9 +207,9 @@ class ObjectActionRule(DenyAbortMixin, Rule):
                 )
 
             elif isinstance(self._obj, Encounter):
-                # Researchers can read other encounters, only org moderators can update and delete
+                # Researchers can read other encounters, only site admins can update and delete
                 # them and those roles are not supported yet
-                if self._action != AccessOperation.READ:
+                if self._action == AccessOperation.READ:
                     has_permission = user.is_researcher
 
         return has_permission
@@ -249,7 +249,7 @@ class ObjectActionRule(DenyAbortMixin, Rule):
                 if not has_permission:
                     if isinstance(self._obj, Encounter):
                         # Optionally add time check so that User can only access encounters after user was added to project
-                        has_permission = self._obj in project.encounters
+                        has_permission = self._obj in project.get_encounters()
                     elif isinstance(self._obj, Asset):
                         for encounter in project.get_encounters():
                             has_permission = self._obj in encounter.get_assets()

--- a/flask_restplus_patched/parameters.py
+++ b/flask_restplus_patched/parameters.py
@@ -311,3 +311,14 @@ class PatchJSONParametersWithPassword(PatchJSONParameters):
                     code=HTTPStatus.FORBIDDEN,
                     message='Updating database requires `current_password` test operation.',
                 )
+
+    @classmethod
+    def replace(cls, obj, field, value, state):
+        from app.extensions.api import abort
+
+        if not cls.SENSITIVE_FIELDS or field in cls.SENSITIVE_FIELDS:
+            if 'current_password' not in state:
+                abort(
+                    code=HTTPStatus.FORBIDDEN,
+                    message='Updating database requires `current_password` test operation.',
+                )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,17 @@ def researcher_1(temp_db_instance_helper):
 
 
 @pytest.fixture(scope='session')
+def contributor_1(temp_db_instance_helper):
+    for _ in temp_db_instance_helper(
+        utils.generate_user_instance(
+            email='contributor1@localhost',
+            is_contributor=True,
+        )
+    ):
+        yield _
+
+
+@pytest.fixture(scope='session')
 def researcher_2(temp_db_instance_helper):
     for _ in temp_db_instance_helper(
         utils.generate_user_instance(
@@ -242,6 +253,14 @@ def admin_user_login(flask_app, admin_user):
 def researcher_1_login(flask_app, researcher_1):
     with flask_app.test_request_context('/'):
         login_user(researcher_1)
+        yield current_user
+        logout_user()
+
+
+@pytest.fixture()
+def contributor_1_login(flask_app, contributor_1):
+    with flask_app.test_request_context('/'):
+        login_user(contributor_1)
         yield current_user
         logout_user()
 

--- a/tests/modules/encounters/resources/test_modify_encounter.py
+++ b/tests/modules/encounters/resources/test_modify_encounter.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-docstring
+import json
+from tests import utils
+
+PATH = '/api/v1/encounters/'
+
+
+def patch_encounter(
+    flask_app_client, encounter_guid, user, data, expected_status_code=200
+):
+    with flask_app_client.login(user, auth_scopes=('encounters:write',)):
+        response = flask_app_client.patch(
+            '%s%s' % (PATH, encounter_guid),
+            content_type='application/json',
+            data=json.dumps(data),
+        )
+    if expected_status_code == 200:
+        utils.validate_dict_response(response, 200, {'guid'})
+    else:
+        utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+    return response
+
+
+def test_modify_encounter(db, flask_app_client, researcher_1, researcher_2):
+    # pylint: disable=invalid-name
+    from app.modules.encounters.models import Encounter
+
+    new_encounter_1 = Encounter(owner=researcher_1)
+
+    with db.session.begin():
+        db.session.add(new_encounter_1)
+
+    # non Owner cannot make themselves the owner
+    new_owner_as_res_2 = [
+        utils.patch_test_op(researcher_2.password_secret),
+        utils.patch_replace_op('owner', '%s' % researcher_2.guid),
+    ]
+
+    patch_encounter(
+        flask_app_client,
+        '%s' % new_encounter_1.guid,
+        researcher_2,
+        new_owner_as_res_2,
+        403,
+    )
+    assert new_encounter_1.owner == researcher_1
+
+    # But the owner can
+    new_owner_as_res_1 = [
+        utils.patch_test_op(researcher_1.password_secret),
+        utils.patch_replace_op('owner', '%s' % researcher_2.guid),
+    ]
+    patch_encounter(
+        flask_app_client, '%s' % new_encounter_1.guid, researcher_1, new_owner_as_res_1
+    )
+    assert new_encounter_1.owner == researcher_2

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -233,3 +233,11 @@ def patch_remove_op(path, value=None):
         operation['value'] = value
 
     return operation
+
+
+def patch_replace_op(path, value):
+    return {
+        'op': 'replace',
+        'path': '/%s' % (path,),
+        'value': value,
+    }


### PR DESCRIPTION
## Pull Request Overview

Researcher and contributor permissions implemented and tested including Researcher ability to change Encounter ownership

--

**REST API Updates [OPTIONAL]**

It is now possible to replace the endpoint owner via patch 

```
[PATCH] /api/v1/Encounter/{uuid}/owner
{
    'user':'{uuid of requester}'
    'current_password':'hash of password'
    'owner': '{uuid of new owner}',
}
```



**Pull Request Checklist**
- [ x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x ] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x ] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x ] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [ x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
