### PR TITLE
Add GitLab to our local deployment composition

### DIFF
--- a/.dockerfiles/docker-entrypoint.sh
+++ b/.dockerfiles/docker-entrypoint.sh
@@ -126,6 +126,10 @@ _main() {
 		fi
 	fi
 
+	# Always process these initialization scripts
+	if [ -d /docker-entrypoint-always-init.d ]; then
+		docker_process_init_files /docker-entrypoint-always-init.d/*
+	fi
 	if [ "$(id -u)" = '0' ]; then
 		exec gosu nobody "$@"
 	else

--- a/.dockerfiles/docker-entrypoint.sh
+++ b/.dockerfiles/docker-entrypoint.sh
@@ -49,6 +49,12 @@ docker_process_init_files() {
 					. "$f"
 				fi
 				;;
+			*.source-sh)
+				# test -x "$f" on a volume mounted file causes `-x` to report
+				# true if the file exist regardless of execution permissions
+				echo "$0: sourcing $f"
+				. "$f"
+				;;
 			*)        echo "$0: ignoring $f" ;;
 		esac
 		echo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,6 @@ exclude: |
       ^app/static/ |
       ^app/templates/ |
       ^clients/ |
-      ^deploy/ |
       ^Houston.egg-info |
       ^virtualenv |
       ^migrations/versions/

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,9 @@ ENV DATA_VOLUME /data
 ENV DATA_ROOT ${DATA_VOLUME}/var
 VOLUME [ "${DATA_VOLUME}" ]
 
+# Location to source additional environment variables
+ENV HOUSTON_DOTENV ${DATA_ROOT}/.env
+
 COPY ./.dockerfiles/docker-entrypoint.sh /docker-entrypoint.sh
 
 ENTRYPOINT [ "/docker-entrypoint.sh" ]

--- a/app/extensions/submission/__init__.py
+++ b/app/extensions/submission/__init__.py
@@ -127,6 +127,9 @@ class SubmissionManager(object):
                 self.mime_type_whitelist_guid = None
                 self.initialized = False
 
+                if self.app.debug:
+                    log.exception('problem initializing GitLab integration')
+
                 raise RuntimeError(
                     'GitLab remote failed to authenticate and/or initialize'
                 )

--- a/app/modules/submissions/models.py
+++ b/app/modules/submissions/models.py
@@ -44,7 +44,7 @@ class GitLabPAT(object):
 
         self.repo = repo
         if url is None:
-            assert repo is not None
+            assert repo is not None, 'both repo and url parameters provided, choose one'
             url = repo.remotes.origin.url
         self.original_url = url
 

--- a/app/modules/submissions/models.py
+++ b/app/modules/submissions/models.py
@@ -5,6 +5,7 @@ Submissions database models
 """
 
 import enum
+import re
 from flask import current_app
 
 from app.extensions import db, HoustonModel, parallel
@@ -51,8 +52,12 @@ class GitLabPAT(object):
         remote_personal_access_token = current_app.config.get(
             'GITLAB_REMOTE_LOGIN_PAT', None
         )
-        self.authenticated_url = self.original_url.replace(
-            'https://', 'https://oauth2:%s@' % (remote_personal_access_token,)
+        self.authenticated_url = re.sub(
+            #: match on either http or https
+            r'(https?)://(.*)$',
+            #: replace with basic-auth entities
+            r'\1://oauth2:%s@\2' % (remote_personal_access_token,),
+            self.original_url,
         )
 
     def __enter__(self):

--- a/config.py
+++ b/config.py
@@ -16,7 +16,8 @@ log = logging.getLogger(__name__)
 HERE = Path(__file__).parent
 
 # Load .env into environment variables (then available under os.environ)
-_dotenv = HERE / '.env'
+_DEFAULT_DOTENV = HERE / '.env'
+_dotenv = os.getenv('HOUSTON_DOTENV', _DEFAULT_DOTENV)
 load_dotenv(_dotenv, override=False)  # gracefully fails if file doesn't exist
 
 PROJECT_ROOT = str(HERE)

--- a/config.py
+++ b/config.py
@@ -251,10 +251,11 @@ class EDMConfig(object):
 
 
 class SubmissionGitLabRemoteConfig(object):
-    GITLAB_REMOTE_URI = 'https://sub.dyn.wildme.io/'
-    GITLAB_PUBLIC_NAME = 'Houston'
-    GITLAB_EMAIL = 'dev@wildme.org'
-    GITLAB_NAMESPACE = 'TEST'
+    GITLAB_REMOTE_URI = os.getenv('GITLAB_REMOTE_URI', 'https://sub.dyn.wildme.io/')
+    GITLAB_PUBLIC_NAME = os.getenv('GITLAB_PUBLIC_NAME', 'Houston')
+    GITLAB_EMAIL = os.getenv('GITLAB_EMAIL', 'dev@wildme.org')
+    GITLAB_NAMESPACE = os.getenv('GITLAB_NAMESPACE', 'TEST')
+    GITLAB_REMOTE_LOGIN_PAT = os.getenv('GITLAB_REMOTE_LOGIN_PAT')
 
 
 class ProductionConfig(

--- a/deploy/codex/.env
+++ b/deploy/codex/.env
@@ -48,3 +48,17 @@ SQLALCHEMY_DATABASE_URI=postgresql://houston:development@db/houston
 EDM_AUTHENTICATIONS_URI__DEFAULT=http://edm:8080/
 EDM_AUTHENTICATIONS_USERNAME__DEFAULT=admin@example.com
 EDM_AUTHENTICATIONS_PASSWORD__DEFAULT=4dm1n
+
+# These are used by the set_up_gitlab.sh init script
+GITLAB_PROTO=http
+GITLAB_HOST=gitlab
+GITLAB_PORT=80
+GITLAB_ADMIN_PASSWORD=development
+#/
+
+GITLAB_REMOTE_URI=http://gitlab
+GITLAB_PUBLIC_NAME=Houston
+GITLAB_EMAIL=dev@wildme.org
+GITLAB_NAMESPACE=TEST
+#: generated and defined by scripts & sourced from /root/.env in the container
+# GITLAB_REMOTE_LOGIN_PAT

--- a/deploy/codex/.env
+++ b/deploy/codex/.env
@@ -60,5 +60,5 @@ GITLAB_REMOTE_URI=http://gitlab
 GITLAB_PUBLIC_NAME=Houston
 GITLAB_EMAIL=dev@wildme.org
 GITLAB_NAMESPACE=TEST
-#: generated and defined by scripts & sourced from /root/.env in the container
+#: generated and defined by scripts & sourced from ${HOUSTON_DOTENV} in the container
 # GITLAB_REMOTE_LOGIN_PAT

--- a/deploy/codex/README.md
+++ b/deploy/codex/README.md
@@ -17,17 +17,53 @@ For development purposes, this setup exposes each of the services as follows:
 - pgAdmin - http://localhost:8000/
 - CODEX (frontend) - http://localhost:84/
 - CODEX (api docs) - http://localhost:84/api/v1/
+- GitLab - http://localhost:85
 
 ### Usage
 
+#### Running the applications
+
 Run the deployment locally with docker-compose:
+
     docker-compose up -d && sleep 5 && docker-compose ps
 
+Note, the composition can take several minutes to successfully come up.
+There are a number of operations setting up the services and automating the connections between them.
+All re-ups should be relatively fast.
+
+#### Cleaning up
+
 Cleanup volumes:
+
     docker volume rm $(docker volume ls -q | grep codex_)
 
 Big red button:
+
     docker-compose down && docker volume rm $(docker volume ls -q | grep codex_)
 
-Precision nuke:
-    SRVC=houston docker-compose stop ${SRVC} && docker-compose rm -f houston && docker volume rm codex_${SRVC}-var
+Precision nuke example:
+
+    docker-compose stop houston && docker-compose rm -f houston && docker volume rm codex_houston-var
+
+#### Running the tests
+
+Place yourself in a shell within the houston container:
+
+    docker-compose exec db psql -U postgres -d houston -c "drop schema public cascade; create schema public;"
+    docker-compose exec houston /bin/bash -c "invoke app.db.upgrade --no-backup; invoke app.db.init-development-data --no-upgrade-db; invoke app.initialize.initialize-gitlab-submissions --email test@localhost"
+    docker-compose exec db psql -U postgres -d houston -c "drop schema public cascade; create schema public;"
+
+This round about way of initializing the required gitlab repositories is necessary.
+We'll need TODO something to set these repositories up within the testing framework rather than outside of it.
+
+Start a shell within the houston container:
+
+    docker-compose exec houston /bin/bash
+
+Now within the houston container you can run the tests:
+
+    unset FLASK_CONFIG
+    pytest
+
+Note, `FLASK_CONFIG` is unset here because it conflicts with the tests.
+It's something that will need fixed. This is simply a work around until then.

--- a/deploy/codex/docker-compose.yml
+++ b/deploy/codex/docker-compose.yml
@@ -112,8 +112,18 @@ services:
       EDM_AUTHENTICATIONS_USERNAME__DEFAULT: "${EDM_AUTHENTICATIONS_USERNAME__DEFAULT}"
       EDM_AUTHENTICATIONS_PASSWORD__DEFAULT: "${EDM_AUTHENTICATIONS_PASSWORD__DEFAULT}"
       REDIS_HOST: redis
+      GITLAB_PROTO: "${GITLAB_PROTO}"
+      GITLAB_HOST: "${GITLAB_HOST}"
+      GITLAB_PORT: "${GITLAB_PORT}"
+      GITLAB_ADMIN_PASSWORD: "${GITLAB_ADMIN_PASSWORD}"
+      GITLAB_REMOTE_URI: "${GITLAB_REMOTE_URI}"
+      GITLAB_PUBLIC_NAME: "${GITLAB_PUBLIC_NAME}"
+      GITLAB_EMAIL: "${GITLAB_EMAIL}"
+      GITLAB_NAMESPACE: "${GITLAB_NAMESPACE}"
     volumes:
       - houston-var:/data
+      - ./houston/docker-entrypoint-init.d:/docker-entrypoint-init.d
+      - ./houston/docker-entrypoint-always-init.d:/docker-entrypoint-always-init.d
       # FIXME: pull in development code while working on bringing up the container
       - ../../:/code
       # FIXME: Can we define a better mountpoint for this file? Maybe /config.py?

--- a/deploy/codex/docker-compose.yml
+++ b/deploy/codex/docker-compose.yml
@@ -40,6 +40,21 @@ services:
       - intranet
       - frontend
 
+  gitlab:
+    image: gitlab/gitlab-ce:13.9.3-ce.0
+    volumes:
+      - gitlab-var-config:/etc/gitlab
+      - gitlab-var-logs:/var/log/gitlab
+      - gitlab-var-data:/var/opt/gitlab
+    networks:
+      - intranet
+    ports:
+      # - "22:22"
+      # - "80:80"
+      # - "443:443"
+      # FIXME: exposed for developers
+      - "85:80"
+
   wbia:
     # https://github.com/WildMeOrg/wildbook-ia
     image: wildme/wildbook-ia:nightly
@@ -139,3 +154,6 @@ volumes:
   pgdata-var:
   wbia-var:
   houston-var:
+  gitlab-var-config:
+  gitlab-var-logs:
+  gitlab-var-data:

--- a/deploy/codex/houston/docker-entrypoint-always-init.d/.gitkeep
+++ b/deploy/codex/houston/docker-entrypoint-always-init.d/.gitkeep
@@ -1,0 +1,1 @@
+directory placeholder

--- a/deploy/codex/houston/docker-entrypoint-always-init.d/dot-env.source-sh
+++ b/deploy/codex/houston/docker-entrypoint-always-init.d/dot-env.source-sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Note, this file purposely does not have execution permission.
-# This is done so that the calling script knows to source this file rather than execute it.
-
-export $(cat ${DATA_ROOT}/.env | xargs)

--- a/deploy/codex/houston/docker-entrypoint-always-init.d/dot-env.source-sh
+++ b/deploy/codex/houston/docker-entrypoint-always-init.d/dot-env.source-sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Note, this file purposely does not have execution permission.
+# This is done so that the calling script knows to source this file rather than execute it.
+
+export $(cat ${DATA_ROOT}/.env | xargs)

--- a/deploy/codex/houston/docker-entrypoint-init.d/_set_up_gitlab.py
+++ b/deploy/codex/houston/docker-entrypoint-init.d/_set_up_gitlab.py
@@ -1,0 +1,89 @@
+import argparse
+import time
+
+import lxml.html
+import requests
+
+
+def parser(argv):
+    p = argparse.ArgumentParser()
+    p.add_argument('gitlab_url', help='url to the gitlab instance (e.g. http://gitlab:80)')
+    p.add_argument('--admin-password', help='password to assign or use for the admin user')
+    return p.parse_args(argv)
+
+
+def parse_form(session, url, form_id):
+    """Returns the form fields and action
+
+    We get the form fields because there are server generated values
+    that need to be carried across to the form post
+
+    """
+    resp = session.get(url)
+    html = lxml.html.document_fromstring(resp.content)
+    try:
+        form = html.get_element_by_id(form_id)
+    except KeyError:  # NoneType
+        raise RuntimeError(f'form not found in {resp} for {url}')
+    return dict(form.fields), form.action
+
+
+def main(argv=None):
+    args = parser(argv)
+    gitlab_url = args.gitlab_url
+    admin_password = args.admin_password
+
+    sign_in_url = f'{gitlab_url}/users/sign_in'
+
+    session = requests.Session()
+
+    # Go directly to the sign in...
+    # On installation this will redirect the user to a form to assign the 'root'/admin user password.
+    # If the installation is already complete we'll land on the signin form.
+    retry_count = 0
+    while True:
+        resp = session.get(sign_in_url, allow_redirects=False)
+        try:
+            assert resp.status_code < 500, resp
+        except AssertionError:
+            # the gitlab service isn't up quite yet
+            if retry_count >= 4:
+                print("Something unexpected happen during the setup of GitLab")
+                raise
+            retry_count += 1
+            time.sleep(30)
+        else:
+            break
+
+    if resp.status_code == 302:  # assume new installation; assign password
+        form_data, action = parse_form(session, sign_in_url, 'new_user')
+        url = f'{gitlab_url}{action}'
+        form_data['user[password]'] = admin_password
+        form_data['user[password_comfirmation]'] = admin_password
+        resp = session.post(url, data=form_data)
+        assert resp.status_code == 200, resp
+
+    # Sign In
+    form_data, action = parse_form(session, sign_in_url, 'new_user')
+    url = f'{gitlab_url}{action}'
+    form_data['user[login]'] = 'root'
+    form_data['user[password]'] = admin_password
+    resp = session.post(url, data=form_data)
+    assert resp.status_code == 200, resp
+
+    # Create a Personal Access Token
+    url = f'{gitlab_url}/-/profile/personal_access_tokens'
+    form_data, action = parse_form(session, url, 'new_personal_access_token')
+    url = f'{gitlab_url}{action}'
+    form_data['personal_access_token[name]'] = 'gitlab cli'
+    form_data['personal_access_token[scopes][]'] = 'api'
+    resp = session.post(url, data=form_data)
+    assert resp.status_code == 200, resp
+    # Pull the PAT out of the page
+    html = lxml.html.document_fromstring(resp.content)
+    personal_access_token = html.get_element_by_id('created-personal-access-token').value
+    print(personal_access_token)
+
+
+if __name__ == '__main__':
+    main()

--- a/deploy/codex/houston/docker-entrypoint-init.d/set_up_gitlab.sh
+++ b/deploy/codex/houston/docker-entrypoint-init.d/set_up_gitlab.sh
@@ -53,10 +53,8 @@ EOF
     echo "Create the 'test' group"
     group_resp_json=$(gitlab -g local-user group create --name TEST --path test)
 
-    echo "Write 'houston' PAT to environment variable sourcing location"
-    echo "GITLAB_REMOTE_LOGIN_PAT=${houston_pat}" >> ${DATA_ROOT}/.env
-    chown root:root ${DATA_ROOT}/.env
-    chmod 600 ${DATA_ROOT}/.env
+    echo "Write 'houston' PAT to ${HOUSTON_DOTENV}"
+    dotenv -f ${HOUSTON_DOTENV} set GITLAB_REMOTE_LOGIN_PAT "${houston_pat}"
 
     echo "GitLab setup complete"
 }

--- a/deploy/codex/houston/docker-entrypoint-init.d/set_up_gitlab.sh
+++ b/deploy/codex/houston/docker-entrypoint-init.d/set_up_gitlab.sh
@@ -2,7 +2,7 @@
 set -Eueo pipefail
 
 HERE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-PYTHON_GITLAB_CFG="/root/.python-gitlab.cfg"
+PYTHON_GITLAB_CFG="${DATA_ROOT}/.python-gitlab.cfg"
 GITLAB_REMOTE_URI="${GITLAB_REMOTE_URI:-${GITLAB_PROTO:-https}://${GITLAB_HOST}:${GITLAB_PORT}}"
 
 write_initial_config() {

--- a/deploy/codex/houston/docker-entrypoint-init.d/set_up_gitlab.sh
+++ b/deploy/codex/houston/docker-entrypoint-init.d/set_up_gitlab.sh
@@ -56,6 +56,9 @@ EOF
     echo "Write 'houston' PAT to ${HOUSTON_DOTENV}"
     dotenv -f ${HOUSTON_DOTENV} set GITLAB_REMOTE_LOGIN_PAT "${houston_pat}"
 
+    # Fix permissions on files
+    chmod 644 ${HOUSTON_DOTENV} ${PYTHON_GITLAB_CFG}
+
     echo "GitLab setup complete"
 }
 

--- a/deploy/codex/houston/docker-entrypoint-init.d/set_up_gitlab.sh
+++ b/deploy/codex/houston/docker-entrypoint-init.d/set_up_gitlab.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -Eueo pipefail
+
+HERE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PYTHON_GITLAB_CFG="/root/.python-gitlab.cfg"
+GITLAB_REMOTE_URI="${GITLAB_REMOTE_URI:-${GITLAB_PROTO:-https}://${GITLAB_HOST}:${GITLAB_PORT}}"
+
+write_initial_config() {
+    cat <<EOF > $PYTHON_GITLAB_CFG
+[global]
+default = local-admin
+
+[local-admin]
+url = ${GITLAB_REMOTE_URI}
+private_token = $1
+ssl_verify = false
+
+EOF
+}
+
+gitlab() {
+    exec gitlab -o json -c $PYTHON_GITLAB_CFG "$@"
+}
+
+_main() {
+    # Wait for gitlab to come online... this takes awhile, so we give feedback
+    while ! $(wait-for -t 10 "${GITLAB_HOST}:${GITLAB_PORT}"); do
+        echo "Waiting for the GitLab instance to come online"
+    done
+
+    echo "Complete the wizard setup for gitlab & create a admin personal access token (PAT)"
+    admin_pat="$(python3 ${HERE_DIR}/_set_up_gitlab.py "${GITLAB_REMOTE_URI}" --admin-password "${GITLAB_ADMIN_PASSWORD}")"
+
+    echo "Write the python-gitlab configuration file to: ${PYTHON_GITLAB_CFG}"
+    write_initial_config $admin_pat
+
+    echo "Create the 'houston' user"
+    user_resp_json=$(gitlab user create --username houston --name Houston --email dev@wildme.org --password 'development' --can-create-group true --skip-confirmation true)
+    user_id=$(echo "$user_resp_json" | python -c 'import json, sys; d = json.load(sys.stdin); print(d["id"])')
+
+    echo "Create a PAT for the 'houston' user"
+    pat_resp_json=$(curl --silent --request POST --header "PRIVATE-TOKEN: ${admin_pat}" --data "name=houston-integration" --data "scopes[]=api" "${GITLAB_REMOTE_URI}/api/v4/users/${user_id}/personal_access_tokens")
+    houston_pat=$(echo "$pat_resp_json" | python -c 'import json, sys; d = json.load(sys.stdin); print(d["token"])')
+
+    echo "Append 'houston' user PAT info to the python-gitlab configuration file"
+    cat <<EOF >> $PYTHON_GITLAB_CFG
+[local-user]
+url = ${GITLAB_REMOTE_URI}
+private_token = $houston_pat
+ssl_verify = false
+EOF
+
+    echo "Create the 'test' group"
+    group_resp_json=$(gitlab -g local-user group create --name TEST --path test)
+
+    echo "Write 'houston' PAT to environment variable sourcing location"
+    echo "GITLAB_REMOTE_LOGIN_PAT=${houston_pat}" >> ${DATA_ROOT}/.env
+    chown root:root ${DATA_ROOT}/.env
+    chmod 600 ${DATA_ROOT}/.env
+
+    echo "GitLab setup complete"
+}
+
+_main

--- a/deploy/codex/houston/local_config.py
+++ b/deploy/codex/houston/local_config.py
@@ -25,3 +25,9 @@ class LocalConfig(BaseConfig):
     #        File "/code/tasks/app/db.py", in upgrade: `if os.path.exists(_db_filepath):`
     # SQLALCHEMY_DATABASE_PATH = None
     SQLALCHEMY_DATABASE_URI = os.getenv('SQLALCHEMY_DATABASE_URI')
+
+    GITLAB_REMOTE_URI = os.getenv('GITLAB_REMOTE_URI')
+    GITLAB_PUBLIC_NAME = os.getenv('GITLAB_PUBLIC_NAME')
+    GITLAB_EMAIL = os.getenv('GITLAB_EMAIL')
+    GITLAB_NAMESPACE = os.getenv('GITLAB_NAMESPACE')
+    GITLAB_REMOTE_LOGIN_PAT = os.getenv('GITLAB_REMOTE_LOGIN_PAT')

--- a/tasks/app/initialize.py
+++ b/tasks/app/initialize.py
@@ -62,6 +62,9 @@ def initialize_gitlab_submissions(context, email, dryrun=False):
     import uuid
     import os
 
+    # This is a tag applied to the repository within GitLab. Whitelisted
+    # repositories are excluded from the externally automated
+    # cleanup procedure.
     WHITELIST_TAG = 'type:pytest-required'
 
     user = User.find(email=email)

--- a/tests/modules/submissions/resources/utils.py
+++ b/tests/modules/submissions/resources/utils.py
@@ -99,7 +99,9 @@ class CloneSubmission(object):
         if self.response.status_code == 200:
             self.submission = Submission.query.get(self.response.json['guid'])
 
-        elif self.response.status_code == 428:
+        elif self.response.status_code in (428, 403):
+            # 428 Precondition Required
+            # 403 Forbidden
             with client.login(admin_user, auth_scopes=('submissions:write',)):
                 self.response = client.post('%s%s' % (PATH, guid))
 


### PR DESCRIPTION
## Pull Request Overview

- Adds a concept of init scripts to the docker image to support customizing initialization (per deploy & at runtime) 
- Adds the GitLab service to the composition
- Automates the setup of GitLab and our Houston user within it
- Fixes the repository PAT assignment procedure to enable using `http`
- Makes the `.env` location customizable via `HOUSTON_DOTENV` environment variable
- Includes the `deploy` directory in pre-commit
- Documents how to run the tests within the container (see note about this below)

Addresses https://wildme.atlassian.net/browse/DEX-209

---

Start with a completely clean composition environment: `docker-compose down && docker volume rm $(docker volume ls -q | grep codex_)`

Note, none of this will work correctly if you don't clean your environment prior to running the rest of this. So don't skip this step. 😺 

I suggest you run these changes using the following to see the details associated with what's happening.

`docker-compose build && docker-compose up -d && docker-compose logs -f houston gitlab`.

You should see houston output that looks like:
```
houston_1       | /docker-entrypoint.sh: ignoring /docker-entrypoint-init.d/_set_up_gitlab.py
houston_1       | 
houston_1       | /docker-entrypoint.sh: running /docker-entrypoint-init.d/set_up_gitlab.sh
houston_1       | Operation timed out
houston_1       | Waiting for the GitLab instance to come online
houston_1       | Operation timed out
houston_1       | Waiting for the GitLab instance to come online
houston_1       | Operation timed out
houston_1       | Waiting for the GitLab instance to come online
houston_1       | Operation timed out
houston_1       | Waiting for the GitLab instance to come online
houston_1       | Operation timed out
houston_1       | Waiting for the GitLab instance to come online
houston_1       | Operation timed out
houston_1       | Waiting for the GitLab instance to come online
houston_1       | Operation timed out
houston_1       | Waiting for the GitLab instance to come online
houston_1       | Complete the wizard setup for gitlab & create a admin personal access token (PAT)
houston_1       | Write the python-gitlab configuration file to: /data/var/.python-gitlab.cfg
houston_1       | Create the 'houston' user
houston_1       | Create a PAT for the 'houston' user
houston_1       | Append 'houston' user PAT info to the python-gitlab configuration file
houston_1       | Create the 'test' group
houston_1       | Write 'houston' PAT to /data/var/.env
houston_1       | GITLAB_REMOTE_LOGIN_PAT=...
houston_1       | GitLab setup complete
```

This output shows that the houston container waits for GitLab to setup and come online before contacting it and working through setting it up for use by Houston.

The application is ready when you see `Running on http://0.0.0.0:5000/` in the houston logs.
At this point you can contact the frontend at http://localhost:84, where you'll see the site

---

Running tests within the container is another story...
Have a look at the [rendered README](https://github.com/WildMeOrg/houston/tree/dex-209/deploy/codex). I'm not happy about the testing story ATM, but I don't want this PR to live forever. So the long-winded, non-intuitive and cryptic instructions for running the tests _work_, but are less than ideal. We'll fix that in a later changeset.

---

**Review Notes**

The goal with this work is to add GitLab but still maintain only one instruction: `docker-compose up`, as documented. So there is a lot added, but the documentation around the usage of the composition hasn't changed.

It's probably best to look at each commit individually since there is a good bit of stuff going on here.

**Pull Request Checklist**
- [X] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [X] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [X] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [X] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [X] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [x] Ensure that the PR is properly reviewed
