### PR TITLE
Update CodeCov Settings

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,9 +2,16 @@ codecov:
   require_ci_to_pass: yes
 
 coverage:
-  precision: 2
-  round: down
+  status:
+    project:
+      default:
+        threshold: 1%
+    patch:
+      default:
+        target: 50%
   range: "50...90"
+  round: down
+  precision: 1
 
 parsers:
   gcov:


### PR DESCRIPTION
## Pull Request Overview

- Moves the CodeCov Project threshold from `0%` to allow up to `1%` of coverage regression (keeping the target at `auto`).
- Changes the Patch status check for a given PR to `50%` instead of `auto`.
- Changes precision to 1 decimal instead of 2

**Pull Request Checklist**
- [X] Ensure that the PR is properly formatted
- [X] Ensure that the PR is properly rebased
  - The PR is rebased on `develop` (commit: `0a1e9e9` after Karen's PostGRES PR)
- [X] Ensure that the PR uses a consolidated database migration
  - _No migration_
- [x] Ensure that the PR is properly tested
- [X] Ensure that the PR is properly sanitized
- [x] Ensure that the PR is properly reviewed
