### PR TITLE
Fix dist-latest invalid symlink in build.frontend.sh

### DIFF
--- a/scripts/build.frontend.sh
+++ b/scripts/build.frontend.sh
@@ -66,10 +66,11 @@ function build() {
 
 function install() {
     dist_install=$(get_install_path)
-    rm -rf app/static/dist-latest
+    rm -rf ${BASE_INSTALL_PATH}/dist-latest
     mkdir -p ${dist_install}
     tar -zxvf _frontend/dist.latest.tar.gz -C ${dist_install} --strip-components=1
-    ln -s ${dist_install} app/static/dist-latest
+    # Assume dist_install is also in $BASE_INSTALL_PATH
+    ln -s $(basename ${dist_install}) ${BASE_INSTALL_PATH}/dist-latest
 }
 
 # Build within a Node container


### PR DESCRIPTION
After running `./scripts/build.frontend.sh` the symlink
`app/static/dist-latest` is broken because it's linked to
`app/static/app/static//dist-148f81e_20210225` which doesn't exist:

```
(py3) karen@yukihira:~/src/wildbook/houston/app/static$ ls -l
total 24
drwxr-xr-x 3 root  root  4096 Feb 23 01:44 bower
drwxr-xr-x 2 karen karen 4096 Feb  4 16:33 css
drwxr-xr-x 2 karen karen 4096 Feb 25 07:16 dist-148f81e_20210225-071638GMT
lrwxrwxrwx 1 karen karen   43 Feb 25 07:16 dist-latest -> app/static//dist-148f81e_20210225-071638GMT
drwxr-xr-x 2 karen karen 4096 Feb  4 16:33 favicon
drwxr-xr-x 2 karen karen 4096 Feb  4 16:33 images
-rw-r--r-- 1 karen karen 1060 Feb  4 16:33 uppy-test.html
```

Fix it so it's:

```
(py3) karen@yukihira:~/src/wildbook/houston$ ls -l app/static/
total 24
drwxr-xr-x 3 root  root  4096 Feb 23 01:44 bower
drwxr-xr-x 2 karen karen 4096 Feb  4 16:33 css
drwxr-xr-x 2 karen karen 4096 Feb 25 07:26 dist-148f81e_20210225-072617GMT
lrwxrwxrwx 1 karen karen   31 Feb 25 07:26 dist-latest -> dist-148f81e_20210225-072617GMT
drwxr-xr-x 2 karen karen 4096 Feb  4 16:33 favicon
drwxr-xr-x 2 karen karen 4096 Feb  4 16:33 images
-rw-r--r-- 1 karen karen 1060 Feb  4 16:33 uppy-test.html
```

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
