### PR TITLE
Implemented the git clone for submission get

### DIFF
--- a/app/extensions/submission/__init__.py
+++ b/app/extensions/submission/__init__.py
@@ -254,6 +254,14 @@ class SubmissionManager(object):
 
         return repo
 
+    def is_submission_on_remote(self, submission_uuid):
+
+        self.ensure_initialed()
+
+        # Try to find remote project by Submission UUID
+        projects = self.gl.projects.list(search=str(submission_uuid))
+        return len(projects) == 1
+
     def ensure_submission(self, submission_uuid, owner=None):
         from app.modules.submissions.models import Submission
 

--- a/app/modules/submissions/parameters.py
+++ b/app/modules/submissions/parameters.py
@@ -5,9 +5,11 @@ Input arguments (Parameters) for Submissions resources RESTful API
 """
 
 from flask_restx_patched import Parameters, PatchJSONParameters
+from flask_login import current_user  # NOQA
 
 from . import schemas
 from .models import Submission
+from app.modules.users.permissions import rules
 
 
 class CreateSubmissionParameters(Parameters, schemas.CreateSubmissionSchema):
@@ -17,6 +19,32 @@ class CreateSubmissionParameters(Parameters, schemas.CreateSubmissionSchema):
 
 class PatchSubmissionDetailsParameters(PatchJSONParameters):
     # pylint: disable=abstract-method,missing-docstring
-    OPERATION_CHOICES = (PatchJSONParameters.OP_REPLACE,)
+    OPERATION_CHOICES = (PatchJSONParameters.OP_REPLACE, PatchJSONParameters.OP_ADD)
 
-    PATH_CHOICES = tuple('/%s' % field for field in (Submission.description.key,))
+    PATH_CHOICES = tuple('/%s' % field for field in (Submission.description.key, 'owner'))
+
+    @classmethod
+    def add(cls, obj, field, value, state):
+        # Add and replace are the same operation so reuse the one method
+        return cls.replace(obj, field, value, state)
+
+    @classmethod
+    def replace(cls, obj, field, value, state):
+        from app.modules.users.models import User
+
+        ret_val = False
+        # Permissions for all fields are the same so have one check
+        if rules.owner_or_privileged(current_user, obj) or current_user.is_admin:
+            if field == Submission.description.key:
+                obj.description = value
+                ret_val = True
+            elif field == 'owner':
+                user = User.query.get(value)
+                if user:
+                    obj.owner = user
+                    ret_val = True
+        return ret_val
+
+    @classmethod
+    def remove(cls, obj, field, value, state):
+        raise NotImplementedError()

--- a/app/modules/submissions/resources.py
+++ b/app/modules/submissions/resources.py
@@ -314,15 +314,12 @@ class SubmissionByID(Resource):
         """
         submission = self._get_submission_with_428(submission)
 
-        if submission is None:
-            # TODO Shouldn't this be a 204 No Content?
-            raise werkzeug.exceptions.NotFound
-
-        context = api.commit_or_abort(
-            db.session, default_error_message='Failed to delete the Submission.'
-        )
-        with context:
-            db.session.delete(submission)
+        if submission is not None:
+            context = api.commit_or_abort(
+                db.session, default_error_message='Failed to delete the Submission.'
+            )
+            with context:
+                db.session.delete(submission)
         return None
 
 

--- a/app/modules/submissions/resources.py
+++ b/app/modules/submissions/resources.py
@@ -162,8 +162,9 @@ class SubmissionsStreamlined(Resource):
         return submission
 
 
-@api.resolve_object_by_model(Submission, 'submission', return_not_found=True)
+@api.login_required(oauth_scopes=['submissions:read'])
 @api.route('/<uuid:submission_guid>')
+@api.resolve_object_by_model(Submission, 'submission', return_not_found=True)
 @api.response(
     code=HTTPStatus.NOT_FOUND,
     description='Submission not found.',
@@ -196,7 +197,6 @@ class SubmissionByID(Resource):
             # Submission neither local nor remote
             return None
 
-    @api.login_required(oauth_scopes=['submissions:read'])
     @api.permission_required(
         permissions.ModuleOrObjectAccessPermission,
         kwargs_on_request=lambda kwargs: {

--- a/app/modules/submissions/resources.py
+++ b/app/modules/submissions/resources.py
@@ -164,7 +164,6 @@ class SubmissionsStreamlined(Resource):
 
 @api.resolve_object_by_model(Submission, 'submission', return_not_found=True)
 @api.route('/<uuid:submission_guid>')
-@api.login_required(oauth_scopes=['submissions:read'])
 @api.response(
     code=HTTPStatus.NOT_FOUND,
     description='Submission not found.',
@@ -197,6 +196,7 @@ class SubmissionByID(Resource):
             # Submission neither local nor remote
             return None
 
+    @api.login_required(oauth_scopes=['submissions:read'])
     @api.permission_required(
         permissions.ModuleOrObjectAccessPermission,
         kwargs_on_request=lambda kwargs: {
@@ -223,12 +223,13 @@ class SubmissionByID(Resource):
 
         return submission
 
+    @api.login_required(oauth_scopes=['submissions:write'])
     @api.permission_required(
         permissions.ModuleOrObjectAccessPermission,
         kwargs_on_request=lambda kwargs: {
             'module': Submission,
             'obj': kwargs['submission'][0],
-            'action': AccessOperation.READ,
+            'action': AccessOperation.WRITE,
         },
     )
     @api.response(schemas.DetailedSubmissionSchema())

--- a/app/modules/users/permissions/__init__.py
+++ b/app/modules/users/permissions/__init__.py
@@ -89,7 +89,6 @@ class ModuleAccessPermission(Permission):
              whether the current user has enough permissions to perform the action on the class.
         action (ObjectAccessOperation) - READ, WRITE, DELETE supported
         """
-        # Sometimes the obj passed is the object itself, sometimes a list with the object as the first item
         self._module = module
         self._action = action
         super().__init__(**kwargs)
@@ -110,13 +109,35 @@ class ObjectAccessPermission(Permission):
              whether the current user has enough permissions to perform the action on the object.
         action (ObjectAccessOperation) - READ, WRITE, DELETE supported
         """
-        # Sometimes the obj passed is the object itself, sometimes a list with the object as the first item
-        self._obj = obj[0] if isinstance(obj, tuple) else obj
+        self._obj = obj
         self._action = action
         super().__init__(**kwargs)
 
     def rule(self):
         return rules.ObjectActionRule(self._obj, self._action)
+
+
+class ModuleOrObjectAccessPermission(Permission):
+    """
+    Ensure that the current user has sufficient permission to perform the action on the object
+    """
+
+    def __init__(self, module=None, obj=None, action=AccessOperation.READ, **kwargs):
+        """
+        Args:
+        module (class) - any class can be passed here, this functionality will determine
+             whether the current user has enough permissions to perform the action on the class.
+        obj (object) - any object can be passed here, this functionality will determine
+             whether the current user has enough permissions to perform the action on the object.
+        action (ObjectAccessOperation) - READ, WRITE, DELETE supported
+        """
+        self._module = module
+        self._obj = obj
+        self._action = action
+        super().__init__(**kwargs)
+
+    def rule(self):
+        return rules.ModuleOrObjectActionRule(self._module, self._obj, self._action)
 
 
 class RolePermission(Permission):

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -300,7 +300,16 @@ class ModuleOrObjectActionRule(DenyAbortMixin, Rule):
             has_permission = ObjectActionRule(self._obj, self._action).check()
         else:
             if self._module == Submission:
-                has_permission = current_user.is_researcher
+                # Read in this case equates to learn that the submission exists on gitlab,
+                # Delete is to allow the researcher to know that it's on gitlab but not local
+                if (
+                    self._action == AccessOperation.READ
+                    or self._action == AccessOperation.DELETE
+                ):
+                    has_permission = current_user.is_researcher
+                # Write equates to allowing the cloning of the submission from gitlab
+                elif self._action == AccessOperation.WRITE:
+                    has_permission = current_user.is_admin
 
         return has_permission
 

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -71,7 +71,7 @@ class ModuleActionRule(DenyAbortMixin, Rule):
         """
         Args:
         module (Class) - any class can be passed here, which this functionality will
-            determine whether the current user has enough permissions to perform te action on the class.
+            determine whether the current user has enough permissions to perform the action on the class.
         action (AccessRule) - can be READ, WRITE, DELETE
         """
         self._module = module
@@ -267,6 +267,32 @@ class ObjectActionRule(DenyAbortMixin, Rule):
     def _permitted_via_collaboration(self, user):
         # TODO:
         return False
+
+
+# Some modules are special (Submissions) mad may require both access controls in one
+class ModuleOrObjectActionRule(DenyAbortMixin, Rule):
+    def __init__(self, module=None, obj=None, action=AccessOperation.READ, **kwargs):
+        """
+        Args:
+        obj (object) - any object can be passed here, which this functionality will
+            determine whether the current user has enough permissions to write given object
+            object.
+        module (Class) - any class can be passed here, which this functionality will
+            determine whether the current user has enough permissions to perform the action on the class.
+        action (AccessRule) - can be READ, WRITE, DELETE
+        """
+        self._obj = obj
+        self._action = action
+        self._module = module
+        super().__init__(**kwargs)
+
+    def check(self):
+        assert self._obj is not None or self._module is not None
+        if self._obj:
+            rule = ObjectActionRule(self._obj, self._action)
+        else:
+            rule = ModuleActionRule(self._module, self._action)
+        return rule.check()
 
 
 class ActiveUserRoleRule(DenyAbortMixin, Rule):

--- a/flask_restx_patched/parameters.py
+++ b/flask_restx_patched/parameters.py
@@ -111,6 +111,9 @@ class PatchJSONParameters(Parameters):
         is prepended with '/'.
         Removing '/' in the beginning to simplify usage in resource.
         """
+        if 'op' not in data:
+            raise ValidationError('operation not supported')
+
         if data['op'] not in self.NO_VALUE_OPERATIONS and 'value' not in data:
             raise ValidationError('value is required')
 

--- a/tests/modules/assets/resources/test_assets.py
+++ b/tests/modules/assets/resources/test_assets.py
@@ -2,16 +2,19 @@
 # pylint: disable=missing-docstring
 import hashlib
 from tests import utils
+import tests.modules.submissions.resources.utils as submission_utils
 
 
 def test_find_asset(
     flask_app_client,
+    admin_user,
     researcher_1,
     test_clone_submission_data,
 ):
     # Clone the known submission so that the asset data is in the database
-    clone = utils.clone_submission(
+    clone = submission_utils.clone_submission(
         flask_app_client,
+        admin_user,
         researcher_1,
         test_clone_submission_data['submission_uuid'],
         later_usage=True,
@@ -49,13 +52,15 @@ def test_find_asset(
 
 def test_find_deleted_asset(
     flask_app_client,
+    admin_user,
     researcher_1,
     db,
     test_clone_submission_data,
 ):
     # Clone the known submission so that the asset data is in the database
-    clone = utils.clone_submission(
+    clone = submission_utils.clone_submission(
         flask_app_client,
+        admin_user,
         researcher_1,
         test_clone_submission_data['submission_uuid'],
         later_usage=True,
@@ -96,14 +101,16 @@ def test_find_deleted_asset(
 
 def test_user_asset_permissions(
     flask_app_client,
+    admin_user,
     researcher_1,
     readonly_user,
     db,
     test_clone_submission_data,
 ):
     # Clone the known submission so that the asset data is in the database
-    clone = utils.clone_submission(
+    clone = submission_utils.clone_submission(
         flask_app_client,
+        admin_user,
         researcher_1,
         test_clone_submission_data['submission_uuid'],
         later_usage=True,
@@ -130,8 +137,9 @@ def test_read_all_assets(
     test_clone_submission_data,
 ):
     # Clone the known submission so that the asset data is in the database
-    clone = utils.clone_submission(
+    clone = submission_utils.clone_submission(
         flask_app_client,
+        admin_user,
         researcher_1,
         test_clone_submission_data['submission_uuid'],
         later_usage=True,

--- a/tests/modules/assets/resources/test_assets.py
+++ b/tests/modules/assets/resources/test_assets.py
@@ -6,13 +6,13 @@ from tests import utils
 
 def test_find_asset(
     flask_app_client,
-    regular_user,
+    researcher_1,
     test_clone_submission_data,
 ):
     # Clone the known submission so that the asset data is in the database
     clone = utils.clone_submission(
         flask_app_client,
-        regular_user,
+        researcher_1,
         test_clone_submission_data['submission_uuid'],
         later_usage=True,
     )
@@ -22,7 +22,7 @@ def test_find_asset(
         test_src_asset = (
             '/api/v1/assets/src/%s' % test_clone_submission_data['asset_uuids'][0]
         )
-        with flask_app_client.login(regular_user, auth_scopes=('assets:read',)):
+        with flask_app_client.login(researcher_1, auth_scopes=('assets:read',)):
             response = flask_app_client.get(test_asset)
             src_response = flask_app_client.get(test_src_asset)
 
@@ -49,14 +49,14 @@ def test_find_asset(
 
 def test_find_deleted_asset(
     flask_app_client,
-    regular_user,
+    researcher_1,
     db,
     test_clone_submission_data,
 ):
     # Clone the known submission so that the asset data is in the database
     clone = utils.clone_submission(
         flask_app_client,
-        regular_user,
+        researcher_1,
         test_clone_submission_data['submission_uuid'],
         later_usage=True,
     )
@@ -69,7 +69,7 @@ def test_find_deleted_asset(
         test_src_asset = (
             '/api/v1/assets/src/%s' % test_clone_submission_data['asset_uuids'][0]
         )
-        with flask_app_client.login(regular_user, auth_scopes=('assets:read',)):
+        with flask_app_client.login(researcher_1, auth_scopes=('assets:read',)):
             response = flask_app_client.get(test_asset)
             src_response = flask_app_client.get(test_src_asset)
 
@@ -96,7 +96,7 @@ def test_find_deleted_asset(
 
 def test_user_asset_permissions(
     flask_app_client,
-    regular_user,
+    researcher_1,
     readonly_user,
     db,
     test_clone_submission_data,
@@ -104,7 +104,7 @@ def test_user_asset_permissions(
     # Clone the known submission so that the asset data is in the database
     clone = utils.clone_submission(
         flask_app_client,
-        regular_user,
+        researcher_1,
         test_clone_submission_data['submission_uuid'],
         later_usage=True,
     )

--- a/tests/modules/submissions/resources/test_ensure_submission.py
+++ b/tests/modules/submissions/resources/test_ensure_submission.py
@@ -5,26 +5,26 @@ from tests.utils import clone_submission
 
 
 def test_ensure_submission_by_uuid(
-    flask_app_client, regular_user, db, test_submission_uuid
+    flask_app_client, researcher_1, db, test_submission_uuid
 ):
-    clone_submission(flask_app_client, regular_user, test_submission_uuid)
+    clone_submission(flask_app_client, researcher_1, test_submission_uuid)
 
 
 def test_ensure_empty_submission_by_uuid(
-    flask_app_client, regular_user, db, test_empty_submission_uuid
+    flask_app_client, researcher_1, db, test_empty_submission_uuid
 ):
-    clone_submission(flask_app_client, regular_user, test_empty_submission_uuid)
+    clone_submission(flask_app_client, researcher_1, test_empty_submission_uuid)
 
 
 def test_ensure_clone_submission_by_uuid(
-    flask_app_client, regular_user, db, test_clone_submission_data
+    flask_app_client, researcher_1, db, test_clone_submission_data
 ):
     from app.modules.submissions.models import SubmissionMajorType
     from app.modules.assets.models import Asset
 
     clone = clone_submission(
         flask_app_client,
-        regular_user,
+        researcher_1,
         test_clone_submission_data['submission_uuid'],
         later_usage=True,
     )

--- a/tests/modules/submissions/resources/test_ensure_submission.py
+++ b/tests/modules/submissions/resources/test_ensure_submission.py
@@ -1,47 +1,52 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 import uuid
-from tests.utils import clone_submission
+import tests.modules.submissions.resources.utils as utils
 
 
 def test_ensure_submission_by_uuid(
-    flask_app_client, researcher_1, db, test_submission_uuid
+    flask_app_client, admin_user, researcher_1, db, test_submission_uuid
 ):
-    clone_submission(flask_app_client, researcher_1, test_submission_uuid)
+    utils.clone_submission(
+        flask_app_client, admin_user, researcher_1, test_submission_uuid
+    )
 
 
 def test_ensure_empty_submission_by_uuid(
-    flask_app_client, researcher_1, db, test_empty_submission_uuid
+    flask_app_client, admin_user, researcher_1, db, test_empty_submission_uuid
 ):
-    clone_submission(flask_app_client, researcher_1, test_empty_submission_uuid)
+    utils.clone_submission(
+        flask_app_client, admin_user, researcher_1, test_empty_submission_uuid
+    )
 
 
 def test_ensure_clone_submission_by_uuid(
-    flask_app_client, researcher_1, db, test_clone_submission_data
+    flask_app_client, admin_user, researcher_1, db, test_clone_submission_data
 ):
     from app.modules.submissions.models import SubmissionMajorType
     from app.modules.assets.models import Asset
 
-    clone = clone_submission(
+    clone = utils.clone_submission(
         flask_app_client,
+        admin_user,
         researcher_1,
         test_clone_submission_data['submission_uuid'],
         later_usage=True,
     )
 
     try:
-        assert clone.temp_submission.major_type == SubmissionMajorType.test
-        assert clone.temp_submission.commit == '1d3dd77e1fba336ae89bd9d7a2788f4a0cb2df90'
-        assert clone.temp_submission.commit_mime_whitelist_guid == uuid.UUID(
+        assert clone.submission.major_type == SubmissionMajorType.test
+        assert clone.submission.commit == '1d3dd77e1fba336ae89bd9d7a2788f4a0cb2df90'
+        assert clone.submission.commit_mime_whitelist_guid == uuid.UUID(
             '4d46c55d-accf-29f1-abe7-a24839ec1b95'
         )
 
-        assert clone.temp_submission.commit_houston_api_version == '0.1.0.6c9d6965'
-        assert clone.temp_submission.description == 'Test Submission (streamlined)'
+        assert clone.submission.commit_houston_api_version == '0.1.0.6c9d6965'
+        assert clone.submission.description == 'Test Submission (streamlined)'
 
         # Checks that there are two valid Assets in the database
-        assert len(clone.temp_submission.assets) == 2
-        temp_assets = sorted(clone.temp_submission.assets)
+        assert len(clone.submission.assets) == 2
+        temp_assets = sorted(clone.submission.assets)
         expected_guid_list = [
             uuid.UUID(test_clone_submission_data['asset_uuids'][0]),
             uuid.UUID(test_clone_submission_data['asset_uuids'][1]),

--- a/tests/modules/submissions/resources/test_permissions.py
+++ b/tests/modules/submissions/resources/test_permissions.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-from tests.utils import clone_submission
+import tests.modules.submissions.resources.utils as utils
 import json
 import uuid
 
@@ -8,13 +8,19 @@ from flask import current_app
 
 
 def test_user_read_permissions(
-    flask_app_client, researcher_1, readonly_user, db, test_clone_submission_data
+    flask_app_client,
+    admin_user,
+    researcher_1,
+    readonly_user,
+    db,
+    test_clone_submission_data,
 ):
     # Clone as the researcher user and then try to reread as both researcher and readonly user,
     # read by researcher user should succeed, read by readonly user should be blocked
 
-    clone = clone_submission(
+    clone = utils.clone_submission(
         flask_app_client,
+        admin_user,
         researcher_1,
         test_clone_submission_data['submission_uuid'],
         later_usage=True,

--- a/tests/modules/submissions/resources/test_permissions.py
+++ b/tests/modules/submissions/resources/test_permissions.py
@@ -7,21 +7,21 @@ from flask import current_app
 
 
 def test_user_read_permissions(
-    flask_app_client, regular_user, readonly_user, db, test_clone_submission_data
+    flask_app_client, researcher_1, readonly_user, db, test_clone_submission_data
 ):
     # Clone as the regular user and then try to reread as both regular and readonly user,
     # read by regular user should succeed, read by readonly user should be blocked
 
     clone = clone_submission(
         flask_app_client,
-        regular_user,
+        researcher_1,
         test_clone_submission_data['submission_uuid'],
         later_usage=True,
     )
 
     try:
         with flask_app_client.login(
-            regular_user,
+            researcher_1,
             auth_scopes=(
                 'submissions:read',
                 'assets:read',

--- a/tests/modules/submissions/resources/test_permissions.py
+++ b/tests/modules/submissions/resources/test_permissions.py
@@ -2,6 +2,7 @@
 # pylint: disable=missing-docstring
 from tests.utils import clone_submission
 import json
+import uuid
 
 from flask import current_app
 
@@ -9,8 +10,8 @@ from flask import current_app
 def test_user_read_permissions(
     flask_app_client, researcher_1, readonly_user, db, test_clone_submission_data
 ):
-    # Clone as the regular user and then try to reread as both regular and readonly user,
-    # read by regular user should succeed, read by readonly user should be blocked
+    # Clone as the researcher user and then try to reread as both researcher and readonly user,
+    # read by researcher user should succeed, read by readonly user should be blocked
 
     clone = clone_submission(
         flask_app_client,
@@ -66,7 +67,7 @@ def test_user_read_permissions(
         clone.cleanup()
 
 
-def test_create_patch_submission(flask_app_client, regular_user, readonly_user, db):
+def test_create_patch_submission(flask_app_client, researcher_1, readonly_user, db):
     # pylint: disable=invalid-name
     submission_guid = None
 
@@ -75,7 +76,7 @@ def test_create_patch_submission(flask_app_client, regular_user, readonly_user, 
 
         test_major_type = SubmissionMajorType.test
 
-        with flask_app_client.login(regular_user, auth_scopes=('submissions:write',)):
+        with flask_app_client.login(researcher_1, auth_scopes=('submissions:write',)):
             create_response = flask_app_client.post(
                 '/api/v1/submissions/',
                 data=json.dumps(
@@ -105,7 +106,7 @@ def test_create_patch_submission(flask_app_client, regular_user, readonly_user, 
             )
         assert readonly_patch_response.status_code == 403
 
-        with flask_app_client.login(regular_user, auth_scopes=('submissions:write',)):
+        with flask_app_client.login(researcher_1, auth_scopes=('submissions:write',)):
             # try to change very polite description slightly and type
             service_major_type = SubmissionMajorType.test
 
@@ -135,11 +136,25 @@ def test_create_patch_submission(flask_app_client, regular_user, readonly_user, 
             )
         assert readonly_delete_response.status_code == 403
 
-        with flask_app_client.login(regular_user, auth_scopes=('submissions:write',)):
+        with flask_app_client.login(researcher_1, auth_scopes=('submissions:write',)):
             regular_delete_response = flask_app_client.delete(
                 '/api/v1/submissions/%s' % submission_guid
             )
         assert regular_delete_response.status_code == 204
+
+        # And if the submission is already gone, a re attempt at deletion should get the same response
+        with flask_app_client.login(researcher_1, auth_scopes=('submissions:write',)):
+            regular_delete_response = flask_app_client.delete(
+                '/api/v1/submissions/%s' % submission_guid
+            )
+        assert regular_delete_response.status_code == 428
+
+        with flask_app_client.login(researcher_1, auth_scopes=('submissions:write',)):
+            regular_delete_response = flask_app_client.delete(
+                '/api/v1/submissions/%s' % uuid.uuid4()
+            )
+        assert regular_delete_response.status_code == 204
+
     except Exception as ex:
         raise ex
     finally:

--- a/tests/modules/submissions/resources/utils.py
+++ b/tests/modules/submissions/resources/utils.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+"""
+Submission resources utils
+-------------
+"""
+import json
+import shutil
+import os
+import config
+from tests import utils as test_utils
+
+PATH = '/api/v1/submissions/'
+
+
+def patch_submission(
+    flask_app_client, submission_guid, user, data, expected_status_code=200
+):
+    with flask_app_client.login(user, auth_scopes=('submissions:write',)):
+        response = flask_app_client.patch(
+            '%s%s' % (PATH, submission_guid),
+            content_type='application/json',
+            data=json.dumps(data),
+        )
+
+    if expected_status_code == 200:
+        test_utils.validate_dict_response(
+            response, 200, {'guid', 'description', 'major_type'}
+        )
+    else:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+    return response
+
+
+def read_submission(flask_app_client, user, submission_guid, expected_status_code=200):
+    with flask_app_client.login(user, auth_scopes=('submissions:read',)):
+        response = flask_app_client.get('%s%s' % (PATH, submission_guid))
+
+    if expected_status_code == 200:
+        test_utils.validate_dict_response(
+            response, 200, {'guid', 'description', 'major_type'}
+        )
+    else:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+    return response
+
+
+def read_all_submissions(flask_app_client, user, expected_status_code=200):
+    with flask_app_client.login(user, auth_scopes=('submissions:read',)):
+        response = flask_app_client.get(PATH)
+
+    if expected_status_code == 200:
+        test_utils.validate_list_response(response, 200)
+    else:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+    return response
+
+
+def delete_submission(flask_app_client, user, submission_guid, expected_status_code=204):
+    with flask_app_client.login(user, auth_scopes=('submissions:write',)):
+        response = flask_app_client.delete('%s%s' % (PATH, submission_guid))
+
+    if expected_status_code == 204:
+        assert response.status_code == 204
+    else:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+
+
+# multiple tests clone a submission, do something with it and clean it up. Make sure this always happens using a
+# class with a cleanup method to be called if any assertions fail
+class CloneSubmission(object):
+    def __init__(self, flask_app_client, admin_user, user, submission_guid, force_clone):
+        from app.modules.submissions.models import Submission
+
+        self.submission = None
+        self.guid = submission_guid
+
+        # Allow the option of forced cloning, this could raise an exception if the assertion fails
+        # but this does not need to be in any try/except/finally construct as no resources are allocated yet
+        if force_clone:
+            database_path = config.TestingConfig.SUBMISSIONS_DATABASE_PATH
+            submission_path = os.path.join(database_path, str(submission_guid))
+
+            if os.path.exists(submission_path):
+                shutil.rmtree(submission_path)
+            assert not os.path.exists(submission_path)
+
+        with flask_app_client.login(user, auth_scopes=('submissions:read',)):
+            self.response = flask_app_client.get('%s%s' % (PATH, submission_guid))
+
+        if self.response.status_code == 428:
+
+            with flask_app_client.login(admin_user, auth_scopes=('submissions:write',)):
+                self.response = flask_app_client.post('%s%s' % (PATH, submission_guid))
+
+            # only store the transient submission for cleanup if the clone worked
+            if self.response.status_code == 200:
+                self.submission = Submission.query.get(self.response.json['guid'])
+
+            # reassign ownership
+            data = [
+                test_utils.patch_add_op('owner', '%s' % user.guid),
+            ]
+            patch_submission(flask_app_client, submission_guid, admin_user, data)
+
+            # and read it back as the real user
+            with flask_app_client.login(user, auth_scopes=('submissions:read',)):
+                self.response = flask_app_client.get('%s%s' % (PATH, submission_guid))
+
+    def remove_files(self):
+        database_path = config.TestingConfig.SUBMISSIONS_DATABASE_PATH
+        submission_path = os.path.join(database_path, str(self.guid))
+        if os.path.exists(submission_path):
+            shutil.rmtree(submission_path)
+
+    def cleanup(self):
+        # Restore original state
+        if self.submission is not None:
+            self.submission.delete()
+            self.submission = None
+        self.remove_files()
+
+
+# Clone the submission
+# If later_usage is set, it's the callers responsibility to call the cleanup method.
+def clone_submission(
+    flask_app_client,
+    admin_user,
+    user,
+    submission_uuid,
+    force_clone=False,
+    later_usage=False,
+):
+    clone = CloneSubmission(
+        flask_app_client, admin_user, user, submission_uuid, force_clone
+    )
+    if not later_usage:
+        clone.cleanup()
+    return clone

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -128,6 +128,12 @@ class CloneSubmission(object):
                 '/api/v1/submissions/%s' % submission_uuid
             )
 
+        if self.response.status_code == 428:
+            # need to do a post to call the ensure_submission
+            with flask_app_client.login(user, auth_scopes=('submissions:read',)):
+                self.response = flask_app_client.post(
+                    '/api/v1/submissions/%s' % submission_uuid
+                )
         # only store the transient submission for cleanup if the clone worked
         if self.response.status_code == 200:
             self.temp_submission = Submission.query.get(self.response.json['guid'])


### PR DESCRIPTION
## Pull Request Overview

- Submission is different and can allow the object to be cloned from gitlab if not already present
- Needs a special call to the resolver
- Implemented new ModuleOrObjectAccessPermission for this special case 
- get patch or delete can return 428 in this case.
- Post is used to perform the clone from the remote repo
---

**Review Notes**
- Specify a list of any items, notes, or qualifiers that need to be known in order to efficiently review this PR

**REST API Updates [OPTIONAL]**

A new example POST API is defined with its expected parameters, if needed to be specified for a thorough review

```
[POST] /api/v1/submissions/{guid}
{
    {No content, this is simply a get with clone} ,
}
```

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
