### PR TITLE
GitLab test repository clean-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
-.coverage
+.coverage*
 ,cover
 .cache
 nosetests.xml

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
-.coverage*
+.coverage.*
 ,cover
 .cache
 nosetests.xml

--- a/app/extensions/submission/__init__.py
+++ b/app/extensions/submission/__init__.py
@@ -295,6 +295,19 @@ class SubmissionManager(object):
 
         return submission
 
+    def delete_remote_submission(self, submission):
+        repo, project = current_app.sub.ensure_repository(submission)
+        self.delete_remote_project(project)
+
+    def delete_remote_project(self, project):
+        self.ensure_initialed()
+        try:
+            self.gl.projects.delete(project.id)
+            return True
+        except gitlab.GitlabDeleteError:
+            pass
+        return False
+
 
 def init_app(app, **kwargs):
     # pylint: disable=unused-argument

--- a/scripts/run_tasks_for_coverage.sh
+++ b/scripts/run_tasks_for_coverage.sh
@@ -77,7 +77,7 @@ coverage run --append `which invoke` app.users.remove-role --role=Researcher --e
 # test app.consistency.*
 coverage run --append `which invoke` app.consistency.all
 coverage run --append `which invoke` app.consistency.user-staff-permissions
-coverage run --append `which invoke` app.consistency.cleanup_gitlab --dryrun
+coverage run --append `which invoke` app.consistency.cleanup-gitlab --dryrun
 
 # test app.submissions.*
 coverage run --append `which invoke` app.submissions.create-submission-from-path --path=tests/submissions/test-000/ || echo 'Expected failure'

--- a/scripts/run_tasks_for_coverage.sh
+++ b/scripts/run_tasks_for_coverage.sh
@@ -77,6 +77,7 @@ coverage run --append `which invoke` app.users.remove-role --role=Researcher --e
 # test app.consistency.*
 coverage run --append `which invoke` app.consistency.all
 coverage run --append `which invoke` app.consistency.user-staff-permissions
+coverage run --append `which invoke` app.consistency.cleanup_gitlab --dryrun
 
 # test app.submissions.*
 coverage run --append `which invoke` app.submissions.create-submission-from-path --path=tests/submissions/test-000/ || echo 'Expected failure'

--- a/scripts/run_tasks_for_coverage.sh
+++ b/scripts/run_tasks_for_coverage.sh
@@ -83,10 +83,10 @@ coverage run --append `which invoke` app.consistency.cleanup-gitlab --dryrun
 coverage run --append `which invoke` app.submissions.create-submission-from-path --path=tests/submissions/test-000/ || echo 'Expected failure'
 coverage run --append `which invoke` app.submissions.create-submission-from-path --path=tests/does-not-exist/ --email=user@example.org || echo 'Expected failure'
 coverage run --append `which invoke` app.submissions.create-submission-from-path --path=tests/submissions/test-000/ --email=user@example.org
-coverage run --append `which invoke` app.submissions.clone-submission-from-gitlab --guid=290950fb-49a8-496a-adf4-e925010f79ce || echo 'Expected failure'
-coverage run --append `which invoke` app.submissions.clone-submission-from-gitlab --guid=300950fb-49a8-496a-adf4-e925010f79ce --email=user@example.org || echo 'Expected failure'
-coverage run --append `which invoke` app.submissions.clone-submission-from-gitlab --guid=290950fb-49a8-496a-adf4-e925010f79ce --email=user@example.org
-coverage run --append `which invoke` app.submissions.clone-submission-from-gitlab --guid=290950fb-49a8-496a-adf4-e925010f79ce --email=user@example.org
+coverage run --append `which invoke` app.submissions.clone-submission-from-gitlab --guid=4d7669ea-9fbe-4f87-be14-25b5391f7333 || echo 'Expected failure'
+coverage run --append `which invoke` app.submissions.clone-submission-from-gitlab --guid=4d7669ea-0000-4f87-be14-25b5391f7333 --email=user@example.org || echo 'Expected failure'
+coverage run --append `which invoke` app.submissions.clone-submission-from-gitlab --guid=4d7669ea-9fbe-4f87-be14-25b5391f7333 --email=user@example.org
+coverage run --append `which invoke` app.submissions.clone-submission-from-gitlab --guid=4d7669ea-9fbe-4f87-be14-25b5391f7333 --email=user@example.org
 coverage run --append `which invoke` app.submissions.list-all
 
 coverage run --append `which invoke` app.organizations.list-all

--- a/tasks/app/consistency.py
+++ b/tasks/app/consistency.py
@@ -9,6 +9,7 @@ import logging
 import tqdm
 
 from app.extensions import db
+from flask import current_app
 
 from ._utils import app_context_task
 
@@ -62,6 +63,56 @@ def user_staff_permissions(context):
                 updated += 1
 
     print('Updated %d users' % (updated,))
+
+
+@app_context_task
+def cleanup_gitlab(context, dryrun=False):
+    import gitlab
+
+    TEST_GROUP_NAMES = ['TEST']
+    PER_PAGE = 100
+    MAX_PAGES = 100
+
+    remote_uri = current_app.config.get('GITLAB_REMOTE_URI', None)
+    remote_personal_access_token = current_app.config.get(
+        'GITLAB_REMOTE_LOGIN_PAT', None
+    )
+
+    gl = gitlab.Gitlab(
+        remote_uri, private_token=remote_personal_access_token
+    )
+    gl.auth()
+    log.info('Logged in: %r' % (gl,))
+
+    projects = []
+    groups = gl.groups.list()
+    for group in groups:
+        if group.name in TEST_GROUP_NAMES:
+            page = 1
+            log.info('Fetching projects...')
+            for page in tqdm.tqdm(range(1, MAX_PAGES + 2), desc='Fetching GitLab Project Pages'):
+                projects_page = group.projects.list(per_page=PER_PAGE, page=page)
+
+                if len(projects_page) == 0:
+                    log.warn('Reached maximum page: %d' % (page, ))
+                    break
+                elif page == MAX_PAGES + 1:
+                    log.warn('More pages exist that were not processed')
+                    break
+                projects += projects_page
+    log.info('Fetched %d projects' % (len(projects), ))
+
+    if dryrun:
+        log.info('[DRYRUN] Would have deleted %d projects for groups %r' % (len(projects), TEST_GROUP_NAMES,))
+    else:
+        deleted = 0
+        for project in tqdm.tqdm(projects, desc='Deleting GitLab Projects'):
+            try:
+                gl.projects.delete(project.id)
+                deleted += 1
+            except gitlab.GitlabDeleteError:
+                pass
+        log.info('Deleted %d / %d projects for groups %r' % (deleted, len(projects), TEST_GROUP_NAMES,))
 
 
 @app_context_task

--- a/tasks/app/submissions.py
+++ b/tasks/app/submissions.py
@@ -80,7 +80,7 @@ def clone_submission_from_gitlab(
     Clone an existing submission from the external GitLab submission archive
 
     Command Line:
-    > invoke app.submissions.clone-submission-from-gitlab --guid 290950fb-49a8-496a-adf4-e925010f79ce --email jason@wildme.org
+    > invoke app.submissions.clone-submission-from-gitlab --guid 4d7669ea-9fbe-4f87-be14-25b5391f7333 --email jason@wildme.org
     """
     from app.modules.users.models import User
     from app.modules.submissions.models import Submission

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,21 +199,21 @@ def empty_individual():
 
 @pytest.fixture(scope='session')
 def test_submission_uuid(flask_app):
-    return uuid.UUID('ce91ad6e-3cc9-48e8-a4f0-ac74f55dfbf0')
+    return uuid.UUID('6e50ece6-742b-4496-bff6-b2c575db3c13')
 
 
 @pytest.fixture(scope='session')
 def test_empty_submission_uuid(flask_app):
-    return uuid.UUID('ce91ad6e-3cc9-48e8-a4f0-ac74f55dfbf1')
+    return uuid.UUID('610a0324-1543-42d6-a7b7-1e488cf7ea69')
 
 
 @pytest.fixture(scope='session')
 def test_clone_submission_data(flask_app):
     return {
-        'submission_uuid': '290950fb-49a8-496a-adf4-e925010f79ce',
+        'submission_uuid': '6e50ece6-742b-4496-bff6-b2c575db3c13',
         'asset_uuids': [
-            '3abc03a8-39c8-42c4-bedb-e08ccc485396',
-            'aee00c38-137e-4392-a4d9-92b545a9efb0',
+            'cb4ff916-8a7f-4f2d-97dc-633c716ee072',
+            'eefff2e0-292f-4874-9258-a069694fdd0d',
         ],
     }
 

--- a/tests/modules/assets/resources/test_assets.py
+++ b/tests/modules/assets/resources/test_assets.py
@@ -28,13 +28,13 @@ def test_find_asset(
 
         assert response.status_code == 200
         assert response.content_type == 'application/json'
-        assert response.json['filename'] == 'fluke.jpg'
+        assert response.json['filename'] == 'zebra.jpg'
         assert response.json['src'] == test_src_asset
         assert src_response.status_code == 200
         assert src_response.content_type == 'image/jpeg'
         assert (
             hashlib.md5(src_response.data).hexdigest()
-            == '0b546f813ec9631ce5c9b1dd579c623b'
+            == '9c2e4476488534c05b7c557a0e663ccd'
         )
 
         # Force the server to release the file handler
@@ -74,13 +74,13 @@ def test_find_deleted_asset(
 
         assert response.status_code == 200
         assert response.content_type == 'application/json'
-        assert response.json['filename'] == 'fluke.jpg'
+        assert response.json['filename'] == 'zebra.jpg'
         assert response.json['src'] == test_src_asset
         assert src_response.status_code == 200
         assert src_response.content_type == 'image/jpeg'
         assert (
             hashlib.md5(src_response.data).hexdigest()
-            == '0b546f813ec9631ce5c9b1dd579c623b'
+            == '9c2e4476488534c05b7c557a0e663ccd'
         )
 
         # Force the server to release the file handler

--- a/tests/modules/encounters/resources/test_modify_encounter.py
+++ b/tests/modules/encounters/resources/test_modify_encounter.py
@@ -3,6 +3,9 @@
 import json
 from tests import utils
 
+from flask import current_app
+
+
 PATH = '/api/v1/encounters/'
 
 
@@ -85,6 +88,7 @@ def no_test_asset_addition(db, flask_app_client):
     )
     assert len(new_encounter.assets) == 1
     # removed submission delete as it was going haywire
+    current_app.sub.delete_remote_submission(new_submission)
     new_submission.delete()
 
 
@@ -154,4 +158,5 @@ def test_asset_file_addition(db, flask_app_client, researcher_1):
         new_encounter.delete()
         # assets are only cleaned up once the submissions are cleaned up
         for submission in researcher_1.submissions:
+            current_app.sub.delete_remote_submission(submission)
             submission.delete()

--- a/tests/modules/submissions/resources/test_ensure_submission.py
+++ b/tests/modules/submissions/resources/test_ensure_submission.py
@@ -31,12 +31,12 @@ def test_ensure_clone_submission_by_uuid(
 
     try:
         assert clone.temp_submission.major_type == SubmissionMajorType.test
-        assert clone.temp_submission.commit == 'e94db0cf015c6c84ab1668186924dc985fc472d6'
+        assert clone.temp_submission.commit == '1d3dd77e1fba336ae89bd9d7a2788f4a0cb2df90'
         assert clone.temp_submission.commit_mime_whitelist_guid == uuid.UUID(
             '4d46c55d-accf-29f1-abe7-a24839ec1b95'
         )
 
-        assert clone.temp_submission.commit_houston_api_version == '0.1.0.8b208226'
+        assert clone.temp_submission.commit_houston_api_version == '0.1.0.6c9d6965'
         assert clone.temp_submission.description == 'Test Submission (streamlined)'
 
         # Checks that there are two valid Assets in the database

--- a/tests/modules/submissions/resources/test_permissions.py
+++ b/tests/modules/submissions/resources/test_permissions.py
@@ -3,6 +3,8 @@
 from tests.utils import clone_submission
 import json
 
+from flask import current_app
+
 
 def test_user_read_permissions(
     flask_app_client, regular_user, readonly_user, db, test_clone_submission_data
@@ -119,6 +121,7 @@ def test_create_patch_submission(flask_app_client, regular_user, readonly_user, 
     except Exception as ex:
         raise ex
     finally:
+        current_app.sub.delete_remote_submission(temp_submission)
         # Restore original state
         temp_submission = Submission.query.get(submission_guid)
         if temp_submission is not None:

--- a/tests/modules/submissions/resources/test_upload_file.py
+++ b/tests/modules/submissions/resources/test_upload_file.py
@@ -5,6 +5,8 @@ import filecmp
 import config
 from os.path import join, basename
 
+from flask import current_app
+
 
 def test_create_open_submission(flask_app_client, regular_user, db):
     # pylint: disable=invalid-name
@@ -43,6 +45,7 @@ def test_create_open_submission(flask_app_client, regular_user, db):
     except Exception as ex:
         raise ex
     finally:
+        current_app.sub.delete_remote_submission(temp_submission)
         # Restore original state
         if temp_submission is not None:
             temp_submission.delete()
@@ -101,6 +104,8 @@ def test_submission_streamlined(flask_app_client, regular_user, db):
     except Exception as ex:
         raise ex
     finally:
+        current_app.sub.delete_remote_submission(temp_submission)
+
         # Restore original state
         if temp_submission is not None:
             temp_submission.delete()


### PR DESCRIPTION
## Pull Request Overview

- Adds a new invoke command `app.consistency.cleanup-gitlab` with an optional `--dryrun` flag
- Adds automatic GitLab PyTest clean-up using the GitLab API to delete the project that is no longer needed in remote.  This can also be done via a Submission object and using `app.sub.delete_remote_submission(submission)`
- Reinstates test submissions `610a0324-1543-42d6-a7b7-1e488cf7ea69` (empty) and `6e50ece6-742b-4496-bff6-b2c575db3c13` (with data) for PyTesting.  The submissions have been tagged with `type:pytest-required`
- Adds feature to not delete any remote GitLab project made within 24 hours (as to not accidentally derail active debugging and CI actions)

In the process of testing this PR, 18,540 test projects were deleted from GitLab.

---

**Reviewer Note**

An earlier build of this PR deleted 3 submission repositories that the `develop` branch relied on for CI testing.  This PR must be merged in to restore passing tests on that branch.

---

**Invoke CLI Updates**

Running `invoke app.consistency.cleanup-gitlab` will login to the GitLab instance and delete all repositories that are under the `TEST` group, as hardcoded with variables at the top of the function.

```
$ invoke app.consistency.cleanup-gitlab
2021-02-26 15:09:22,946 [INFO] [app] Using app.config 'local_config.LocalConfig'
2021-02-26 15:09:23,871 [INFO] [tasks.app.consistency] Logged in: <gitlab.Gitlab object at 0x13695fb10>
2021-02-26 15:09:23,982 [INFO] [tasks.app.consistency] Fetching projects...
Fetching GitLab Project Pages:   1%|██                                                                                                                                                                                                          | 1/101 [00:00<01:36,  1.03it/s]2021-02-26 15:09:25,047 [WARNING] [tasks.app.consistency] Reached maximum page: 2
Fetching GitLab Project Pages:   1%|██                                                                                                                                                                                                          | 1/101 [00:01<01:46,  1.06s/it]
2021-02-26 15:09:25,048 [INFO] [tasks.app.consistency] Fetched 5 projects
Deleting GitLab Projects:   0%|                                                                                                                                                                                                                           | 0/5 [00:00<?, ?it/s]2021-02-26 15:09:25,051 [INFO] [tasks.app.consistency] Skipping '6e50ece6-742b-4496-bff6-b2c575db3c13' (<GroupProject id:19469>), marked with 'type:pytest-required'
2021-02-26 15:09:25,051 [INFO] [tasks.app.consistency] Skipping '610a0324-1543-42d6-a7b7-1e488cf7ea69' (<GroupProject id:19463>), marked with 'type:pytest-required'
Deleting GitLab Projects: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 5/5 [00:00<00:00, 1537.05it/s]
2021-02-26 15:09:25,052 [INFO] [tasks.app.consistency] Deleted 0 / 5 projects for groups ['TEST']
2021-02-26 15:09:25,052 [INFO] [tasks.app.consistency] Skipped 3 projects last modified within last 24 hours
```

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
- [x] Ensure that the PR is properly rebased
  - The PR is rebased on `develop` (commit: `1277bf3`)
- [x] Ensure that the PR uses a consolidated database migration
  - _No migration_
- [x] Ensure that the PR is properly tested
- [x] Ensure that the PR is properly sanitized
- [ ] Ensure that the PR is properly reviewed
