### PR TITLE
DEX-158: cascading sighting delete

### DIFF
--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -186,6 +186,10 @@ class Asset(db.Model, HoustonModel):
         return target_path
 
     def delete(self):
+        with db.session.begin():
+            db.session.delete(self)
+
+    def delete_cascade(self):
         sub = self.submission
         with db.session.begin(subtransactions=True):
             db.session.delete(self)

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -186,8 +186,10 @@ class Asset(db.Model, HoustonModel):
         return target_path
 
     def delete(self):
+        sub = self.submission
         with db.session.begin():
             db.session.delete(self)
+        sub.justify_existence()
 
     @classmethod
     def find(cls, guid):

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -187,7 +187,7 @@ class Asset(db.Model, HoustonModel):
 
     def delete(self):
         sub = self.submission
-        with db.session.begin():
+        with db.session.begin(subtransactions=True):
             db.session.delete(self)
         sub.justify_existence()
 

--- a/app/modules/encounters/models.py
+++ b/app/modules/encounters/models.py
@@ -105,11 +105,14 @@ class Encounter(db.Model, FeatherModel):
             self.add_asset_no_context(asset)
 
     def delete(self):
-        with db.session.begin():
+        assets = self.get_assets()
+        with db.session.begin(subtransactions=True):
             while self.assets:
-                asset = self.assets.pop()
-                asset.delete()
+                db.session.delete(self.assets.pop())
             db.session.delete(self)
+        while assets:
+            asset = assets.pop()
+            asset.delete()
 
     def delete_from_edm(self, current_app):
         response = current_app.edm.request_passthrough(

--- a/app/modules/encounters/models.py
+++ b/app/modules/encounters/models.py
@@ -107,7 +107,8 @@ class Encounter(db.Model, FeatherModel):
     def delete(self):
         with db.session.begin():
             while self.assets:
-                db.session.delete(self.assets.pop())
+                asset = self.assets.pop()
+                asset.delete()
             db.session.delete(self)
 
     def delete_from_edm(self, current_app):

--- a/app/modules/encounters/models.py
+++ b/app/modules/encounters/models.py
@@ -104,15 +104,25 @@ class Encounter(db.Model, FeatherModel):
         for asset in asset_list:
             self.add_asset_no_context(asset)
 
+    # we dont delete .assets here because that is complex (due to annotations)
     def delete(self):
+        with db.session.begin():
+            while self.assets:
+                # this is actually removing the EncounterAssets joining object (not the assets)
+                db.session.delete(self.assets.pop())
+            db.session.delete(self)
+
+    def delete_cascade(self):
         assets = self.get_assets()
+        # TODO modify behavior when we have annotations
         with db.session.begin(subtransactions=True):
             while self.assets:
+                # this is actually removing the EncounterAssets joining object (not the assets)
                 db.session.delete(self.assets.pop())
             db.session.delete(self)
         while assets:
             asset = assets.pop()
-            asset.delete()
+            asset.delete_cascade()
 
     def delete_from_edm(self, current_app):
         response = current_app.edm.request_passthrough(

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -49,11 +49,20 @@ class Sighting(db.Model, FeatherModel):
             self.encounters.append(encounter)
 
     def delete(self):
-        with db.session.begin():
+        with db.session.begin(subtransactions=True):
             while self.encounters:
                 enc = self.encounters.pop()
                 enc.delete()
             db.session.delete(self)
+
+    def delete_from_edm(self, current_app):
+        response = current_app.edm.request_passthrough(
+            'sighting.data',
+            'delete',
+            {},
+            self.guid,
+        )
+        return response
 
     # given edm_json (verbose json from edm) will populate with houston-specific data from feather object
     # note: this modifies the passed in edm_json, so not sure how legit that is?

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -78,11 +78,16 @@ class Sighting(db.Model, FeatherModel):
             db.session.delete(self)
 
     def delete_from_edm(self, current_app):
+        return Sighting.delete_from_edm_by_guid(current_app, self.guid)
+
+    @classmethod
+    def delete_from_edm_by_guid(cls, current_app, guid):
+        assert guid is not None
         response = current_app.edm.request_passthrough(
             'sighting.data',
             'delete',
             {},
-            self.guid,
+            guid,
         )
         return response
 

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -41,6 +41,24 @@ class Sighting(db.Model, FeatherModel):
             return self.get_owners()[0]
         return None
 
+    # will return None if not a single owner of all encounters (otherwise that user)
+    def single_encounter_owner(self):
+        single = None
+        for encounter in self.encounters:
+            if (
+                single is not None and not single == encounter.owner
+            ):  # basically a mismatch, so we fail
+                return None
+            if encounter.owner is not None:
+                single = encounter.owner
+        return single
+
+    def user_owns_all_encounters(self, user):
+        return user is not None and user == self.single_encounter_owner()
+
+    def user_can_edit_all_encounters(self, user):
+        return self.user_owns_all_encounters(user)
+
     def get_encounters(self):
         return self.encounters
 

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -50,8 +50,9 @@ class Sighting(db.Model, FeatherModel):
 
     def delete(self):
         with db.session.begin():
-            # while self.encounters:  #not going to do this yet!
-            # db.session.delete(self.encounters.pop())
+            while self.encounters:
+                enc = self.encounters.pop()
+                enc.delete()
             db.session.delete(self)
 
     # given edm_json (verbose json from edm) will populate with houston-specific data from feather object

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -49,10 +49,14 @@ class Sighting(db.Model, FeatherModel):
             self.encounters.append(encounter)
 
     def delete(self):
+        with db.session.begin():
+            db.session.delete(self)
+
+    def delete_cascade(self):
         with db.session.begin(subtransactions=True):
             while self.encounters:
                 enc = self.encounters.pop()
-                enc.delete()
+                enc.delete_cascade()
             db.session.delete(self)
 
     def delete_from_edm(self, current_app):

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -423,5 +423,5 @@ class SightingByID(Resource):
 
         # if we get here, edm has deleted the sighting, now houston feather
         # TODO handle failure of feather deletion (when edm successful!)  out-of-sync == bad
-        sighting.delete()  # this will cascade through encounters/assets/submissions
+        sighting.delete_cascade()
         return None

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -30,22 +30,23 @@ log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace('sightings', description='Sightings')  # pylint: disable=invalid-name
 
 
-def _cleanup_post_and_abort(
-    sighting_guid, submission, message='Unknown error', log_message=None
-):
-    # TODO actually clean up edm based on guid!!!
-    if sighting_guid is not None:
-        log.warning(
-            '#### TODO ####   need to properly cleanup edm sighting id=%r' % sighting_guid
-        )
-    if submission is not None:
-        log.warning(
-            '#### TODO ####   need to properly cleanup submission %r' % submission
-        )
-    if log_message is None:
-        log_message = message
-    log.error('Bailing on sighting creation: %r' % log_message)
-    abort(success=False, passed_message=message, message='Error', code=400)
+class SightingCleanup(object):
+    def __init__(self):
+        self.sighting_guid = None
+        self.submission = None
+
+    def rollback_and_abort(self, message='Unknown error', log_message=None):
+        if log_message is None:
+            log_message = message
+        log.error('Bailing on sighting creation: %r' % log_message)
+        if self.sighting_guid is not None:
+            log.warning('Cleanup removing Sighting %r from EDM' % self.sighting_guid)
+            Sighting.delete_from_edm_by_guid(current_app, self.sighting_guid)
+        if self.submission is not None:
+            log.warning('Cleanup removing %r' % self.submission)
+            self.submission.delete()
+            self.submission = None
+        abort(success=False, passed_message=message, message='Error', code=400)
 
 
 def _validate_asset_references(enc_list):
@@ -169,6 +170,7 @@ class Sightings(Resource):
         Create a new instance of Sighting.
         """
 
+        cleanup = SightingCleanup()
         request_in = {}
         try:
             request_in_ = json.loads(request.data)
@@ -182,9 +184,7 @@ class Sightings(Resource):
             or not isinstance(request_in['encounters'], list)
             or len(request_in['encounters']) < 1
         ):
-            _cleanup_post_and_abort(
-                None,
-                None,
+            cleanup.rollback_and_abort(
                 'Must have at least one encounter',
                 'Sighting.post empty encounters in %r' % request_in,
             )
@@ -207,11 +207,13 @@ class Sightings(Resource):
             or not response_data.get('success', False)
             or result_data is None
         ):
-            log.warning('Sighting.post failed')
             passed_message = {'message': {'key': 'error'}}
             if response_data is not None and 'message' in response_data:
                 passed_message = response_data['message']
-            abort(success=False, passed_message=passed_message, message='Error', code=400)
+            cleanup.rollback_and_abort(passed_message, 'Sighting.post failed')
+
+        # Created it, need to clean it up if we rollback
+        cleanup.sighting_guid = result_data['id']
 
         # if we get here, edm has made the sighting.  now we have to consider encounters contained within,
         # and make houston for the sighting + encounters
@@ -220,17 +222,13 @@ class Sightings(Resource):
         if ('encounters' in request_in and 'encounters' not in result_data) or (
             'encounters' not in request_in and 'encounters' in result_data
         ):
-            _cleanup_post_and_abort(
-                result_data['id'],
-                None,
+            cleanup.rollback_and_abort(
                 'Missing encounters between request_in and result',
                 'Sighting.post missing encounters in one of %r or %r'
                 % (request_in, result_data),
             )
         if not len(request_in['encounters']) == len(result_data['encounters']):
-            _cleanup_post_and_abort(
-                result_data['id'],
-                None,
+            cleanup.rollback_and_abort(
                 'Imbalance in encounters between data and result',
                 'Sighting.post imbalanced encounters in %r or %r'
                 % (request_in, result_data),
@@ -239,9 +237,7 @@ class Sightings(Resource):
         try:
             all_arefs, paths_wanted = _validate_asset_references(request_in['encounters'])
         except Exception as ex:
-            _cleanup_post_and_abort(
-                result_data['id'],
-                None,
+            cleanup.rollback_and_abort(
                 'Invalid assetReference data in encounter(s)',
                 '_validate_asset_references threw %r on encounters=%r'
                 % (ex, request_in['encounters']),
@@ -251,7 +247,6 @@ class Sightings(Resource):
         )
 
         submission = None
-        assets_added = None
         pub = True
         owner_guid = None
         if current_user is not None and not current_user.is_anonymous:
@@ -273,18 +268,17 @@ class Sightings(Resource):
                     paths=all_arefs[transaction_id],
                 )
             except Exception as ex:
-                _cleanup_post_and_abort(
-                    result_data['id'],
-                    submission,
+                cleanup.submission = submission
+                cleanup.rollback_and_abort(
                     'Problem with encounter/assets',
                     '%r on create_submission_from_tus transaction_id=%r paths=%r'
                     % (ex, transaction_id, all_arefs[transaction_id]),
                 )
+            cleanup.submission = submission
 
-            assets_added = submission.assets
             log.debug(
                 'create_submission_from_tus returned: %r => %r'
-                % (submission, assets_added)
+                % (submission, submission.assets)
             )
 
         sighting = Sighting(
@@ -308,16 +302,14 @@ class Sightings(Resource):
                     enc_assets = None
                     if paths_wanted is not None:
                         # will throw exception if we dont have all we need
-                        enc_assets = _enc_assets(assets_added, paths_wanted[i])
+                        enc_assets = _enc_assets(submission.assets, paths_wanted[i])
                         if enc_assets is not None:
                             encounter.add_assets_no_context(enc_assets)
                     log.debug('%r is adding enc_assets=%r' % (encounter, enc_assets))
                     sighting.add_encounter(encounter)
                     i += 1
                 except Exception as ex:
-                    _cleanup_post_and_abort(
-                        result_data['id'],
-                        submission,
+                    cleanup.rollback_and_abort(
                         'Problem with encounter/assets',
                         '%r on encounter %d: paths_wanted=%r; enc=%r'
                         % (ex, i, paths_wanted, request_in['encounters'][i]),

--- a/app/modules/submissions/models.py
+++ b/app/modules/submissions/models.py
@@ -587,9 +587,16 @@ class Submission(db.Model, HoustonModel):
 
         return submission_path
 
+    # TODO should this blow away remote repo?  by default?
     def delete(self):
         for asset in self.assets:
             asset.delete()
         db.session.refresh(self)
         with db.session.begin():
             db.session.delete(self)
+
+    # stub of DEX-220 ... to be continued
+    def justify_existence(self):
+        if self.assets:  # we have assets, so we live on
+            return
+        self.delete()  # TODO will this also kill remote repo?

--- a/app/modules/submissions/models.py
+++ b/app/modules/submissions/models.py
@@ -592,11 +592,12 @@ class Submission(db.Model, HoustonModel):
         for asset in self.assets:
             asset.delete()
         db.session.refresh(self)
-        with db.session.begin():
+        with db.session.begin(subtransactions=True):
             db.session.delete(self)
 
     # stub of DEX-220 ... to be continued
     def justify_existence(self):
         if self.assets:  # we have assets, so we live on
             return
+        log.warning('justify_existence() found ZERO assets, self-destructing %r' % self)
         self.delete()  # TODO will this also kill remote repo?

--- a/app/modules/submissions/models.py
+++ b/app/modules/submissions/models.py
@@ -275,10 +275,7 @@ class Submission(db.Model, HoustonModel):
                 'create_submission_from_tus() had problems with import_tus_files(); deleting from db and fs %r'
                 % submission
             )
-            if os.path.exists(submission.get_absolute_path()):
-                shutil.rmtree(submission.get_absolute_path())
-            with db.session.begin():
-                db.session.delete(submission)
+            submission.delete()
             raise
 
         log.info('submission imported %r' % added)
@@ -587,6 +584,10 @@ class Submission(db.Model, HoustonModel):
 
         return submission_path
 
+    def delete_dirs(self):
+        if os.path.exists(self.get_absolute_path()):
+            shutil.rmtree(self.get_absolute_path())
+
     # TODO should this blow away remote repo?  by default?
     def delete(self):
         for asset in self.assets:
@@ -594,6 +595,7 @@ class Submission(db.Model, HoustonModel):
         db.session.refresh(self)
         with db.session.begin(subtransactions=True):
             db.session.delete(self)
+        self.delete_dirs()
 
     # stub of DEX-220 ... to be continued
     def justify_existence(self):

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -597,11 +597,9 @@ class User(db.Model, FeatherModel, UserEDMMixin):
             if obj.submission is not None:
                 ret_val = obj.submission.owner is self
         elif isinstance(obj, (Sighting, Individual)):
-            # up for consideration. old world allows control of a sighting or individual if you own at least one encounter on it.
-            for encounter in obj.get_encounters():
-                if encounter.get_owner() is self:
-                    ret_val = True
-                    break
+            # decided (2021-03-12) that "owner" of these objects is not applicable therefore always False
+            #   permissions on these objects must be handled in ways not dependent on ownership
+            ret_val = False
 
         return ret_val
 

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -596,10 +596,15 @@ class User(db.Model, FeatherModel, UserEDMMixin):
             # TODO: need to understand once assets become part of an encounter, do they still have a submission
             if obj.submission is not None:
                 ret_val = obj.submission.owner is self
-        elif isinstance(obj, (Sighting, Individual)):
-            # decided (2021-03-12) that "owner" of these objects is not applicable therefore always False
-            #   permissions on these objects must be handled in ways not dependent on ownership
+        elif isinstance(obj, Sighting):
+            # decided (2021-03-12) that "owner" of a Sighting is not applicable therefore always False
+            #   permissions must be handled in ways not dependent on ownership
             ret_val = False
+        elif isinstance(obj, Individual):
+            for encounter in obj.get_encounters():
+                if encounter.get_owner() is self:
+                    ret_val = True
+                    break
 
         return ret_val
 

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -199,6 +199,7 @@ class ObjectActionRule(DenyAbortMixin, Rule):
     def _permitted_via_user(self, user):
         from app.modules.individuals.models import Individual
         from app.modules.encounters.models import Encounter
+        from app.modules.sightings.models import Sighting
         from app.modules.users.models import User
 
         # users can read write and delete anything they own while some users can do anything
@@ -225,6 +226,11 @@ class ObjectActionRule(DenyAbortMixin, Rule):
                 # them and those roles are not supported yet
                 if self._action == AccessOperation.READ:
                     has_permission = user.is_researcher
+
+        # Sightings depend on if user is the _only_ owner of referenced Encounters
+        if not has_permission and isinstance(self._obj, Sighting):
+            if self._action == AccessOperation.DELETE:
+                has_permission = self._obj.user_can_edit_all_encounters(user)
 
         return has_permission
 

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -2,6 +2,7 @@
 # pylint: disable=missing-docstring
 
 from tests.modules.sightings.resources import utils as sighting_utils
+from tests import utils as test_utils
 
 
 def test_create_failures(flask_app_client, researcher_1):
@@ -55,12 +56,7 @@ def test_create_and_delete_sighting(db, flask_app_client, researcher_1, staff_us
     import datetime
 
     # we should end up with these same counts (which _should be_ all zeros!)
-    orig_ct = [
-        sighting_utils.row_count(db, Sighting),
-        sighting_utils.row_count(db, Encounter),
-        sighting_utils.row_count(db, Asset),
-        sighting_utils.row_count(db, Submission),
-    ]
+    orig_ct = test_utils.multi_count(db, (Sighting, Encounter, Asset, Submission))
 
     timestamp = datetime.datetime.now().isoformat()
     transaction_id, test_filename = sighting_utils.prep_tus_dir()
@@ -90,10 +86,5 @@ def test_create_and_delete_sighting(db, flask_app_client, researcher_1, staff_us
     sighting_utils.cleanup_tus_dir(transaction_id)
     sighting_utils.delete_sighting(flask_app_client, staff_user, sighting_id)
 
-    post_ct = [
-        sighting_utils.row_count(db, Sighting),
-        sighting_utils.row_count(db, Encounter),
-        sighting_utils.row_count(db, Asset),
-        sighting_utils.row_count(db, Submission),
-    ]
+    post_ct = test_utils.multi_count(db, (Sighting, Encounter, Asset, Submission))
     assert orig_ct == post_ct

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -84,7 +84,7 @@ def test_create_and_delete_sighting(db, flask_app_client, researcher_1, staff_us
 
     # upon success (yay) we clean up our mess
     sighting_utils.cleanup_tus_dir(transaction_id)
-    sighting_utils.delete_sighting(flask_app_client, staff_user, sighting_id)
+    sighting_utils.delete_sighting(flask_app_client, researcher_1, sighting_id)
 
     post_ct = test_utils.multi_count(db, (Sighting, Encounter, Asset, Submission))
     assert orig_ct == post_ct

--- a/tests/modules/sightings/resources/utils.py
+++ b/tests/modules/sightings/resources/utils.py
@@ -91,7 +91,3 @@ def delete_sighting(flask_app_client, user, sight_guid, expected_status_code=204
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message'}
         )
-
-
-def row_count(db, cls):
-    return db.session.query(cls).count()

--- a/tests/modules/sightings/resources/utils.py
+++ b/tests/modules/sightings/resources/utils.py
@@ -70,21 +70,20 @@ def create_sighting(
 
 
 # not yet implemented
-def read_sighting(flask_app_client, user, enc_guid, expected_status_code=200):
+def read_sighting(flask_app_client, user, sight_guid, expected_status_code=200):
     with flask_app_client.login(user, auth_scopes=('sightings:read',)):
-        response = flask_app_client.get('%s%s' % (PATH, enc_guid))
+        response = flask_app_client.get('%s%s' % (PATH, sight_guid))
 
     assert isinstance(response.json, dict)
     assert response.status_code == expected_status_code
     if expected_status_code == 200:
-        assert response.json['id'] == str(enc_guid)
+        assert response.json['id'] == str(sight_guid)
     return response
 
 
-# not yet implemented
-def delete_sighting(flask_app_client, user, enc_guid, expected_status_code=204):
-    with flask_app_client.login(user, auth_scopes=('sighting:write',)):
-        response = flask_app_client.delete('%s%s' % (PATH, enc_guid))
+def delete_sighting(flask_app_client, user, sight_guid, expected_status_code=204):
+    with flask_app_client.login(user, auth_scopes=('sightings:write',)):
+        response = flask_app_client.delete('%s%s' % (PATH, sight_guid))
 
     if expected_status_code == 204:
         assert response.status_code == 204
@@ -92,3 +91,7 @@ def delete_sighting(flask_app_client, user, enc_guid, expected_status_code=204):
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message'}
         )
+
+
+def row_count(db, cls):
+    return db.session.query(cls).count()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -239,3 +239,14 @@ def patch_replace_op(path, value):
         'path': '/%s' % (path,),
         'value': value,
     }
+
+
+def multi_count(db, cls_list):
+    cts = []
+    for cls in cls_list:
+        cts.append(row_count(db, cls))
+    return cts
+
+
+def row_count(db, cls):
+    return db.session.query(cls).count()


### PR DESCRIPTION
## Pull Request Overview

- Allow (very) deep deletion of Sightings, namely removal of EDM counterpart (including Encounters), feather encounters, assets, and submission
- Introduces `delete_cascade()` on these classes for this purpose
- Implements the above via `DELETE /api/v1/sightings/GUID` endpoint

---

**Review Notes**
- Previous behavior of `.delete()` unaffected
- Needs to have "cascading" permission logic implemented


**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
