### PR TITLE
Add db fixture to collaboration models tests

### DIFF
--- a/tests/modules/collaborations/test_models.py
+++ b/tests/modules/collaborations/test_models.py
@@ -43,7 +43,7 @@ def test_collaboration_create_with_members(
             assert association.initiator is False
 
 
-def test_collaboration_read_state_changes(collab_user_a, collab_user_b):
+def test_collaboration_read_state_changes(db, collab_user_a, collab_user_b):
     collab = Collaboration(
         title='Collab for state change',
         user_guids=[collab_user_a.guid, collab_user_b.guid],
@@ -106,7 +106,7 @@ def test_collaboration_read_state_changes(collab_user_a, collab_user_b):
     assert collab.get_read_state() == CollaborationUserState.DECLINED
 
 
-def test_collaboration_edit_state_changes(collab_user_a, collab_user_b):
+def test_collaboration_edit_state_changes(db, collab_user_a, collab_user_b):
 
     collab = Collaboration(
         title='Collab for state change',


### PR DESCRIPTION
When running "test_collaboration_read_state_changes" and
"test_collaboration_edit_state_changes" by themselves, there are errors
returned:

```
<string>:4: in __init__
    ???
virtualenv/houston3.7/lib/python3.7/site-packages/sqlalchemy/orm/state.py:433: in _initialize_instance
    manager.dispatch.init_failure(self, args, kwargs)
virtualenv/houston3.7/lib/python3.7/site-packages/sqlalchemy/util/langhelpers.py:70: in __exit__
    with_traceback=exc_tb,
virtualenv/houston3.7/lib/python3.7/site-packages/sqlalchemy/util/compat.py:182: in raise_
    raise exception
virtualenv/houston3.7/lib/python3.7/site-packages/sqlalchemy/orm/state.py:430: in _initialize_instance
    return manager.original_init(*mixed[1:], **kwargs)
app/modules/collaborations/models.py:83: in __init__
    user_tup = User.ensure_edm_obj(user_guids[guid_index])
app/modules/users/models.py:68: in ensure_edm_obj
    with db.session.begin():
virtualenv/houston3.7/lib/python3.7/site-packages/sqlalchemy/orm/scoping.py:163: in do
    return getattr(self.registry(), name)(*args, **kwargs)
virtualenv/houston3.7/lib/python3.7/site-packages/sqlalchemy/util/_collections.py:1022: in __call__
    return self.registry.setdefault(key, self.createfunc())
virtualenv/houston3.7/lib/python3.7/site-packages/sqlalchemy/orm/session.py:3309: in __call__
    return self.class_(**local_kw)
virtualenv/houston3.7/lib/python3.7/site-packages/flask_sqlalchemy/__init__.py:136: in __init__
    self.app = app = db.get_app()
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <SQLAlchemy engine=None>, reference_app = None

    def get_app(self, reference_app=None):
        """Helper method that implements the logic to look up an
        application."""

        if reference_app is not None:
            return reference_app

        if current_app:
            return current_app._get_current_object()

        if self.app is not None:
            return self.app

        raise RuntimeError(
>           'No application found. Either work inside a view function or push'
            ' an application context. See'
            ' http://flask-sqlalchemy.pocoo.org/contexts/.'
        )
E       RuntimeError: No application found. Either work inside a view function or push an application context. See http://flask-sqlalchemy.pocoo.org/contexts/.

virtualenv/houston3.7/lib/python3.7/site-packages/flask_sqlalchemy/__init__.py:988: RuntimeError
```

It seems the flask app is not created.  Adding the "db" fixture
initiates the app and so fixes the problem.


**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [x] Ensure that the PR is properly reviewed
