### PR TITLE
Publish wildme/houston:latest image

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -47,15 +47,3 @@ jobs:
         if: github.ref == 'refs/heads/develop'
         run: |
           ./scripts/publish.sh -t latest houston
-
-      # Notify status in Slack
-      - name: Slack Notification
-        if: ${{ failure() }}
-        uses: rtCamp/action-slack-notify@master
-        env:
-          SLACK_CHANNEL: ia-development
-          SLACK_COLOR: '#FF0000'
-          SLACK_ICON: https://avatars.slack-edge.com/2020-03-02/965719891842_db87aa21ccb61076f236_44.png
-          SLACK_MESSAGE: 'Latest (tagged) build failed :sob:'
-          SLACK_USERNAME: "Latest"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -24,19 +24,28 @@ jobs:
       - name: Log into GitHub Packages
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
 
-      # Push containers out to container registries
+      # ############################################################
+      # Push Tagged image to registries
       - name: Push to GitHub Packages
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
         run: |
           VERSION=$(echo ${GITHUB_REF} | sed 's#.*/v##')
           ./scripts/publish.sh -t ${VERSION} -r docker.pkg.github.com houston
-          ./scripts/publish.sh -t latest -r docker.pkg.github.com houston
-
       - name: Push to Docker Hub
         if: ${{ github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags/v') }}
         run: |
           VERSION=$(echo ${GITHUB_REF} | sed 's#.*/v##')
           ./scripts/publish.sh -t ${VERSION} houston
+
+      # ############################################################
+      # Push latest image to registries
+      - name: Push to GitHub Packages
+        if: github.ref == 'refs/heads/develop'
+        run: |
+          ./scripts/publish.sh -t latest -r docker.pkg.github.com houston
+      - name: Push to Docker Hub
+        if: github.ref == 'refs/heads/develop'
+        run: |
           ./scripts/publish.sh -t latest houston
 
       # Notify status in Slack


### PR DESCRIPTION
## Pull Request Overview

- Changes the existing publishing step, which only works on tag right
now. This no longer pushes the `latest` as the latest release. Instead
this publishes the tip of `develop` as the `wildme/houston:latest` image.

   I wanted to be able to release the `latest` tagged image, so we aren't
pulling an out of date image when a tag is not specified. We're not
currently doing tagged releases (yet?). Maybe when we do, we can
change this behavior back and create a `develop` image tag.
- Remove CI step to report problems to slack, because it's reporting to the wrong channel.

---

**Review Notes**

I did test this works on CI in https://github.com/WildMeOrg/houston/runs/2036182515. These changes require being run on `develop` or a tag. Without the shim commit put into that run this won't publish. So `wildme/houston:latest` is now up and will be based on the tip of the `develop` branch from here out.

**Pull Request Checklist**
- [X] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [X] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [X] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [X] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [X] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [x] Ensure that the PR is properly reviewed
