### PR TITLE
Fix uploads directory definition, creation and usage

### DIFF
--- a/app/extensions/tus/__init__.py
+++ b/app/extensions/tus/__init__.py
@@ -25,9 +25,7 @@ def init_app(app, **kwargs):
         os.makedirs(uploads_directory)
 
     tm = TusManager()
-    tm.init_app(
-        app, upload_url='/api/v1/submissions/tus', upload_folder=uploads_directory
-    )
+    tm.init_app(app, upload_url='/api/v1/submissions/tus')
     tm.upload_file_handler(_tus_file_handler)
 
 

--- a/app/extensions/tus/__init__.py
+++ b/app/extensions/tus/__init__.py
@@ -6,6 +6,9 @@ Logging adapter
 import logging
 import os
 
+from flask import current_app
+
+
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
@@ -16,11 +19,15 @@ def init_app(app, **kwargs):
     """
     from app.extensions.tus.flask_tus_cont import TusManager
 
-    updir = tus_upload_dir()
-    if not os.path.exists(updir):
-        os.makedirs(updir)
+    # Ensure the upload directory exists
+    uploads_directory = app.config['UPLOADS_DATABASE_PATH']
+    if not os.path.exists(uploads_directory):
+        os.makedirs(uploads_directory)
+
     tm = TusManager()
-    tm.init_app(app, upload_url='/api/v1/submissions/tus', upload_folder=str(updir))
+    tm.init_app(
+        app, upload_url='/api/v1/submissions/tus', upload_folder=uploads_directory
+    )
     tm.upload_file_handler(_tus_file_handler)
 
 
@@ -46,8 +53,8 @@ def _tus_file_handler(upload_file_path, filename, req):
 
 
 def tus_upload_dir(guid=None):
-    # TODO implement this in config.py  see: https://github.com/WildMeOrg/houston/pull/30#pullrequestreview-574566762
-    d = os.path.join('_db', 'uploads')
+    """Returns the location to an upload directory"""
+    uploads = current_app.config['UPLOADS_DATABASE_PATH']
     if guid is None:
-        return d
-    return os.path.join(d, '-'.join(['sub', str(guid)]))
+        return uploads
+    return os.path.join(uploads, '-'.join(['sub', str(guid)]))

--- a/app/extensions/tus/flask_tus_cont.py
+++ b/app/extensions/tus/flask_tus_cont.py
@@ -29,14 +29,11 @@ class TusManager(object):
         if app is not None:
             self.init_app(app)
 
-    def init_app(self, app, **kwargs):
-        self.upload_url = app.config.get('tus_uploads_url', '/file-upload')
+    def init_app(self, app, upload_url='/file-upload'):
+        self.upload_url = app.config.get('tus_uploads_url', upload_url)
         self.upload_folder = app.config['UPLOADS_DATABASE_PATH']
         self.tus_max_file_size = app.config.get('tus_max_file_size_in_bytes', 4294967296)
         self.file_overwrite = app.config.get('tus_file_overwrite', True)
-
-        for key, value in kwargs.items():
-            setattr(self, key, value)
 
         self._register_routes()
         self.app = app

--- a/app/extensions/tus/flask_tus_cont.py
+++ b/app/extensions/tus/flask_tus_cont.py
@@ -30,17 +30,10 @@ class TusManager(object):
             self.init_app(app)
 
     def init_app(self, app, **kwargs):
-        if hasattr(app, 'config'):
-            setattr(self, 'upload_url', app.config.get('tus_uploads_url', '/file-upload'))
-            setattr(
-                self, 'upload_folder', app.config.get('tus_uploads_folder', 'uploads/')
-            )
-            setattr(
-                self,
-                'tus_max_file_size',
-                app.config.get('tus_max_file_size_in_bytes', 4294967296),
-            )
-            setattr(self, 'file_overwrite', app.config.get('tus_file_overwrite', True))
+        self.upload_url = app.config.get('tus_uploads_url', '/file-upload')
+        self.upload_folder = app.config['UPLOADS_DATABASE_PATH']
+        self.tus_max_file_size = app.config.get('tus_max_file_size_in_bytes', 4294967296)
+        self.file_overwrite = app.config.get('tus_file_overwrite', True)
 
         for key, value in kwargs.items():
             setattr(self, key, value)

--- a/app/extensions/tus/flask_tus_cont.py
+++ b/app/extensions/tus/flask_tus_cont.py
@@ -37,10 +37,6 @@ class TusManager(object):
 
         for key, value in kwargs.items():
             setattr(self, key, value)
-        if hasattr(self, 'upload_folder') is False:
-            self.upload_folder = 'uploads/'
-        if hasattr(self, 'upload_url') is False:
-            self.upload_url = '/file-upload'
 
         self._register_routes()
         self.app = app

--- a/app/modules/submissions/resources.py
+++ b/app/modules/submissions/resources.py
@@ -16,6 +16,7 @@ from flask_restplus._http import HTTPStatus
 from app.extensions import db
 from app.extensions.api import Namespace
 from app.extensions.api.parameters import PaginationParameters
+from app.extensions.tus import tus_upload_dir
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 
@@ -275,9 +276,7 @@ class SubmissionTusCollect(Resource):
             raise werkzeug.exceptions.NotFound
 
         repo, project = submission.ensure_repository()
-        updir = os.path.join(
-            '_db', 'uploads', '-'.join(['sub', str(submission.guid)])
-        )  # note: duplicates tus_upload_dir()
+        updir = tus_upload_dir(submission.guid)
         submission_abspath = submission.get_absolute_path()
         submission_path = os.path.join(submission_abspath, '_submission')
         ct = 0

--- a/config.py
+++ b/config.py
@@ -83,6 +83,8 @@ class BaseConfig(object):
         '.tiff',
     ]
 
+    UPLOADS_DATABASE_PATH = os.path.join(PROJECT_DATABASE_PATH, 'uploads')
+
     SQLALCHEMY_DATABASE_PATH = os.path.join(PROJECT_DATABASE_PATH, 'database.sqlite3')
     SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI') or 'sqlite:///%s' % (
         SQLALCHEMY_DATABASE_PATH

--- a/deploy/codex/houston/local_config.py
+++ b/deploy/codex/houston/local_config.py
@@ -14,6 +14,7 @@ class LocalConfig(BaseConfig):
     PROJECT_DATABASE_PATH = str(DATA_ROOT)
     SUBMISSIONS_DATABASE_PATH = str(DATA_ROOT / 'submissions')
     ASSET_DATABASE_PATH = str(DATA_ROOT / 'assets')
+    UPLOADS_DATABASE_PATH = str(DATA_ROOT / 'uploads')
     SQLALCHEMY_DATABASE_PATH = str(DATA_ROOT / 'database.sqlite3')
 
     SECRET_KEY = 'seekret'


### PR DESCRIPTION
## Pull Request Overview

 - Fix upload directory creation and lookup
    
    This removes the hardcoded `_db/uploads` to use the configured
    location at `UPLOADS_DATABASE_PATH`.
 - Fix tus init_app to assume app has a config
    
    We can safely assume the given app has a config, because at the very
    least, flask is going to guarantee the config is a basic mapping
    object.
 - DRY out the definition of defaults
 - Make tus-manager init_app call explicit in what it wants
    
    Many of the values here should probably be coming from the app's
    configuration. FYI, lowercase config names are filtered out by flask
    config logic when Config.from_mapping is used, which is the case in
    this application.

Fixes https://wildme.atlassian.net/browse/DEX-179
Addresses out-of-scope error in #53 reported by @colinwkingen 

---

**Review Notes**
n/a

**Pull Request Checklist**
- [X] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [X] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [X] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [X] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [X] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [x] Ensure that the PR is properly reviewed
