### PR TITLE
DEX-211 Refactor tus code in submissions and fileuploads

### DIFF
--- a/app/modules/fileuploads/models.py
+++ b/app/modules/fileuploads/models.py
@@ -15,46 +15,6 @@ import shutil
 log = logging.getLogger(__name__)
 
 
-# TODO move these to common tus area, possibly new extension (as suggested by jp) related to "file acquisition"
-#   also, resolve overlap with submission.import_tus_files ... which prob should be moved to same new area!
-
-
-def _tus_filepath_from(transaction_id, path):  # singular path, one filepath returned
-    filepaths = _tus_filepaths_from(transaction_id, paths=[path])
-    if filepaths is None or len(filepaths) < 1:
-        return None
-    return filepaths[0]
-
-
-def _tus_filepaths_from(transaction_id, paths=None):
-    from app.extensions.tus import tus_upload_dir
-
-    upload_dir = tus_upload_dir(current_app, transaction_id=transaction_id)
-    log.debug('_tus_filepaths_from passed paths=%r' % (paths))
-    filepaths = []
-    if isinstance(paths, list):
-        if len(paths) < 1:
-            return None
-        for path in paths:
-            want_path = os.path.join(upload_dir, path)
-            assert os.path.exists(want_path)
-            filepaths.append(want_path)
-
-    else:  # traverse who upload dir and take everything
-        for root, dirs, files in os.walk(upload_dir):
-            for path in files:
-                filepaths.append(os.path.join(upload_dir, path))
-
-    return filepaths
-
-
-def _tus_purge(transaction_id):
-    from app.extensions.tus import tus_upload_dir
-
-    upload_dir = tus_upload_dir(current_app, transaction_id=transaction_id)
-    shutil.rmtree(upload_dir)
-
-
 class FileUpload(db.Model, HoustonModel):
     """
     FileUploads database model.
@@ -90,24 +50,28 @@ class FileUpload(db.Model, HoustonModel):
     #   note: this is 'path' from { transaction_id, path } in tus args.  sorry so many things called path.
     @classmethod
     def create_fileupload_from_tus(cls, transaction_id, path):
+        from app.extensions.tus import _tus_filepaths_from, _tus_purge
+
         assert transaction_id is not None
         assert path is not None
-        source_path = _tus_filepath_from(transaction_id, path)
-        fup = FileUpload.create_fileupload_from_path(source_path)
-        _tus_purge(transaction_id)
+        source_paths = _tus_filepaths_from(transaction_id=transaction_id, paths=[path])
+        fup = FileUpload.create_fileupload_from_path(source_paths[0])
+        _tus_purge(transaction_id=transaction_id)
         return fup
 
     # plural paths is optional (will do all files in dir if skipped)
     @classmethod
     def create_fileuploads_from_tus(cls, transaction_id, paths=None):
+        from app.extensions.tus import _tus_filepaths_from, _tus_purge
+
         assert transaction_id is not None
-        source_paths = _tus_filepaths_from(transaction_id, paths)
+        source_paths = _tus_filepaths_from(transaction_id=transaction_id, paths=paths)
         if source_paths is None or len(source_paths) < 1:
             return None
         fups = []
         for source_path in source_paths:
             fups.append(FileUpload.create_fileupload_from_path(source_path))
-        _tus_purge(transaction_id)
+        _tus_purge(transaction_id=transaction_id)
         return fups
 
     @classmethod

--- a/tests/modules/fileuploads/test_models.py
+++ b/tests/modules/fileuploads/test_models.py
@@ -3,6 +3,9 @@
 
 import config
 import os
+import pathlib
+import shutil
+
 from app.modules.fileuploads.models import FileUpload
 
 
@@ -16,7 +19,26 @@ def _source_file():
     )
 
 
-def test_fileupload_create_delete(db):
+def cleanup_fileuploads_directory(fileuploads_directory):
+    """Recursively clean up empty directories in fileuploads directory"""
+    for c in fileuploads_directory.glob('*'):
+        child = pathlib.Path(c)
+        if child.is_dir():
+            cleanup_fileuploads_directory(c)
+            if not list(child.glob('*')):
+                c.rmdir()
+
+
+def test_fileupload_create_delete(db, flask_app, request):
+    fup_dir = None
+    FILEUPLOAD_BASE_PATH = pathlib.Path(flask_app.config.get('FILEUPLOAD_BASE_PATH'))
+
+    def cleanup():
+        if fup_dir and fup_dir.exists():
+            shutil.rmtree(fup_dir)
+        cleanup_fileuploads_directory(FILEUPLOAD_BASE_PATH)
+
+    request.addfinalizer(cleanup)
 
     source_file = _source_file()
     sz = os.path.getsize(source_file)
@@ -28,6 +50,7 @@ def test_fileupload_create_delete(db):
     fup_guid = fup.guid
 
     fup_path = fup.get_absolute_path()
+    fup_dir = pathlib.Path(fup_path)
     fup_sz = os.path.getsize(fup_path)
     assert sz == fup_sz
     f_test = FileUpload.query.get(fup_guid)
@@ -41,10 +64,100 @@ def test_fileupload_create_delete(db):
     assert not os.path.exists(fup_path)
 
 
-def test_fileuploads_get_src(flask_app_client, db):
+def test_fileupload_from_tus(db, flask_app, request):
+    UPLOADS_DATABASE_PATH = pathlib.Path(flask_app.config.get('UPLOADS_DATABASE_PATH'))
+    FILEUPLOAD_BASE_PATH = pathlib.Path(flask_app.config.get('FILEUPLOAD_BASE_PATH'))
+    TRANSACTION_ID = 'transaction-id'
+    tus_dir = UPLOADS_DATABASE_PATH / f'trans-{TRANSACTION_ID}'
+    fup_dir = None
+
+    def cleanup():
+        if tus_dir.exists():
+            shutil.rmtree(tus_dir)
+        if fup_dir and fup_dir.exists():
+            shutil.rmtree(fup_dir)
+        cleanup_fileuploads_directory(FILEUPLOAD_BASE_PATH)
+
+    request.addfinalizer(cleanup)
+
+    tus_dir.mkdir(parents=True, exist_ok=True)
+    with (tus_dir / 'a.jpg').open('wb') as f:
+        with pathlib.Path(_source_file()).open('rb') as g:
+            f.write(g.read())
+
+    # Create fileupload using file from tus
+    fup = FileUpload.create_fileupload_from_tus(TRANSACTION_ID, 'a.jpg')
+    with db.session.begin():
+        db.session.add(fup)
+    fup_path = pathlib.Path(fup.get_absolute_path())
+    fup_dir = fup_path.parent
+
+    assert fup.src == f'/api/v1/fileuploads/src/{fup.guid}'
+
+    # Delete fileupload when the file on disk is already deleted
+    fup_path.unlink()
+    fup.delete()
+
+
+def test_fileuploads_from_tus(db, flask_app, request):
+    UPLOADS_DATABASE_PATH = pathlib.Path(flask_app.config.get('UPLOADS_DATABASE_PATH'))
+    FILEUPLOAD_BASE_PATH = pathlib.Path(flask_app.config.get('FILEUPLOAD_BASE_PATH'))
+    TRANSACTION_ID = 'transaction-id'
+    tus_dir = UPLOADS_DATABASE_PATH / f'trans-{TRANSACTION_ID}'
+    fup_dirs = []
+    fups = []
+
+    def cleanup():
+        for fup in fups:
+            fup.delete()
+        if tus_dir.exists():
+            shutil.rmtree(tus_dir)
+        for fup_dir in fup_dirs:
+            if fup_dir.exists():
+                shutil.rmtree(fup_dir)
+        cleanup_fileuploads_directory(FILEUPLOAD_BASE_PATH)
+
+    request.addfinalizer(cleanup)
+
+    tus_dir.mkdir(parents=True, exist_ok=True)
+
+    # Try creating file uploads with no files
+    assert FileUpload.create_fileuploads_from_tus(TRANSACTION_ID) is None
+
+    with (tus_dir / 'a.jpg').open('wb') as f:
+        with pathlib.Path(_source_file()).open('rb') as g:
+            f.write(g.read())
+
+    with (tus_dir / 'a.txt').open('w') as f:
+        f.write('abcd\n')
+
+    # Create file uploads with files but paths=[]
+    assert FileUpload.create_fileuploads_from_tus(TRANSACTION_ID, paths=[]) is None
+
+    fups = FileUpload.create_fileuploads_from_tus(TRANSACTION_ID)
+    with db.session.begin():
+        for fup in fups:
+            db.session.add(fup)
+    fup_paths = [pathlib.Path(fup.get_absolute_path()) for fup in fups]
+    fup_dirs = [fup_path.parent for fup_path in fup_paths]
+    assert len(fups) == 2
+    assert all([fup_path.is_file() for fup_path in fup_paths])
+
+
+def test_fileuploads_get_src(flask_app, flask_app_client, db, request):
+    fup_dir = None
+    FILEUPLOAD_BASE_PATH = pathlib.Path(flask_app.config.get('FILEUPLOAD_BASE_PATH'))
+
+    def cleanup():
+        if fup_dir and fup_dir.exists():
+            shutil.rmtree(fup_dir)
+        cleanup_fileuploads_directory(FILEUPLOAD_BASE_PATH)
+
+    request.addfinalizer(cleanup)
     source_file = _source_file()
     sz = os.path.getsize(source_file)
     fup = FileUpload.create_fileupload_from_path(source_file, copy=True)
+    fup_dir = pathlib.Path(fup.get_absolute_path())
     with db.session.begin():
         db.session.add(fup)
     response = flask_app_client.get('/api/v1/fileuploads/src/' + str(fup.guid))

--- a/tests/modules/submissions/test_tus_creation.py
+++ b/tests/modules/submissions/test_tus_creation.py
@@ -21,7 +21,7 @@ def test_create_submission_from_tus(db, researcher_1):
 
     # now with a file dir+files but ask for wrong one
     tid, valid_file = prep_tus_dir()
-    with pytest.raises(OSError):
+    with pytest.raises(AssertionError):
         sub = Submission.create_submission_from_tus(
             'PYTEST', researcher_1, tid, paths={'fail.jpg'}
         )


### PR DESCRIPTION
## Pull Request Overview

- Add FileUpload create fileuploads from tus tests

  Create fileuploads from tus transactions is what we are going to use in
  user profile image API so adding some tests to make sure everything
  works.

- Refactor tus code in submissions and fileuploads

  Move tus code from FileUpload models.py to
  app/extensions/tus/__init__.py so that code can be shared between
  FileUpload models.py and Submission models.py.

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [x] Ensure that the PR is properly reviewed
