### PR TITLE
Add docker examples for wildme/houston in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,15 +402,34 @@ Installation
 
 ### Using Docker
 
-It is very easy to start exploring the example using Docker:
+It is very easy to start development using Docker:
 
-```bash
-$ docker run -it --rm --publish 5000:5000 frolvlad/flask-restplus-server-example
-```
+1. Build the `wildme/houston` image:
 
-<!--
-[![](https://images.microbadger.com/badges/image/frolvlad/flask-restplus-server-example.svg)](http://microbadger.com/images/frolvlad/flask-restplus-server-example "Get your own image badge on microbadger.com")
- -->
+   ```bash
+   docker build -t wildme/houston .
+   ```
+
+2. Mount the current directory and run bash in the container:
+
+   ```bash
+   docker run --rm -u root --entrypoint= -v $PWD:/code -it wildme/houston /bin/bash
+   ```
+
+3. Install houston and run tests:
+
+   ```bash
+   pip install -e .[testing]
+   FLASK_CONFIG= pytest
+   ```
+
+4. Or to run the app:
+
+   ```bash
+   invoke app.run --host 0.0.0.0
+   ```
+
+   You should see the site at http://localhost:5000/ in your browser.
 
 ### From sources
 


### PR DESCRIPTION
There was an example in the README for how to run
`frolvlad/flask-restplus-server-example` which is completely unrelated
to houston.  Change it to use the local `Dockerfile` and specifically
how to run the tests.

The entrypoint for the wildme/houston file at the time of writing
ignores `-u root` in docker run to run as root and causes permission
problems when using `pip` etc so disabling the entrypoint by doing
`--entrypoint=`.

---

**Review Notes**

@mmulich I know you didn't write the docker entrypoint for development and I looked briefly and can't figure out how to not always run as "nobody".  Is there something critical for development in the entrypoint?  Is it ok to disable it? 


**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
