### PR TITLE
Fix wbia not coming up in docker-compose

### DIFF
--- a/deploy/codex/docker-compose.yml
+++ b/deploy/codex/docker-compose.yml
@@ -51,6 +51,9 @@ services:
       - wbia-var:/data/db
     networks:
       - intranet
+    environment:
+      # FIXME: Run as root to fix the PermissionError in volumes
+      EXEC_PRIVILEGED: 1
     ports:
       # FIXME: exposed for developer verification
       - "82:5000"

--- a/deploy/codex/docker-compose.yml
+++ b/deploy/codex/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     # https://github.com/WildMeOrg/wildbook-ia
     image: wildme/wildbook-ia:latest
     # FIXME: Adjust entrypoint to allow for additive command arguments
-    command: [ "wait-for", "db:5432", "--", "python3", "-m", "wbia.dev", "--dbdir", "${WBIA_DB_DIR}", "--logdir", "/data/logs/", "--web", "--port", "5000", "--web-deterministic-ports", "--containerized", "--cpudark", "--production", "--db-uri", "${WBIA_DB_URI}" ]
+    command: [ "wait-for", "db:5432", "--", "python3.7", "-m", "wbia.dev", "--dbdir", "${WBIA_DB_DIR}", "--logdir", "/data/logs/", "--web", "--port", "5000", "--web-deterministic-ports", "--containerized", "--cpudark", "--production", "--db-uri", "${WBIA_DB_URI}" ]
     volumes:
       # FIXME: `PermissionError: [Errno 13] Permission denied: '/data/db/_ibsdb'`
       #        https://github.com/WildMeOrg/wildbook-ia/pull/184

--- a/deploy/codex/docker-compose.yml
+++ b/deploy/codex/docker-compose.yml
@@ -42,7 +42,7 @@ services:
 
   wbia:
     # https://github.com/WildMeOrg/wildbook-ia
-    image: wildme/wildbook-ia:latest
+    image: wildme/wildbook-ia:nightly
     # FIXME: Adjust entrypoint to allow for additive command arguments
     command: [ "wait-for", "db:5432", "--", "python3.7", "-m", "wbia.dev", "--dbdir", "${WBIA_DB_DIR}", "--logdir", "/data/logs/", "--web", "--port", "5000", "--web-deterministic-ports", "--containerized", "--cpudark", "--production", "--db-uri", "${WBIA_DB_URI}" ]
     volumes:


### PR DESCRIPTION
## Pull Request Overview

- Change python3 to python3.7 in docker-compose wbia command line
- Run docker-compose wbia as root, fix for permission error
- Use wildme/wildbook-ia:nightly in docker-compose file

---

**Review Notes**
- We can tag `wildme/wildbook-ia` now instead of using the nightly one :shrug:

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
