### PR TITLE
Revert "Add --no-autogenerate to app.db.migrate"

### DIFF
--- a/README.md
+++ b/README.md
@@ -795,11 +795,11 @@ class MyObjects(Resource):
         return create_my_object(args)
 ```
 
-How to Update Schemas
+How to Update Schemas / Create a Migration
 ============
 1. Update schema objects in `/app/modules`
-2. Run `invoke app.db.migrate`
-3. A new file should have been created in `/app/migrations/versions`. Add `import app.extensions` to the top of that file
+2. Run `invoke app.db.migrate` to create an auto generated migration or `invoke app.db.revision` to create an empty migration for non-schema updates
+3. A new file should have been created in `/app/migrations/versions`
 4. Run `invoke app.db.upgrade`
 
 RFC 6902 Compliance

--- a/tasks/app/db.py
+++ b/tasks/app/db.py
@@ -137,7 +137,6 @@ def migrate(
     branch_label=None,
     version_path=None,
     rev_id=None,
-    autogenerate=True,
 ):
     """Alias for 'revision --autogenerate'"""
     config = _get_config(directory, opts=['autogenerate'])
@@ -145,7 +144,7 @@ def migrate(
         command.revision(
             config,
             message,
-            autogenerate=autogenerate,
+            autogenerate=True,
             sql=sql,
             head=head,
             splice=splice,


### PR DESCRIPTION
## Pull Request Overview

- Revert "Add --no-autogenerate to app.db.migrate"
- Update README with steps to create an empty migration

---

**Review Notes**
- I added `app.db.migrate --no-autogenerate` in #46 but what I needed was actually `app.db.revision` so reverting that commit.

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
