### PR TITLE
allow public access to GET /api/v1/users/GUID; and include nested FileUpload data

### DIFF
--- a/app/modules/users/schemas.py
+++ b/app/modules/users/schemas.py
@@ -5,8 +5,9 @@ User schemas
 ------------
 """
 
-# from flask_marshmallow import base_fields
+from flask_marshmallow import base_fields
 from flask_restx_patched import ModelSchema
+from app.modules.fileuploads.schemas import DetailedFileUploadSchema  # noqa
 
 from .models import User
 
@@ -27,6 +28,21 @@ class BaseUserSchema(ModelSchema):
         dump_only = (User.guid.key,)
 
 
+class PublicUserSchema(ModelSchema):
+    """ Only fields which are safe for public display (very minimal). """
+
+    profile_fileupload = base_fields.Nested('DetailedFileUploadSchema')
+
+    class Meta:
+        # pylint: disable=missing-docstring
+        model = User
+        fields = (
+            User.guid.key,
+            User.full_name.key,
+            User.profile_fileupload.key,
+        )
+
+
 class DetailedUserPermissionsSchema(ModelSchema):
     class Meta:
         # pylint: disable=missing-docstring
@@ -38,6 +54,8 @@ class DetailedUserPermissionsSchema(ModelSchema):
 class DetailedUserSchema(BaseUserSchema):
     """ Detailed user schema exposes all fields used to render a normal user profile. """
 
+    profile_fileupload = base_fields.Nested('DetailedFileUploadSchema')
+
     class Meta(BaseUserSchema.Meta):
         fields = BaseUserSchema.Meta.fields + (
             User.created.key,
@@ -46,11 +64,11 @@ class DetailedUserSchema(BaseUserSchema):
             User.is_active.fget.__name__,
             User.is_staff.fget.__name__,
             User.is_admin.fget.__name__,
-            User.profile_fileupload_guid.key,
             User.affiliation.key,
             User.location.key,
             User.forum_id.key,
             User.website.key,
+            User.profile_fileupload.key,
         )
 
 

--- a/tests/modules/users/resources/test_general_access.py
+++ b/tests/modules/users/resources/test_general_access.py
@@ -4,14 +4,14 @@ import pytest
 
 
 @pytest.mark.parametrize(
-    'http_method,http_path',
+    'http_method,http_path,expected_code',
     (
-        ('GET', '/api/v1/users/'),
-        ('GET', '/api/v1/users/11111111-1111-1111-1111-111111111111'),
-        ('PATCH', '/api/v1/users/11111111-1111-1111-1111-111111111111'),
-        ('GET', '/api/v1/users/me'),
+        ('GET', '/api/v1/users/', 401),
+        ('GET', '/api/v1/users/11111111-1111-1111-1111-111111111111', 404),
+        ('PATCH', '/api/v1/users/11111111-1111-1111-1111-111111111111', 404),
+        ('GET', '/api/v1/users/me', 401),
     ),
 )
-def test_unauthorized_access(http_method, http_path, flask_app_client):
+def test_unauthorized_access(http_method, http_path, expected_code, flask_app_client):
     response = flask_app_client.open(method=http_method, path=http_path)
-    assert response.status_code == 401
+    assert response.status_code == expected_code

--- a/tests/modules/users/resources/test_getting_users_info.py
+++ b/tests/modules/users/resources/test_getting_users_info.py
@@ -59,10 +59,10 @@ def test_getting_user_info_by_unauthorized_user(
     with flask_app_client.login(regular_user, auth_scopes=('users:read',)):
         response = flask_app_client.get('/api/v1/users/%s' % admin_user.guid)
 
-    assert response.status_code == 403
+    assert response.status_code == 200
     assert response.content_type == 'application/json'
     assert isinstance(response.json, dict)
-    assert set(response.json.keys()) >= {'status', 'message'}
+    assert set(response.json.keys()) == {'full_name', 'guid', 'profile_fileupload'}
 
 
 def test_getting_user_info_by_authorized_user(flask_app_client, regular_user, admin_user):

--- a/tests/modules/users/resources/test_modifying_users_info.py
+++ b/tests/modules/users/resources/test_modifying_users_info.py
@@ -394,7 +394,10 @@ def test_user_profile_fileupload(db, flask_app, flask_app_client, regular_user, 
         response = flask_app_client.patch(*args, **kwargs)
         assert response.status_code == 200, response.data
         fup = FileUpload.query.get(response.json['profile_fileupload']['guid'])
-        assert flask_app_client.get(fup.src).data == b'1234'
+        src_response = flask_app_client.get(fup.src)
+        src_data = src_response.data
+        src_response.close()  # h/t https://github.com/pallets/flask/issues/2468#issuecomment-517797518
+        assert src_data == b'1234'
         clean_up_objects.append(fup)
         clean_up_paths.append(td)
 

--- a/tests/modules/users/resources/test_modifying_users_info.py
+++ b/tests/modules/users/resources/test_modifying_users_info.py
@@ -301,7 +301,7 @@ def test_user_profile_fileupload(db, flask_app, flask_app_client, regular_user, 
         }
         response = flask_app_client.patch(*args, **kwargs)
         assert response.status_code == 200, response.data
-        assert response.json['profile_fileupload_guid'] == str(fup.guid)
+        assert response.json['profile_fileupload']['guid'] == str(fup.guid)
         updated_user = User.query.get(regular_user.guid)
         assert updated_user.profile_fileupload_guid == fup.guid
 
@@ -393,7 +393,7 @@ def test_user_profile_fileupload(db, flask_app, flask_app_client, regular_user, 
         }
         response = flask_app_client.patch(*args, **kwargs)
         assert response.status_code == 200, response.data
-        fup = FileUpload.query.get(response.json['profile_fileupload_guid'])
+        fup = FileUpload.query.get(response.json['profile_fileupload']['guid'])
         assert flask_app_client.get(fup.src).data == b'1234'
         clean_up_objects.append(fup)
         clean_up_paths.append(td)
@@ -417,7 +417,7 @@ def test_user_profile_fileupload(db, flask_app, flask_app_client, regular_user, 
         }
         response = flask_app_client.patch(*args, **kwargs)
         assert response.status_code == 200, response.data
-        response_asset_guid = response.json['profile_fileupload_guid']
+        response_asset_guid = response.json['profile_fileupload']['guid']
         updated_user = User.query.get(regular_user.guid)
         assert str(updated_user.profile_fileupload_guid) == response_asset_guid
         fileupload = FileUpload.query.get(response_asset_guid)

--- a/tests/modules/users/resources/test_options.py
+++ b/tests/modules/users/resources/test_options.py
@@ -10,7 +10,7 @@ REPLACE_KEY = '<REPLACE_UUID>'
     'path,status_code,expected_allowed_methods',
     (
         ('/api/v1/users/', 204, {'POST', 'OPTIONS'}),
-        ('/api/v1/users/11111111-1111-1111-1111-111111111111', 401, None),
+        ('/api/v1/users/11111111-1111-1111-1111-111111111111', 404, None),
     ),
 )
 def test_users_options_unauthorized(

--- a/tests/modules/users/test_schemas.py
+++ b/tests/modules/users/test_schemas.py
@@ -41,7 +41,7 @@ def test_DetailedUserSchema_dump_user_instance(user_instance):
         'is_active',
         'is_staff',
         'is_admin',
-        'profile_fileupload_guid',
+        'profile_fileupload',
         'affiliation',
         'location',
         'forum_id',


### PR DESCRIPTION
## Pull Request Overview

- Modifies behavior of `GET /api/v1/users/GUID` to allow public access, but based returned content on different Schema depending on privileges
- Provides a **profile_fileupload** value which includes a _nested_ FileUpload schema

### Changes in tests
- Though minimal change in code to provide different output for this GET api endpoint, it affected quite a few tests.  Thus, most changes were made there.

---

**Pull Request Checklist**
- [ ] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [ ] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [ ] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [ ] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [ ] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [ ] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
