### PR TITLE
Fix coverage changing between test runs

### DIFF
--- a/tests/modules/projects/test_models.py
+++ b/tests/modules/projects/test_models.py
@@ -6,7 +6,9 @@ import sqlalchemy
 import logging
 
 
-def test_project_add_members(db, temp_user):  # pylint: disable=unused-argument
+def test_project_add_members(
+    db, temp_user, researcher_1, researcher_2
+):  # pylint: disable=unused-argument
     from app.modules.projects.models import (
         Project,
         ProjectUserMembershipEnrollment,
@@ -56,6 +58,11 @@ def test_project_add_members(db, temp_user):  # pylint: disable=unused-argument
             db.session.add(duplicate_enrollment)
     except (sqlalchemy.orm.exc.FlushError, sqlalchemy.exc.IntegrityError):
         pass
+
+    temp_proj.add_user_in_context(researcher_1)
+    # try removing a user that's not in the project
+    temp_proj.remove_user_in_context(researcher_2)
+    temp_proj.remove_user_in_context(researcher_1)
 
     with db.session.begin():
         db.session.delete(temp_proj)


### PR DESCRIPTION
- Add tests for object access permissions via project

  Tests for
  `app.modules.users.permissions.rules.ObjectActionRule._permitted_via_project`.
  Includes "Encounter", "Asset", "Project" and "other" object access
  permissions for users.

- Add tests for removing users not in project from project

  Add coverage for
  `app.modules.projects.models.Project.remove_user_in_context`.  By
  removing users not in the project from the project, we are sure to
  trigger "if member.user != user".

- Add test for Collaboration.get_read_state returning approved

  Coverage for
  `app.modules.collaborations.models.Collaboration.get_read_state`.
  
  The tests only included "not_initiated" and "declined" so added
  "approved" as well.

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [x] Ensure that the PR is properly reviewed
