### PR TITLE
Add postgresql to github testing workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -39,13 +39,12 @@ jobs:
           # exit-zero treats all errors as warnings.
           flake8 . --count --exit-zero --max-complexity=10 --statistics
 
-  test:
-    runs-on: ${{ matrix.os }}
+  test_macos:
+    runs-on: macos-latest
     strategy:
       max-parallel: 1
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
         python-version: [3.7, 3.8, 3.9]
     env:
       OS: ${{ matrix.os }}
@@ -66,14 +65,8 @@ jobs:
             ${{ runner.os }}-pip-
 
       - name: Install libmagic on macOS
-        if: runner.os == 'macOS'
         run: |
           brew install libmagic
-
-      - name: Install libmagic on Ubuntu
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt install libmagic1
 
       # Install and test - Test order is randomized, run three times to ensure correctness
       - name: Reset local database
@@ -94,6 +87,98 @@ jobs:
           source virtualenv/houston3.7/bin/activate
           invoke app.db.downgrade
           invoke app.db.upgrade
+
+      - name: Run tests after DB checks
+        run: |
+          source virtualenv/houston3.7/bin/activate
+          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
+
+      - name: Run Codecov
+        continue-on-error: true
+        run: |
+          source virtualenv/houston3.7/bin/activate
+          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}" --cov=./ --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1.0.7
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./_coverage/coverage.xml
+          env_vars: OS,PYTHON
+          fail_ci_if_error: true
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        python-version: [3.7, 3.8, 3.9]
+        db-uri: ["postgresql://postgres:testing@localhost/postgres", ""]
+    services:
+      db:
+        image: postgres:10
+        env:
+          POSTGRES_PASSWORD: testing
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+      SQLALCHEMY_DATABASE_URI: ${{ matrix.db-uri }}
+    steps:
+      # Checkout and env setup
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install libmagic on Ubuntu
+        run: |
+          sudo apt install libmagic1
+
+      # Install and test - Test order is randomized, run three times to ensure correctness
+      - name: Reset local database
+        run: |
+          tar -zxvf _db.initial.tar.gz
+          mv _db.initial _db
+          ./scripts/install.sh
+
+      - name: Run tests (random x3)
+        run: |
+          source virtualenv/houston3.7/bin/activate
+          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
+          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
+          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
+
+      - name: Check DB migrations (sqlite)
+        if: matrix.db-uri == ''
+        run: |
+          source virtualenv/houston3.7/bin/activate
+          invoke app.db.downgrade
+          invoke app.db.upgrade
+
+      - name: Check DB migrations (postgresql)
+        if: matrix.db-uri != ''
+        run: |
+          source virtualenv/houston3.7/bin/activate
+          invoke app.db.upgrade --no-backup
+          invoke app.db.downgrade
+          invoke app.db.upgrade --no-backup
 
       - name: Run tests after DB checks
         run: |

--- a/app/extensions/config/__init__.py
+++ b/app/extensions/config/__init__.py
@@ -61,7 +61,13 @@ class HoustonFlaskConfig(flask.Config):
 
         assert not self.db_init
 
-        houston_configs = HoustonConfig.query.all()
+        try:
+            houston_configs = HoustonConfig.query.all()
+        except sqlalchemy.exc.ProgrammingError as e:
+            if 'relation "houston_config" does not exist' in str(e):
+                houston_configs = []
+            else:
+                raise
 
         for houston_config in houston_configs:
             log.warning('CONFIG DB OVERRIDE: %r' % (houston_config,))

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -33,6 +33,7 @@ permission>=0.4.1,<0.5
 phonenumbers
 Pillow
 premailer
+psycopg2-binary
 
 pygeocoder
 python-gitlab

--- a/config.py
+++ b/config.py
@@ -84,7 +84,9 @@ class BaseConfig(object):
     ]
 
     SQLALCHEMY_DATABASE_PATH = os.path.join(PROJECT_DATABASE_PATH, 'database.sqlite3')
-    SQLALCHEMY_DATABASE_URI = 'sqlite:///%s' % (SQLALCHEMY_DATABASE_PATH)
+    SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI') or 'sqlite:///%s' % (
+        SQLALCHEMY_DATABASE_PATH
+    )
 
     DEBUG = False
     ERROR_404_HELP = False
@@ -226,7 +228,7 @@ class DevelopmentConfig(
 class TestingConfig(DevelopmentConfig):
     TESTING = True
 
-    # Use in-memory SQLite database for testing
-    SQLALCHEMY_DATABASE_URI = 'sqlite://'
+    # Use in-memory SQLite database for testing if SQLALCHEMY_DATABASE_URI is not specified
+    SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI') or 'sqlite://'
 
     MAIL_SUPPRESS_SEND = True

--- a/migrations/versions/3c818cf3688c_update_submissionmajortype_enum.py
+++ b/migrations/versions/3c818cf3688c_update_submissionmajortype_enum.py
@@ -1,0 +1,53 @@
+"""Update submissionmajortype enum
+
+Revision ID: 3c818cf3688c
+Revises: 5854c14c634d
+Create Date: 2021-02-17 00:27:10.599431
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '3c818cf3688c'
+down_revision = '5854c14c634d'
+
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_utils
+
+import app
+import app.extensions
+
+
+
+def upgrade():
+    """
+    Upgrade Semantic Description:
+        Change submissionmajortype enum to match the model.
+
+        In migration f4f2436d30f2, the submissionmajortype was defined
+        for the first time and didn't include "test".
+
+        Then in migration a042326c4b51, the submissionmajortype enum is
+        changed to include "test" but it was ignored and
+        submissionmajortype still doesn't include "test" so this
+        migration adds it.
+    """
+    if op.get_bind().dialect.name != 'postgresql':
+        # This migration is only for postgresql
+        return
+
+    old_type = sa.Enum('filesystem', 'archive', 'service', 'unknown', 'error', 'reject', name='old_submissionmajortype')
+    new_type = sa.Enum('filesystem', 'archive', 'service', 'test', 'unknown', 'error', 'reject', name='submissionmajortype')
+
+    op.execute('ALTER TYPE submissionmajortype RENAME TO old_submissionmajortype')
+    new_type.create(op.get_bind())
+    op.execute('ALTER TABLE submission ALTER COLUMN major_type TYPE submissionmajortype USING major_type::text::submissionmajortype')
+    old_type.drop(op.get_bind())
+
+
+def downgrade():
+    """
+    Downgrade Semantic Description:
+        Skip
+    """
+    pass

--- a/tasks/app/db.py
+++ b/tasks/app/db.py
@@ -137,6 +137,7 @@ def migrate(
     branch_label=None,
     version_path=None,
     rev_id=None,
+    autogenerate=True,
 ):
     """Alias for 'revision --autogenerate'"""
     config = _get_config(directory, opts=['autogenerate'])
@@ -144,7 +145,7 @@ def migrate(
         command.revision(
             config,
             message,
-            autogenerate=True,
+            autogenerate=autogenerate,
             sql=sql,
             head=head,
             splice=splice,

--- a/tasks/app/db.py
+++ b/tasks/app/db.py
@@ -215,10 +215,17 @@ def upgrade(
     backup=True,
 ):
     """Upgrade to a later version"""
-    _db_filepath = current_app.config.get('SQLALCHEMY_DATABASE_PATH', None)
-    _db_filepath_backup = '%s.backup' % (_db_filepath,)
+    db_uri = current_app.config.get('SQLALCHEMY_DATABASE_URI')
+    sqlite = db_uri.startswith('sqlite://')
+    if sqlite:
+        _db_filepath = current_app.config.get('SQLALCHEMY_DATABASE_PATH', None)
+        _db_filepath_backup = '%s.backup' % (_db_filepath,)
 
     if backup:
+        if not sqlite:
+            raise NotImplementedError(
+                'No backup code implemented for non sqlite databases, use --no-backup'
+            )
         if os.path.exists(_db_filepath):
             log.info('Pre-upgrade Sqlite3 database backup')
             log.info('\tDatabase : %r' % (_db_filepath,))
@@ -230,13 +237,13 @@ def upgrade(
         command.upgrade(config, revision, sql=sql, tag=tag)
         command.current(config)
     except Exception:
-        if os.path.exists(_db_filepath_backup):
+        if sqlite and os.path.exists(_db_filepath_backup):
             log.error('Rolling back Sqlite3 database to backup')
             shutil.copy2(_db_filepath_backup, _db_filepath)
             log.error('...restored')
         log.critical('Database upgrade failed', exc_info=True)
     finally:
-        if os.path.exists(_db_filepath_backup):
+        if sqlite and os.path.exists(_db_filepath_backup):
             log.info('Deleting database backup %r' % (_db_filepath_backup,))
             os.remove(_db_filepath_backup)
             log.info('...deleted')

--- a/tests/modules/auth/resources/test_getting_oauth2clients_info.py
+++ b/tests/modules/auth/resources/test_getting_oauth2clients_info.py
@@ -22,7 +22,8 @@ def test_getting_list_of_oauth2_clients_by_authorized_user(
     assert response.content_type == 'application/json'
     assert isinstance(response.json, list)
     assert set(response.json[0].keys()) >= {'guid'}
-    assert uuid.UUID(response.json[0]['guid']) == regular_user_oauth2_client.guid
+    guids = [uuid.UUID(obj['guid']) for obj in response.json]
+    assert regular_user_oauth2_client.guid in guids
 
 
 @pytest.mark.parametrize(

--- a/tests/modules/projects/resources/test_modify_project.py
+++ b/tests/modules/projects/resources/test_modify_project.py
@@ -157,16 +157,12 @@ def test_owner_permission(flask_app_client, researcher_1, researcher_2):
     # Owner can do that
     data = [
         utils.patch_test_op(researcher_1.password_secret),
-        utils.patch_add_op(
-            'title', 'This is an owner modified test project, please ignore'
-        ),
+        utils.patch_add_op('title', 'An owner modified test project, please ignore'),
     ]
     response = proj_utils.patch_project(
         flask_app_client, project_guid, researcher_1, data
     )
-    assert (
-        response.json['title'] == 'This is an owner modified test project, please ignore'
-    )
+    assert response.json['title'] == 'An owner modified test project, please ignore'
 
     # Encounter addition and removal not tested for owner as it's already tested in test_modify_project
 


### PR DESCRIPTION
**Review Notes**
- Is it ok to use an environment variable `SQLALCHEMY_DATABASE_URI` to specify the database uri ~for tests~? ~(It's only for tests at the moment)~
- In the tests, the app is initialized before the database tables are created.  But during the app initialization, we try to get config from the database from a table that doesn't exist yet.  I'm catching the exception and ignoring it, but may be there's a different way of doing this
- The reason I moved the macos tests to its own job is because github returns an error when initializing the db service and I don't know how to include the db service only for ubuntu
- In /api/v1/auth/clients test, there are multiple guids returned.  When we tested with sqlite, we only checked the first guid and it always matched.  With postgresql that's not the case so I am checking all the guids.  I don't know if we're expecting multiple guids to be returned.
- I had to run `invoke app.db.upgrade` before `invoke app.db.downgrade` because the postgresql database doesn't exist and returns an error

There's more details in the commit messages, feel free to have a look.

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
