### PR TITLE
Integrate frontend development

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ cd deploy/codex
 docker-compose up
 ```
 
-Surf to http://localhost:83/
+Surf to http://localhost:84/
 
 #### Developer Usage Note
 

--- a/deploy/codex/README.md
+++ b/deploy/codex/README.md
@@ -15,6 +15,8 @@ For development purposes, this setup exposes each of the services as follows:
 - Sage (Wildbook-IA) - http://localhost:82/
 - Houston - http://localhost:83/
 - pgAdmin - http://localhost:8000/
+- CODEX (frontend) - http://localhost:84/
+- CODEX (api docs) - http://localhost:84/api/v1/
 
 ### Usage
 

--- a/deploy/codex/dev-frontend/docker-entrypoint.sh
+++ b/deploy/codex/dev-frontend/docker-entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -ex
+
+npm install
+export NODE_ENV=development
+npx webpack serve --config ./config/webpack/webpack.common.js --host $HOST --public ${HOST}:${PORT} --env=houston=relative

--- a/deploy/codex/docker-compose.yml
+++ b/deploy/codex/docker-compose.yml
@@ -100,6 +100,31 @@ services:
       # FIXME: Can we define a better mountpoint for this file? Maybe /config.py?
       - ./houston/local_config.py:/code/local_config.py
 
+  dev-frontend:
+    # this component is intended to only be used in development
+    image: node:latest
+    working_dir: /code
+    entrypoint: "/docker-entrypoint.sh"
+    networks:
+      - intranet
+    environment:
+      HOST: "0.0.0.0"
+      # See port served by 'www' component (i.e. the reverse proxy)
+      PORT: "84"
+    volumes:
+      - ./dev-frontend/docker-entrypoint.sh:/docker-entrypoint.sh
+      - ../../_frontend:/code
+
+  www:
+    image: nginx:latest
+    networks:
+      - intranet
+      - frontend
+    ports:
+      - "84:80"
+    volumes:
+      - ./www/codex.conf:/etc/nginx/conf.d/default.conf
+
 networks:
   intranet:
   frontend:

--- a/deploy/codex/houston/local_config.py
+++ b/deploy/codex/houston/local_config.py
@@ -10,6 +10,7 @@ DATA_ROOT = Path(os.getenv('DATA_ROOT', '/data/var'))
 
 class LocalConfig(BaseConfig):
     DEBUG = True
+    REVERSE_PROXY_SETUP = True
 
     PROJECT_DATABASE_PATH = str(DATA_ROOT)
     SUBMISSIONS_DATABASE_PATH = str(DATA_ROOT / 'submissions')

--- a/deploy/codex/www/codex.conf
+++ b/deploy/codex/www/codex.conf
@@ -2,6 +2,9 @@ server {
     listen       80;
     server_name  0.0.0.0;
 
+    proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    # proxy_set_header X-Forwarded-Host $http_host;
     location ~ /(houston|api|swaggerui|login|logout) {
         proxy_pass http://houston:5000;
     }

--- a/deploy/codex/www/codex.conf
+++ b/deploy/codex/www/codex.conf
@@ -1,0 +1,11 @@
+server {
+    listen       80;
+    server_name  0.0.0.0;
+
+    location ~ /(houston|api|swaggerui|login|logout) {
+        proxy_pass http://houston:5000;
+    }
+    location / {
+        proxy_pass http://dev-frontend:3000;
+    }
+}


### PR DESCRIPTION
## Pull Request Overview

Change that attempts to bring in a frontend developer story. The idea
is that the (frontend|backend) developer can develop with all the
components available to them.

The essence of the change is to proxy the webpack DevServer through nginx. nginx is therefore acting as a reverse proxy for houston and the frontend. In production, we'd have nginx pointing at the build distribution of the frontend code.

Note, I've used a `dev-` prefix on the frontend component within the
component composition to indicate this component is only for
development usage. It's probably not obvious and doesn't really need
to be, but just wanted to mention incase that came into question.

Addresses https://wildme.atlassian.net/browse/DEX-194

---

**Review Notes**

Try the docker-compose install instructions. Not the change to use port `84` rather than `83`. So surf to http://localhost:84 once docker-compose is up. Note, it may take a minute or so for the frontend to start.

Once things are started, you should be able to change frontend code within the checked out submodule at `_frontend` and see those changes in the site.

In the background this is just running `webpack serve ...` that is proxied through nginx.

**Pull Request Checklist**
- [X] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [X] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [X] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [X] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [X] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [x] Ensure that the PR is properly reviewed
