### PR TITLE
DEX-201 Create single db transaction for encounters patch API

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -183,6 +183,8 @@ jobs:
         run: |
           source virtualenv/houston3.7/bin/activate
           pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}" --cov=./ --cov-append
+          pytest -s -v -m separate tests/test_transactions.py::test_transactions[None-request_transaction] --cov-append
+          pytest -s -v -m separate tests/test_transactions.py::test_transactions[None-commit_or_abort] --cov-append
 
       - name: Run other invoke tasks for coverage and errors
         if: matrix.python-version == '3.9'

--- a/app/extensions/config/__init__.py
+++ b/app/extensions/config/__init__.py
@@ -95,25 +95,26 @@ class HoustonFlaskConfig(flask.Config):
 
             app = current_app
 
-            houston_config = HoustonConfig.query.filter(HoustonConfig.key == key).first()
-            if houston_config is None:
-                houston_config = HoustonConfig(key=key, value=value)
-                with app_db.session.begin():
-                    app_db.session.add(houston_config)
-                label = 'Added'
-            else:
-                if self.USE_UPDATE_OR_INSERT:
-                    if value != houston_config.value:
-                        houston_config.value = value
-                        with app_db.session.begin():
-                            app_db.session.merge(houston_config)
-                        label = 'Updated'
-                    else:
-                        label = 'Checked'
+        houston_config = HoustonConfig.query.filter(HoustonConfig.key == key).first()
+        if houston_config is None:
+            houston_config = HoustonConfig(key=key, value=value)
+            with app_db.session.begin():
+                app_db.session.add(houston_config)
+            label = 'Added'
+        else:
+            if self.USE_UPDATE_OR_INSERT:
+                if value != houston_config.value:
+                    houston_config.value = value
+                    with app_db.session.begin():
+                        app_db.session.merge(houston_config)
+                    label = 'Updated'
                 else:
-                    raise ValueError(
-                        'You tried to update a database config that already exists (use update_or_insert=True)'
-                    )
+                    label = 'Checked'
+            else:
+                raise ValueError(
+                    'You tried to update a database config that already exists (use update_or_insert=True)'
+                )
+
         app_db.session.refresh(houston_config)
         log.warning(
             '%s non-volatile database configuration %r'

--- a/app/extensions/submission/__init__.py
+++ b/app/extensions/submission/__init__.py
@@ -297,12 +297,13 @@ class SubmissionManager(object):
             if owner is None:
                 owner = current_user
 
+            submission = Submission(
+                created=created,
+                guid=submission_uuid,
+                owner_guid=owner.guid,
+            )
+
             with db.session.begin():
-                submission = Submission(
-                    created=created,
-                    guid=submission_uuid,
-                    owner_guid=owner.guid,
-                )
                 db.session.add(submission)
             db.session.refresh(submission)
 

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -186,7 +186,7 @@ class Asset(db.Model, HoustonModel):
         return target_path
 
     def delete(self):
-        with db.session.begin():
+        with db.session.begin(subtransactions=True):
             db.session.delete(self)
 
     def delete_cascade(self):

--- a/app/modules/auth/models.py
+++ b/app/modules/auth/models.py
@@ -418,8 +418,8 @@ class Code(db.Model, HoustonModel):
                 'reject_code': reject_code,
                 'expires': expires_utc,
             }
+            code = Code(**code_kwargs)
             with db.session.begin():
-                code = Code(**code_kwargs)
                 db.session.add(code)
             db.session.refresh(code)
             db.session.refresh(user)

--- a/app/modules/encounters/models.py
+++ b/app/modules/encounters/models.py
@@ -83,7 +83,7 @@ class Encounter(db.Model, FeatherModel):
         return [ref.asset for ref in self.assets]
 
     def add_asset(self, asset):
-        with db.session.begin():
+        with db.session.begin(subtransactions=True):
             self.add_asset_in_context(asset)
 
     def add_assets(self, asset_list):

--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -208,8 +208,8 @@ class EncounterByID(Resource):
         context = api.commit_or_abort(
             db.session, default_error_message='Failed to update Encounter details.'
         )
-        parameters.PatchEncounterDetailsParameters.perform_patch(args, obj=encounter)
         with context:
+            parameters.PatchEncounterDetailsParameters.perform_patch(args, obj=encounter)
             db.session.merge(encounter)
         return encounter
 

--- a/app/modules/submissions/models.py
+++ b/app/modules/submissions/models.py
@@ -594,6 +594,10 @@ class Submission(db.Model, HoustonModel):
         with db.session.begin():
             for asset in self.assets:
                 asset.delete()
+        db.session.refresh(self)
+        # TODO: This is potentially dangerous as it decouples the Asset deletion
+        #       transaction with the Submission deletion transaction, bad for rollbacks
+        with db.session.begin():
             db.session.delete(self)
         self.delete_dirs()
 

--- a/app/modules/submissions/models.py
+++ b/app/modules/submissions/models.py
@@ -261,7 +261,7 @@ class Submission(db.Model, HoustonModel):
             description=description,
         )
         submission.owner = owner
-        with db.session.begin():
+        with db.session.begin(subtransactions=True):
             db.session.add(submission)
 
         log.info('created submission %r' % submission)
@@ -424,7 +424,7 @@ class Submission(db.Model, HoustonModel):
             print('\tErrors  : %d' % (len(errors),))
 
         # Compute the xxHash64 for all found files
-        filepath_list = [file_data['filepath'] for file_data in files]
+        filepath_list = [file_data_['filepath'] for file_data_ in files]
         arguments_list = list(zip(filepath_list))
         print('Computing filesystem xxHash64...')
         filesystem_xxhash64_list = parallel(
@@ -470,7 +470,7 @@ class Submission(db.Model, HoustonModel):
             file_data.pop('filepath', None) for file_data in files
         ]
         assets = []
-        with db.session.begin():
+        with db.session.begin(subtransactions=True):
             for file_data, asset_submission_filepath in zip(
                 files, asset_submission_filepath_list
             ):
@@ -520,7 +520,7 @@ class Submission(db.Model, HoustonModel):
         deleted_assets = list(set(self.assets) - set(assets))
         if verbose:
             print('Deleting %d orphaned Assets' % (len(deleted_assets),))
-        with db.session.begin():
+        with db.session.begin(subtransactions=True):
             for deleted_asset in deleted_assets:
                 deleted_asset.delete()
         db.session.refresh(self)
@@ -555,7 +555,7 @@ class Submission(db.Model, HoustonModel):
         return repo
 
     def update_metadata_from_commit(self, commit):
-        with db.session.begin():
+        with db.session.begin(subtransactions=True):
             self.commit = commit.hexsha
 
             metadata_path = os.path.join(commit.repo.working_dir, 'metadata.json')

--- a/app/modules/submissions/models.py
+++ b/app/modules/submissions/models.py
@@ -591,13 +591,13 @@ class Submission(db.Model, HoustonModel):
 
     # TODO should this blow away remote repo?  by default?
     def delete(self):
-        with db.session.begin():
+        with db.session.begin(subtransactions=True):
             for asset in self.assets:
                 asset.delete()
         db.session.refresh(self)
         # TODO: This is potentially dangerous as it decouples the Asset deletion
         #       transaction with the Submission deletion transaction, bad for rollbacks
-        with db.session.begin():
+        with db.session.begin(subtransactions=True):
             db.session.delete(self)
         self.delete_dirs()
 

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -65,23 +65,23 @@ class UserEDMMixin(EDMObjectMixin):
 
     @classmethod
     def ensure_edm_obj(cls, guid):
-        with db.session.begin():
-            user = User.query.filter(User.guid == guid).first()
-            is_new = False
+        user = User.query.filter(User.guid == guid).first()
+        is_new = user is None
 
-            if user is None:
-                email = '%s@localhost' % (guid,)
-                password = security.generate_random(128)
-                user = User(
-                    guid=guid,
-                    email=email,
-                    password=password,
-                    version=None,
-                    is_active=True,
-                    in_alpha=True,
-                )
+        if is_new:
+            email = '%s@localhost' % (guid,)
+            password = security.generate_random(128)
+            user = User(
+                guid=guid,
+                email=email,
+                password=password,
+                version=None,
+                is_active=True,
+                in_alpha=True,
+            )
+            with db.session.begin():
                 db.session.add(user)
-                is_new = True
+            db.session.refresh(user)
 
         return user, is_new
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,10 +49,12 @@ single-quotes = true
 
 [tool:pytest]
 minversion = 5.4
-addopts = -v -p no:doctest --xdoctest --xdoctest-style=google --random-order --random-order-bucket=global --cov=./ --cov-report html
+addopts = -v -p no:doctest --xdoctest --xdoctest-style=google --random-order --random-order-bucket=global --cov=./ --cov-report html -m "not separate"
 testpaths =
     app
     tests
+markers =
+    separate: a test that should not be run with other tests
 filterwarnings =
     default
     ignore:.*No cfgstr given in Cacher constructor or call.*:Warning

--- a/tasks/app/consistency.py
+++ b/tasks/app/consistency.py
@@ -22,47 +22,49 @@ def user_staff_permissions(context):
 
     users = User.query.all()
 
-    updated = 0
+    updates = []
+    for user in tqdm.tqdm(users):
+
+        update = False
+
+        if not user.in_alpha:
+            user.in_alpha = True
+            update = True
+        if not user.in_beta:
+            user.in_beta = True
+            update = True
+
+        email = user.email.strip()
+        whitlist = [
+            'bluemellophone@gmail.com',
+            'sito.org+giraffeadmin@gmail.com',
+            'sito.org+gstest@gmail.com',
+        ]
+        is_wildme = email.endswith('@wildme.org') or email in whitlist
+        if is_wildme:
+            if not user.is_staff:
+                user.is_staff = True
+                update = True
+            if not user.is_admin:
+                user.is_admin = True
+                update = True
+            print(user)
+        else:
+            if user.is_staff:
+                user.is_staff = False
+                update = True
+            if user.is_admin:
+                user.is_admin = False
+                update = True
+
+        if update:
+            updates.append(user)
+
     with db.session.begin():
-        for user in tqdm.tqdm(users):
+        for user in updates:
+            db.session.merge(user)
 
-            update = False
-
-            if not user.in_alpha:
-                user.in_alpha = True
-                update = True
-            if not user.in_beta:
-                user.in_beta = True
-                update = True
-
-            email = user.email.strip()
-            whitlist = [
-                'bluemellophone@gmail.com',
-                'sito.org+giraffeadmin@gmail.com',
-                'sito.org+gstest@gmail.com',
-            ]
-            is_wildme = email.endswith('@wildme.org') or email in whitlist
-            if is_wildme:
-                if not user.is_staff:
-                    user.is_staff = True
-                    update = True
-                if not user.is_admin:
-                    user.is_admin = True
-                    update = True
-                print(user)
-            else:
-                if user.is_staff:
-                    user.is_staff = False
-                    update = True
-                if user.is_admin:
-                    user.is_admin = False
-                    update = True
-
-            if update:
-                db.session.merge(user)
-                updated += 1
-
-    print('Updated %d users' % (updated,))
+    print('Updated %d users' % (len(updates),))
 
 
 @app_context_task

--- a/tasks/app/initial_development_data.py
+++ b/tasks/app/initial_development_data.py
@@ -17,43 +17,40 @@ DOCUMENTATION_CLIENT_SECRET = 'SECRET'
 def init_users():
     from app.modules.users.models import User
 
+    root_user = User(
+        email='root@localhost',
+        password='q',
+        is_active=True,
+        is_admin=True,
+    )
+    docs_user = User(
+        email='documentation@localhost',
+        password='w',
+        is_active=True,
+    )
+    staff_member = User(
+        email='staff@localhost',
+        password='w',
+        is_active=True,
+        is_staff=True,
+    )
+    regular_user = User(
+        email='test@localhost',
+        password='w',
+        is_active=True,
+    )
+    internal_user = User(
+        email='internal@localhost',
+        password='q',
+        is_active=True,
+        is_internal=True,
+    )
+
     with db.session.begin():
-        root_user = User(
-            email='root@localhost',
-            password='q',
-            is_active=True,
-            is_admin=True,
-        )
         db.session.add(root_user)
-
-        docs_user = User(
-            email='documentation@localhost',
-            password='w',
-            is_active=True,
-        )
         db.session.add(docs_user)
-
-        staff_member = User(
-            email='staff@localhost',
-            password='w',
-            is_active=True,
-            is_staff=True,
-        )
         db.session.add(staff_member)
-
-        regular_user = User(
-            email='test@localhost',
-            password='w',
-            is_active=True,
-        )
         db.session.add(regular_user)
-
-        internal_user = User(
-            email='internal@localhost',
-            password='q',
-            is_active=True,
-            is_internal=True,
-        )
         db.session.add(internal_user)
 
     return docs_user
@@ -64,14 +61,14 @@ def init_auth(docs_user):
 
     # TODO: OpenAPI documentation has to have OAuth2 Implicit Flow instead
     # of Resource Owner Password Credentials Flow
+    oauth2_client = OAuth2Client(
+        guid=DOCUMENTATION_CLIENT_GUID,
+        secret=DOCUMENTATION_CLIENT_SECRET,
+        user_guid=docs_user.guid,
+        redirect_uris=[],
+        default_scopes=api.api_v1.authorizations['oauth2_password']['scopes'],
+    )
     with db.session.begin():
-        oauth2_client = OAuth2Client(
-            guid=DOCUMENTATION_CLIENT_GUID,
-            secret=DOCUMENTATION_CLIENT_SECRET,
-            user_guid=docs_user.guid,
-            redirect_uris=[],
-            default_scopes=api.api_v1.authorizations['oauth2_password']['scopes'],
-        )
         db.session.add(oauth2_client)
     return oauth2_client
 

--- a/tasks/app/initialize.py
+++ b/tasks/app/initialize.py
@@ -116,14 +116,14 @@ def initialize_gitlab_submissions(context, email, dryrun=False):
                 log.info(
                     'Submission %r missing locally, creating...' % (submission_guid,)
                 )
+                args = {
+                    'guid': submission_guid,
+                    'owner_guid': user.guid,
+                    'major_type': SubmissionMajorType.test,
+                    'description': 'This is a required PyTest submission (do not delete)',
+                }
+                submission = Submission(**args)
                 with db.session.begin():
-                    args = {
-                        'guid': submission_guid,
-                        'owner_guid': user.guid,
-                        'major_type': SubmissionMajorType.test,
-                        'description': 'This is a required PyTest submission (do not delete)',
-                    }
-                    submission = Submission(**args)
                     db.session.add(submission)
                 db.session.refresh(submission)
                 log.info('Submission %r created' % (submission,))

--- a/tasks/app/submissions.py
+++ b/tasks/app/submissions.py
@@ -42,13 +42,14 @@ def create_submission_from_path(
     if not os.path.exists(path):
         raise IOError('The path %r does not exist.' % (absolute_path,))
 
+    args = {
+        'owner_guid': user.guid,
+        'major_type': SubmissionMajorType.filesystem,
+        'description': description,
+    }
+    submission = Submission(**args)
+
     with db.session.begin():
-        args = {
-            'owner_guid': user.guid,
-            'major_type': SubmissionMajorType.filesystem,
-            'description': description,
-        }
-        submission = Submission(**args)
         db.session.add(submission)
 
     db.session.refresh(submission)

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+from app.extensions.api import api_v1, Namespace, http_exceptions
+from app.modules.users.models import User
+from app.modules.users.schemas import DetailedUserSchema
+from flask import got_request_exception
+from flask_marshmallow import base_fields
+from flask_restx_patched import Resource, Parameters
+from flask_restx_patched._http import HTTPStatus
+import pytest
+import sqlalchemy
+
+
+class TransactionParameters(Parameters):
+    guid = base_fields.UUID()
+    email = base_fields.String()
+    full_name = base_fields.String()
+    locale = base_fields.String()
+    website = base_fields.String()
+
+
+def setup_request_transaction(transaction_api, flask_app, db):
+    def before_request_func():
+        db.session.begin()
+
+    def after_request_func(response):
+        try:
+            db.session.commit()
+        except:  # noqa
+            db.session.rollback()
+        return response
+
+    try:
+        # This is @flask_app.before_request
+        before_request_func = flask_app.before_request(before_request_func)
+        # This is @flask_app.after_request
+        after_request_func = flask_app.after_request(after_request_func)
+    except AssertionError:
+        pytest.skip('Test expected to be run on its own')
+
+    class TransactionResources(Resource):
+        @transaction_api.parameters(TransactionParameters())
+        @transaction_api.response(DetailedUserSchema())
+        def get(self, args):
+            user = User.query.get(args.get('guid'))
+            user.full_name = args.get('full_name')
+            user.locale = args.get('locale')
+            db.session.merge(user)
+            with db.session.begin(subtransactions=True):
+                user.website = args.get('website')
+                db.session.merge(user)
+            user.email = args.get('email')
+            db.session.merge(user)
+            return user
+
+    return TransactionResources
+
+
+def setup_commit_or_abort(transaction_api, flask_app, db):
+    class TransactionResources(Resource):
+        @transaction_api.parameters(TransactionParameters())
+        @transaction_api.response(DetailedUserSchema())
+        def get(self, args):
+            user = User.query.get(args.get('guid'))
+            context = transaction_api.commit_or_abort(db.session)
+            with context:
+                user.full_name = args.get('full_name')
+                user.locale = args.get('locale')
+                db.session.merge(user)
+                with db.session.begin(subtransactions=True):
+                    user.website = args.get('website')
+                    db.session.merge(user)
+            # Just to make sure it's ok to do subtransactions=True when
+            # it's not a subtransaction
+            with db.session.begin(subtransactions=True):
+                user.email = args.get('email')
+                db.session.merge(user)
+
+            return user
+
+    return TransactionResources
+
+
+@pytest.mark.separate
+@pytest.mark.parametrize('setup_type', ('request_transaction', 'commit_or_abort'))
+def test_transactions(flask_app, flask_app_client, db, regular_user, request, setup_type):
+    orig_email = regular_user.email
+    orig_full_name = regular_user.full_name
+    orig_locale = regular_user.locale
+    orig_website = regular_user.website
+
+    def reset_regular_user():
+        regular_user.email = orig_email
+        regular_user.full_name = orig_full_name
+        regular_user.locale = orig_locale
+        regular_user.website = orig_website
+        db.session.add(regular_user)
+
+    request.addfinalizer(reset_regular_user)
+
+    transaction_api = Namespace('test-transactions')
+    api_v1.add_namespace(transaction_api)
+    TransactionResources = globals()[f'setup_{setup_type}'](
+        transaction_api, flask_app, db
+    )
+
+    def signal_handler(sender, exception, **extra):
+        if isinstance(exception, sqlalchemy.exc.DataError):
+            http_exceptions.abort(code=HTTPStatus.CONFLICT, message=str(exception))
+
+    # Instead of catching exceptions in api/extensions/api/http_exceptions.py?
+    got_request_exception.connect(signal_handler)
+
+    try:
+        # This is @transaction_api.route('/')
+        TransactionResources = transaction_api.route('/')(TransactionResources)
+    except AssertionError:
+        pytest.skip('Test expected to be run on its own')
+
+    # locale too long
+    resp = flask_app_client.get(
+        '/api/v1/test-transactions/',
+        query_string={
+            'guid': regular_user.guid,
+            'email': 'nobody@example.org',
+            'full_name': 'First',
+            'locale': 'more than twenty characters',
+            'website': 'https://example.org/',
+        },
+    )
+    assert resp.status_code == HTTPStatus.CONFLICT
+    # make sure no changes are committed
+    refreshed_user = User.query.get(regular_user.guid)
+    assert refreshed_user.email == orig_email
+    assert refreshed_user.full_name == orig_full_name
+    assert refreshed_user.locale == orig_locale
+    assert refreshed_user.website is None
+
+    # website too long
+    resp = flask_app_client.get(
+        '/api/v1/test-transactions/',
+        query_string={
+            'guid': regular_user.guid,
+            'email': 'nobody@example.org',
+            'full_name': 'First',
+            'locale': 'FR',
+            'website': 'https://www.example.org/?{}'.format('a' * 100),
+        },
+    )
+    assert resp.status_code == HTTPStatus.CONFLICT
+    # make sure no changes are committed
+    refreshed_user = User.query.get(regular_user.guid)
+    assert refreshed_user.email == orig_email
+    assert refreshed_user.full_name == orig_full_name
+    assert refreshed_user.locale == orig_locale
+    assert refreshed_user.website is None
+
+    resp = flask_app_client.get(
+        '/api/v1/test-transactions/',
+        query_string={
+            'guid': regular_user.guid,
+            'email': 'nobody@example.org',
+            'full_name': 'First',
+            'locale': 'FR',
+            'website': 'https://www.example.org/',
+        },
+    )
+    assert resp.status_code == 200
+    refreshed_user = User.query.get(regular_user.guid)
+    assert resp.json['email'] == refreshed_user.email == 'nobody@example.org'
+    assert resp.json['full_name'] == refreshed_user.full_name == 'First'
+    assert refreshed_user.locale == 'FR'
+    assert resp.json['website'] == refreshed_user.website == 'https://www.example.org/'


### PR DESCRIPTION
- Add example to show how transactions work

  The view code for `/api/v1/test-transactions/` is basically:
  
  ```
  (implicitly or explicitly) start db transaction:
      change full_name
      change locale
      start nested transaction:
          change website
      change email
  ```
  
  Check nothing is updated if locale is too long.
  
  Check nothing is updated if website is too long.
  
  Check everything is updated if everything goes through.

- Create single db transaction for encounters patch API

  This means if anything fails during the encounters patch API everything
  written to the database will be reverted.



# Review Notes

> What do people think about implicitly starting a db transaction in the before_request hook and committing in the after_request hook?
>
> This way we can definitely avoid accidental changes to the database.  We sometimes call functions from our views and we may miss that the function actually commits something to the database.  By having an implicit database transaction around request, we can be sure everything that happened within the request is reverted.

Jason raised concerns about locking the database for the whole of the request.  We can possibly look into isolation level but we'll leave it for now

> I haven't done the change yet but I think it's ok to change all the `db.session.begin()` to `db.session.begin(subtransactions=True)` because it seems to work whether or not there's already a transaction.

We are only adding `subtransactions=True` where necessary

---

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
