### PR TITLE
Fix SQLAlchemy version pinning to <1.4.0

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -52,7 +52,7 @@ setuptools_scm[toml]>=3.4
 
 six
 
-SQLAlchemy>=1.3.0,<2
+SQLAlchemy>=1.3.0,<1.4.0
 SQLAlchemy-Utils>=0.34,<0.35
 
 stripe


### PR DESCRIPTION
## Pull Request Overview

SQLAlchemy 1.4.0 was just released and breaks some imports. This is a
stopgap measure to fix the issue before looking into the upgrade.

---

**Pull Request Checklist**
- [X] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [X] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [X] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [X] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [X] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
