### PR TITLE
implementation of ACM Manager and EDM Manager as derived classes of c…

### DIFF
--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -57,6 +57,8 @@ from .email import mail  # NOQA
 
 from . import edm  # NOQA
 
+from . import acm  # NOQA
+
 from . import submission  # NOQA
 
 from . import tus  # NOQA
@@ -267,6 +269,7 @@ def init_app(app):
         cross_origin_resource_sharing,
         marshmallow,
         edm,
+        acm,
         submission,
         tus,
         mail,

--- a/app/extensions/acm/__init__.py
+++ b/app/extensions/acm/__init__.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=no-self-use
+"""
+Asset Curation Model (ACM) manager.
+
+"""
+import logging
+
+from flask import current_app, request, session, render_template  # NOQA
+from flask_login import current_user  # NOQA
+from app.extensions.restManager.RestManager import RestManager
+
+import keyword
+
+KEYWORD_SET = set(keyword.kwlist)
+
+log = logging.getLogger(__name__)
+
+
+class ACMManager(RestManager):
+    # pylint: disable=abstract-method
+    """"""
+    NAME = 'ACM'
+    ENDPOINT_PREFIX = 'api'
+
+    # We use // as a shorthand for prefix
+    # fmt: off
+    ENDPOINTS = {
+        'session': {
+            'login': '//v0/login?content={"login":"%s","password":"%s"}',
+        },
+    }
+    # fmt: on
+
+    def __init__(self, app, pre_initialize=False, *args, **kwargs):
+        super(ACMManager, self).__init__(app, pre_initialize, *args, **kwargs)
+
+
+def init_app(app, **kwargs):
+    # pylint: disable=unused-argument
+    """
+    API extension initialization point.
+    """
+    ACMManager(app)

--- a/app/extensions/acm/__init__.py
+++ b/app/extensions/acm/__init__.py
@@ -22,18 +22,19 @@ class ACMManager(RestManager):
     """"""
     NAME = 'ACM'
     ENDPOINT_PREFIX = 'api'
-
     # We use // as a shorthand for prefix
     # fmt: off
     ENDPOINTS = {
-        'session': {
-            'login': '//v0/login?content={"login":"%s","password":"%s"}',
+        # No user.session, wbia doesn't support logins
+        'annotations': {
+            'list': '//annot/json/',
+            'data': '//annot/name/uuid/json/?annot_uuid_list=[{"__UUID__": "%s"}]',
         },
     }
     # fmt: on
 
-    def __init__(self, app, pre_initialize=False, *args, **kwargs):
-        super(ACMManager, self).__init__(app, pre_initialize, *args, **kwargs)
+    def __init__(self, pre_initialize=False, *args, **kwargs):
+        super(ACMManager, self).__init__(False, pre_initialize, *args, **kwargs)
 
 
 def init_app(app, **kwargs):
@@ -41,4 +42,4 @@ def init_app(app, **kwargs):
     """
     API extension initialization point.
     """
-    ACMManager(app)
+    app.acm = ACMManager()

--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -75,11 +75,8 @@ class EDMManager(RestManager):
     }
     # fmt: on
 
-    def __init__(self, app, pre_initialize=False, *args, **kwargs):
-        super(EDMManager, self).__init__(app, pre_initialize, *args, **kwargs)
-
-    # Implemented in derived class as it has dependencies upon "EDM_URIS' 'EDM_AUTHENTICATIONS' and
-    # 'default'. Once ACMManager is finalised, see if this can move into the base class
+    def __init__(self, pre_initialize=False, *args, **kwargs):
+        super(EDMManager, self).__init__(True, pre_initialize, *args, **kwargs)
 
 
 class EDMObjectMixin(object):
@@ -230,4 +227,4 @@ def init_app(app, **kwargs):
     """
     API extension initialization point.
     """
-    EDMManager(app)
+    app.edm = EDMManager()

--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -5,15 +5,12 @@ Ecological Data Management (EDM) manager.
 
 """
 import logging
-from werkzeug.exceptions import BadRequest
 from flask import current_app, request, session, render_template  # NOQA
 from flask_login import current_user  # NOQA
 from app.extensions import db
-import requests
-from collections import namedtuple
-import utool as ut
+from app.extensions.restManager.RestManager import RestManager
+
 import types
-import json
 import tqdm
 import keyword
 import uuid
@@ -24,24 +21,16 @@ KEYWORD_SET = set(keyword.kwlist)
 log = logging.getLogger(__name__)
 
 
-def _json_object_hook(data):
-    keys = list(data.keys())
-    keys_set = set(keys)
-    keys_ = []
-    for key in keys:
-        if key in KEYWORD_SET:
-            key_ = '%s_' % (key,)
-            assert key_ not in keys_set
-        else:
-            key_ = key
-        keys_.append(key_)
-    values = data.values()
-    data_ = namedtuple('obj', keys_)(*values)
-    return data_
+class EDMManager(RestManager):
+    """
+        note the content of User in the 2nd item has stuff you can ignore. it also has the id as "uuid" (which is what it is internally, sigh).  also note it references Organizations !  we didnt touch on this on the call, but i think this should (must?) live with Users.  what we have in java is very lightweight anyway, so no loss to go away.   as you can see, user.organizations is an array of orgs, and (since it is many-to-many) you will see org.members is a list of Users.  easy peasy.  btw, by the time we got to Organizations, we did call the primary key id and make it a uuid.  "live and learn".  :confused:
+    also!  the user.profileAsset is fabricated!  ben wanted something so i literally hardcoded a random choice (including empty) from a list of like 4 user faces. haha.  so you arent going crazy if you see this change per user.  and obviously in the future the contents of this will be more whatever we land on for final asset format.
 
+        btw, as a bonus.  here is what an Organization is on wildbook[edm] ... they are hierarchical -- which i would argue we drop!!  it was fun for playing with, but i do not want to have to support that when security starts using these!!!  (no real world orgs use this currently anyway, not in any important way.)   other than that (and killing it off!) there are .members and .logoAsset.  boringly simple.
+    https://nextgen.dev-wildbook.org/api/org.ecocean.Organization?id==%273b868b21-729f-46ca-933f-c4ecdf02e97d%27
+    """
 
-class EDMManagerEndpointMixin(object):
-
+    NAME = 'EDM'
     ENDPOINT_PREFIX = 'api'
 
     # We use // as a shorthand for prefix
@@ -86,343 +75,11 @@ class EDMManagerEndpointMixin(object):
     }
     # fmt: on
 
-    def _endpoint_fmtstr(self, tag, target='default'):
-        endpoint_tag_fmtstr = self._endpoint_tag_fmtstr(tag)
-        assert endpoint_tag_fmtstr is not None, 'The endpoint tag was not recognized'
-
-        if endpoint_tag_fmtstr.startswith('//'):
-            endpoint_tag_fmtstr = endpoint_tag_fmtstr[2:]
-            endpoint_tag_fmtstr = '%s/%s' % (
-                self.ENDPOINT_PREFIX,
-                endpoint_tag_fmtstr,
-            )
-
-        endpoint_url_ = self.get_target_endpoint_url(target)
-        endpoint_fmtstr = '%s/%s' % (
-            endpoint_url_,
-            endpoint_tag_fmtstr,
-        )
-        return endpoint_fmtstr
-
-    def _endpoint_tag_fmtstr(self, tag):
-        endpoint = self.ENDPOINTS
-
-        component_list = tag.split('.')
-        for component in component_list:
-            try:
-                endpoint_ = endpoint.get(component, None)
-            except Exception:
-                endpoint_ = None
-
-            if endpoint_ is None:
-                break
-
-            endpoint = endpoint_
-
-        return endpoint
-
-
-class EDMManagerUserMixin(object):
-    def check_user_login(self, username, password):
-        self._ensure_initialized()
-
-        success = False
-        for target in self.targets:
-            # Create temporary session
-            temporary_session = requests.Session()
-            try:
-                response = self._get(
-                    'session.login',
-                    username,
-                    password,
-                    target=target,
-                    target_session=temporary_session,
-                )
-
-                assert response.ok
-                decoded_response = response.json()
-                assert decoded_response['message']['key'] == 'success'
-
-                log.info('User authenticated via EDM (target = %r)' % (target,))
-                success = True
-                break
-            except Exception:
-                pass
-            finally:
-                # Cleanup temporary session
-                temporary_session.cookies.clear_session_cookies()
-                temporary_session.close()
-
-        return success
-
-
-class EDMManager(EDMManagerEndpointMixin, EDMManagerUserMixin):
-    # pylint: disable=abstract-method
-    """
-        note the content of User in the 2nd item has stuff you can ignore. it also has the id as "uuid" (which is what it is internally, sigh).  also note it references Organizations !  we didnt touch on this on the call, but i think this should (must?) live with Users.  what we have in java is very lightweight anyway, so no loss to go away.   as you can see, user.organizations is an array of orgs, and (since it is many-to-many) you will see org.members is a list of Users.  easy peasy.  btw, by the time we got to Organizations, we did call the primary key id and make it a uuid.  "live and learn".  :confused:
-    also!  the user.profileAsset is fabricated!  ben wanted something so i literally hardcoded a random choice (including empty) from a list of like 4 user faces. haha.  so you arent going crazy if you see this change per user.  and obviously in the future the contents of this will be more whatever we land on for final asset format.
-
-        btw, as a bonus.  here is what an Organization is on wildbook[edm] ... they are hierarchical -- which i would argue we drop!!  it was fun for playing with, but i do not want to have to support that when security starts using these!!!  (no real world orgs use this currently anyway, not in any important way.)   other than that (and killing it off!) there are .members and .logoAsset.  boringly simple.
-    https://nextgen.dev-wildbook.org/api/org.ecocean.Organization?id==%273b868b21-729f-46ca-933f-c4ecdf02e97d%27
-    """
-
     def __init__(self, app, pre_initialize=False, *args, **kwargs):
-        super(EDMManager, self).__init__(*args, **kwargs)
-        self.initialized = False
+        super(EDMManager, self).__init__(app, pre_initialize, *args, **kwargs)
 
-        self.app = app
-        self.targets = set([])
-
-        app.edm = self
-
-        if pre_initialize:
-            self._ensure_initialized()
-
-    def _parse_config_edm_uris(self):
-        """Obtain and verify the required configuration settings and
-        update the list of known EDM targets by URI.
-
-        This procedure is primarily focused on matching a URI to
-        authentication credentials. It ignores matching in the other direction.
-
-        """
-        uris = self.app.config.get('EDM_URIS', {})
-        authns = self.app.config.get('EDM_AUTHENTICATIONS', {})
-
-        # Check for the 'default' EDM
-        assert uris.get('default'), "Missing a 'default' EDM_URI"
-        has_required_default_authn = (
-            isinstance(authns.get('default'), dict)
-            and authns['default'].get('username')
-            and authns['default'].get('password')
-        )
-        assertion_msg = "Missing EDM_AUTHENTICATION credentials for 'default'"
-        assert has_required_default_authn, assertion_msg
-
-        # Check URIs have matching credentials
-        missing_creds = [k for k in uris.keys() if not authns.get(k)]
-        assert (
-            not missing_creds
-        ), f"Missing credentials for named EDM configs: {', '.join(missing_creds)}"
-
-        # Update the list of known named targets
-        self.targets.update(uris.keys())
-
-        # Assign local references to the configuration settings
-        self.uris = uris
-        self.auths = authns
-
-    def _init_sessions(self):
-        self.sessions = {}
-        for target in self.uris:
-            auth = self.auths[target]
-
-            email = auth.get('username', auth.get('email', None))
-            password = auth.get('password', auth.get('pass', None))
-
-            message = 'EDM Authentication for %s unspecified (email)' % (target,)
-            assert email is not None, message
-            message = 'EDM Authentication for %s unspecified (password)' % (target,)
-            assert password is not None, message
-
-            self.sessions[target] = requests.Session()
-            response = self._get(
-                'session.login', email, password, target=target, ensure_initialized=False
-            )
-            assert (
-                not isinstance(response, requests.models.Response) or response.ok
-            ), 'EDM Authentication for %s returned non-OK code: %d' % (
-                target,
-                response.status_code,
-            )
-
-            log.info('Created authenticated session for EDM target %r' % (target,))
-
-    def _ensure_initialized(self):
-        if not self.initialized:
-            log.info('Initializing EDM')
-            self._parse_config_edm_uris()
-            self._init_sessions()
-            log.info('\t%s' % (ut.repr3(self.uris)))
-            log.info('EDM Manager is ready')
-            self.initialized = True
-
-    def get_target_endpoint_url(self, target='default'):
-        endpoint_url = self.uris[target]
-        endpoint_url_ = endpoint_url.strip('/')
-        return endpoint_url_
-
-    def get_target_list(self):
-        self._ensure_initialized()
-        return list(self.targets)
-
-    def _request(
-        self,
-        method,
-        tag,
-        *args,
-        endpoint=None,
-        target='default',
-        target_session=None,
-        _pre_request_func=None,
-        decode_as_object=True,
-        decode_as_dict=False,
-        passthrough_kwargs={},
-        ensure_initialized=True,
-        verbose=True,
-    ):
-        if ensure_initialized:
-            self._ensure_initialized()
-
-        method = method.lower()
-        assert method in ['get', 'post', 'delete', 'put', 'patch']
-
-        if endpoint is None:
-            assert tag is not None
-            endpoint_fmtstr = self._endpoint_fmtstr(tag, target=target)
-            endpoint = endpoint_fmtstr % args
-
-        if tag is None:
-            assert endpoint is not None
-
-        endpoint_encoded = requests.utils.quote(endpoint, safe='/?:=&')
-
-        if verbose:
-            log.info('Sending request to: %r' % (endpoint_encoded,))
-
-        if target_session is None:
-            target_session = self.sessions[target]
-
-        with target_session:
-            if _pre_request_func is not None:
-                target_session = _pre_request_func(target_session)
-
-            request_func = getattr(target_session, method, None)
-            assert request_func is not None
-
-            response = request_func(endpoint_encoded, **passthrough_kwargs)
-
-        if response.ok:
-            if decode_as_object and decode_as_dict:
-                log.warning(
-                    'Both decode_object and decode_dict are True, defaulting to object'
-                )
-                decode_as_dict = False
-
-            if decode_as_object:
-                response = json.loads(response.text, object_hook=_json_object_hook)
-
-            if decode_as_dict:
-                response = response.json()
-        else:
-            log.warning(
-                'Non-OK (%r) response on %r %r: %r'
-                % (
-                    response.status_code,
-                    method,
-                    endpoint,
-                    response.content,
-                )
-            )
-
-        return response
-
-    def _get(self, *args, **kwargs):
-        return self._request('get', *args, **kwargs)
-
-    def _post(self, *args, **kwargs):
-        return self._request('post', *args, **kwargs)
-
-    def _delete(self, *args, **kwargs):
-        return self._request('delete', *args, **kwargs)
-
-    def get_list(self, list_name, target='default'):
-        response = self._get(list_name, target=target)
-
-        items = {}
-        for value in response:
-            try:
-                guid = value.id
-                version = value.version
-            except AttributeError as exception:
-                log.error('Invalid response from EDM [%s]' % (list_name,))
-                raise exception
-
-            guid = uuid.UUID(guid)
-            assert isinstance(version, int)
-
-            items[guid] = {'version': version}
-
-        return items
-
-    def get_dict(self, list_name, guid, target='default'):
-
-        assert isinstance(guid, uuid.UUID)
-        response = self._get(
-            list_name,
-            guid,
-            target=target,
-            decode_as_object=False,
-            decode_as_dict=True,
-        )
-        return response
-
-    def get_data_item(self, guid, item_name, target='default'):
-        assert isinstance(guid, uuid.UUID)
-        response = self._get(item_name, guid, target=target)
-        return response
-
-    def request_passthrough(
-        self, tag, method, passthrough_kwargs, args=None, target='default'
-    ):
-        self._ensure_initialized()
-        try:
-            # Try to convert string integers to integers
-            target = int(target)
-        except ValueError:
-            pass
-
-        # Check target
-        targets = list(self.targets)
-        if target not in targets:
-            raise BadRequest('The specified target %r is invalid.' % (target,))
-
-        headers = passthrough_kwargs.get('headers', {})
-        allowed_header_key_list = [
-            'Accept',
-            'Content-Type',
-            'User-Agent',
-        ]
-        is_json = False
-        for header_key in allowed_header_key_list:
-            header_value = request.headers.get(header_key, None)
-            header_existing = headers.get(header_key, None)
-            if header_value is not None and header_existing is None:
-                headers[header_key] = header_value
-
-            if header_key == 'Content-Type':
-                if header_value is not None:
-                    if header_value.lower().startswith(
-                        'application/javascript'
-                    ) or header_value.lower().startswith('application/json'):
-                        is_json = True
-        passthrough_kwargs['headers'] = headers
-
-        if is_json:
-            data_ = passthrough_kwargs.pop('data', None)
-            if data_ is not None:
-                passthrough_kwargs['json'] = data_
-
-        response = self._request(
-            method,
-            tag,
-            args,
-            target=target,
-            decode_as_object=False,
-            decode_as_dict=False,
-            passthrough_kwargs=passthrough_kwargs,
-        )
-        return response
+    # Implemented in derived class as it has dependencies upon "EDM_URIS' 'EDM_AUTHENTICATIONS' and
+    # 'default'. Once ACMManager is finalised, see if this can move into the base class
 
 
 class EDMObjectMixin(object):
@@ -466,7 +123,7 @@ class EDMObjectMixin(object):
         failed_items = []
         for model_obj, version in tqdm.tqdm(stale_items):
             try:
-                model_obj.sync_edm_item(model_obj.guid, version)
+                model_obj._sync_item(model_obj.guid, version)
                 updated_items.append(model_obj)
             except sqlalchemy.exc.IntegrityError:
                 log.error(
@@ -557,7 +214,7 @@ class EDMObjectMixin(object):
         else:
             log.info('Updating to found version %r' % (found_version,))
 
-    def sync_edm_item(self, guid, version):
+    def _sync_item(self, guid, version):
         response = current_app.edm.get_data_item(guid, '%s.data' % (self.EDM_NAME,))
 
         assert response.success

--- a/app/extensions/restManager/RestManager.py
+++ b/app/extensions/restManager/RestManager.py
@@ -1,0 +1,367 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=no-self-use
+"""
+Rest Manager base class, to be used for any entity (EDM/ACM) where we need to interface with an external
+system using REST API
+
+"""
+import logging
+from werkzeug.exceptions import BadRequest
+from flask import current_app, request, session, render_template  # NOQA
+from flask_login import current_user  # NOQA
+import requests
+from collections import namedtuple
+import utool as ut
+import json
+import keyword
+import uuid
+
+KEYWORD_SET = set(keyword.kwlist)
+
+log = logging.getLogger(__name__)
+
+
+def _json_object_hook(data):
+    keys = list(data.keys())
+    keys_set = set(keys)
+    keys_ = []
+    for key in keys:
+        if key in KEYWORD_SET:
+            key_ = '%s_' % (key,)
+            assert key_ not in keys_set
+        else:
+            key_ = key
+        keys_.append(key_)
+    values = data.values()
+    data_ = namedtuple('obj', keys_)(*values)
+    return data_
+
+
+# Not entirely certain how appropriate this is as a Mixin as it's dependent on a couple of things in
+# the main class
+class RestManagerUserMixin(object):
+    def check_user_login(self, username, password):
+        self._ensure_initialized()
+
+        success = False
+        for target in self.targets:
+            # Create temporary session
+            temporary_session = requests.Session()
+            try:
+                response = self._get(
+                    'session.login',
+                    username,
+                    password,
+                    target=target,
+                    target_session=temporary_session,
+                )
+
+                assert response.ok
+                decoded_response = response.json()
+                assert decoded_response['message']['key'] == 'success'
+
+                log.info(f'User authenticated via {self.NAME} (target = {target})')
+                success = True
+                break
+            except Exception:
+                pass
+            finally:
+                # Cleanup temporary session
+                temporary_session.cookies.clear_session_cookies()
+                temporary_session.close()
+
+        return success
+
+
+class RestManager(RestManagerUserMixin):
+    # pylint: disable=abstract-method
+
+    ENDPOINT_PREFIX = None
+    ENDPOINTS = None
+    NAME = None
+
+    def __init__(self, app, pre_initialize=False, *args, **kwargs):
+        super(RestManager, self).__init__(*args, **kwargs)
+        self.initialized = False
+
+        # Must be overwritten by the derived class
+        assert self.NAME is not None
+        assert self.ENDPOINT_PREFIX is not None
+        assert self.ENDPOINTS is not None
+
+        self.app = app
+        self.targets = set([])
+
+        app.edm = self
+
+        if pre_initialize:
+            self._ensure_initialized()
+
+    def _endpoint_fmtstr(self, tag, target='default'):
+        endpoint_tag_fmtstr = self._endpoint_tag_fmtstr(tag)
+        assert endpoint_tag_fmtstr is not None, 'The endpoint tag was not recognized'
+
+        if endpoint_tag_fmtstr.startswith('//'):
+            endpoint_tag_fmtstr = endpoint_tag_fmtstr[2:]
+            endpoint_tag_fmtstr = f'{self.ENDPOINT_PREFIX}/{endpoint_tag_fmtstr}'
+
+        endpoint_url_ = self.get_target_endpoint_url(target)
+        endpoint_fmtstr = f'{endpoint_url_}/{endpoint_tag_fmtstr}'
+        return endpoint_fmtstr
+
+    def _endpoint_tag_fmtstr(self, tag):
+        endpoint = self.ENDPOINTS
+
+        component_list = tag.split('.')
+        for component in component_list:
+            try:
+                endpoint_ = endpoint.get(component, None)
+            except Exception:
+                endpoint_ = None
+
+            if endpoint_ is None:
+                break
+
+            endpoint = endpoint_
+
+        return endpoint
+
+    def _parse_config_uris(self):
+        """Obtain and verify the required configuration settings and
+        update the list of known EDM targets by URI.
+
+        This procedure is primarily focused on matching a URI to
+        authentication credentials. It ignores matching in the other direction.
+
+        """
+        uris = self.app.config.get(f'{self.NAME}_URIS', {})
+        authns = self.app.config.get(f'{self.NAME}_AUTHENTICATIONS', {})
+
+        # Check for the 'default' EDM
+        assert uris.get('default'), f"Missing a 'default' {self.NAME}_URI"
+        has_required_default_authn = (
+            isinstance(authns.get('default'), dict)
+            and authns['default'].get('username')
+            and authns['default'].get('password')
+        )
+        assertion_msg = f"Missing {self.NAME}_AUTHENTICATION credentials for 'default'"
+        assert has_required_default_authn, assertion_msg
+
+        # Check URIs have matching credentials
+        missing_creds = [k for k in uris.keys() if not authns.get(k)]
+        assert (
+            not missing_creds
+        ), f"Missing credentials for named {self.NAME} configs: {', '.join(missing_creds)}"
+
+        # Update the list of known named targets
+        self.targets.update(uris.keys())
+
+        # Assign local references to the configuration settings
+        self.uris = uris
+        self.auths = authns
+
+    def _init_sessions(self):
+        self.sessions = {}
+        for target in self.uris:
+            auth = self.auths[target]
+
+            email = auth.get('username', auth.get('email', None))
+            password = auth.get('password', auth.get('pass', None))
+
+            message = '%s Authentication for %s unspecified (email)' % (
+                self.NAME,
+                target,
+            )
+            assert email is not None, message
+            message = f'{self.NAME} Authentication for {target} unspecified (password)'
+            assert password is not None, message
+
+            self.sessions[target] = requests.Session()
+            response = self._get(
+                'session.login', email, password, target=target, ensure_initialized=False
+            )
+            assert (
+                not isinstance(response, requests.models.Response) or response.ok
+            ), f'{self.NAME} Authentication for {target} returned non-OK code: {response.status_code}'
+
+            log.info('Created authenticated session for EDM target %r' % (target,))
+
+    def _ensure_initialized(self):
+        if not self.initialized:
+            log.info('Initializing %s' % self.NAME)
+            self._parse_config_uris()
+            self._init_sessions()
+            log.info('\t%s' % (ut.repr3(self.uris)))
+            log.info('%s Manager is ready' % self.NAME)
+            self.initialized = True
+
+    def get_target_endpoint_url(self, target='default'):
+        endpoint_url = self.uris[target]
+        endpoint_url_ = endpoint_url.strip('/')
+        return endpoint_url_
+
+    def get_target_list(self):
+        self._ensure_initialized()
+        return list(self.targets)
+
+    def _request(
+        self,
+        method,
+        tag,
+        *args,
+        endpoint=None,
+        target='default',
+        target_session=None,
+        _pre_request_func=None,
+        decode_as_object=True,
+        decode_as_dict=False,
+        passthrough_kwargs={},
+        ensure_initialized=True,
+        verbose=True,
+    ):
+        if ensure_initialized:
+            self._ensure_initialized()
+
+        method = method.lower()
+        assert method in ['get', 'post', 'delete', 'put', 'patch']
+
+        if endpoint is None:
+            assert tag is not None
+            endpoint_fmtstr = self._endpoint_fmtstr(tag, target=target)
+            endpoint = endpoint_fmtstr % args
+
+        if tag is None:
+            assert endpoint is not None
+
+        endpoint_encoded = requests.utils.quote(endpoint, safe='/?:=&')
+
+        if verbose:
+            log.info('Sending request to: %r' % (endpoint_encoded,))
+
+        if target_session is None:
+            target_session = self.sessions[target]
+
+        with target_session:
+            if _pre_request_func is not None:
+                target_session = _pre_request_func(target_session)
+
+            request_func = getattr(target_session, method, None)
+            assert request_func is not None
+
+            response = request_func(endpoint_encoded, **passthrough_kwargs)
+
+        if response.ok:
+            if decode_as_object and decode_as_dict:
+                log.warning(
+                    'Both decode_object and decode_dict are True, defaulting to object'
+                )
+                decode_as_dict = False
+
+            if decode_as_object:
+                response = json.loads(response.text, object_hook=_json_object_hook)
+
+            if decode_as_dict:
+                response = response.json()
+        else:
+            log.warning(
+                f'Non-OK ({response.status_code}) response on {method} {endpoint}: {response.content}'
+            )
+
+        return response
+
+    def _get(self, *args, **kwargs):
+        return self._request('get', *args, **kwargs)
+
+    def _post(self, *args, **kwargs):
+        return self._request('post', *args, **kwargs)
+
+    def _delete(self, *args, **kwargs):
+        return self._request('delete', *args, **kwargs)
+
+    def get_list(self, list_name, target='default'):
+        response = self._get(list_name, target=target)
+
+        items = {}
+        for value in response:
+            try:
+                guid = value.id
+                version = value.version
+            except AttributeError as exception:
+                log.error(f'Invalid response from {self.NAME} [{list_name}]')
+                raise exception
+
+            guid = uuid.UUID(guid)
+            assert isinstance(version, int)
+
+            items[guid] = {'version': version}
+
+        return items
+
+    def get_dict(self, list_name, guid, target='default'):
+
+        assert isinstance(guid, uuid.UUID)
+        response = self._get(
+            list_name,
+            guid,
+            target=target,
+            decode_as_object=False,
+            decode_as_dict=True,
+        )
+        return response
+
+    def get_data_item(self, guid, item_name, target='default'):
+        assert isinstance(guid, uuid.UUID)
+        response = self._get(item_name, guid, target=target)
+        return response
+
+    def request_passthrough(
+        self, tag, method, passthrough_kwargs, args=None, target='default'
+    ):
+        self._ensure_initialized()
+        try:
+            # Try to convert string integers to integers
+            target = int(target)
+        except ValueError:
+            pass
+
+        # Check target
+        targets = list(self.targets)
+        if target not in targets:
+            raise BadRequest('The specified target %r is invalid.' % (target,))
+
+        headers = passthrough_kwargs.get('headers', {})
+        allowed_header_key_list = [
+            'Accept',
+            'Content-Type',
+            'User-Agent',
+        ]
+        is_json = False
+        for header_key in allowed_header_key_list:
+            header_value = request.headers.get(header_key, None)
+            header_existing = headers.get(header_key, None)
+            if header_value is not None and header_existing is None:
+                headers[header_key] = header_value
+
+            if header_key == 'Content-Type':
+                if header_value is not None:
+                    if header_value.lower().startswith(
+                        'application/javascript'
+                    ) or header_value.lower().startswith('application/json'):
+                        is_json = True
+        passthrough_kwargs['headers'] = headers
+
+        if is_json:
+            data_ = passthrough_kwargs.pop('data', None)
+            if data_ is not None:
+                passthrough_kwargs['json'] = data_
+
+        response = self._request(
+            method,
+            tag,
+            args,
+            target=target,
+            decode_as_object=False,
+            decode_as_dict=False,
+            passthrough_kwargs=passthrough_kwargs,
+        )
+        return response

--- a/app/modules/annotations/resources.py
+++ b/app/modules/annotations/resources.py
@@ -9,6 +9,7 @@ import logging
 
 from flask_restx_patched import Resource
 from flask_restx._http import HTTPStatus
+from flask import current_app
 
 from app.extensions import db
 from app.extensions.api import Namespace, abort
@@ -24,11 +25,11 @@ log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace('annotations', description='Annotations')  # pylint: disable=invalid-name
 
 
-@api.route('/')
+@api.route('/local/')
 @api.login_required(oauth_scopes=['annotations:read'])
-class Annotations(Resource):
+class AnnotationsLocal(Resource):
     """
-    Manipulations with Annotations.
+    Read Annotations that are on Houston but not on ACM
     """
 
     @api.permission_required(
@@ -48,6 +49,39 @@ class Annotations(Resource):
         parameter.
         """
         return Annotation.query.offset(args['offset']).limit(args['limit'])
+
+
+@api.route('/')
+@api.login_required(oauth_scopes=['annotations:read'])
+class Annotations(Resource):
+    """
+    Manipulations with Annotations.
+    """
+
+    @api.permission_required(
+        permissions.ModuleAccessPermission,
+        kwargs_on_request=lambda kwargs: {
+            'module': Annotation,
+            'action': AccessOperation.READ,
+        },
+    )
+    @api.parameters(PaginationParameters())
+    def get(self, args):
+        """
+        List of Annotation.
+
+        Returns the unprocessed passthrough response from WBIA
+        """
+        response = current_app.acm.request_passthrough('annotations.list', 'get', {})
+        # TODO what should this actually pass back?
+        # Should this parse what has come back from ACM to return a list of the uuids from WBIA
+        # but without the __UUID__ construct so that they appear to be just within Houston to the frontend?
+        # Could Houston know about annotations that WBIA doesn't?
+        data = response.json()
+        if response.ok and 'response' in data:
+            return data['response']
+
+        return response
 
     @api.permission_required(
         permissions.ModuleAccessPermission,

--- a/app/modules/passthroughs/resources.py
+++ b/app/modules/passthroughs/resources.py
@@ -108,3 +108,90 @@ class EDMPassthroughs(Resource):
         )
 
         return response
+
+
+@acm_pass.route('/')
+@acm_pass.login_required(oauth_scopes=['passthroughs:read'])
+class ACMPassthroughTargets(Resource):
+    """
+    Manipulations with Passthroughs.
+    """
+
+    def get(self):
+        """
+        List the possible EDM passthrough targets.
+        """
+        targets = current_app.acm.get_target_list()
+        return targets
+
+
+@edm_pass.route('/<string:target>/', defaults={'path': None}, doc=False)
+@edm_pass.route('/<string:target>/<path:path>')
+@edm_pass.login_required(oauth_scopes=['passthroughs:read'])
+class ACMPassthroughs(Resource):
+    r"""
+    A pass-through allows a GET or POST request to be referred to a registered back-end EDM
+
+    CommandLine:
+        EMAIL='test@localhost'
+        PASSWORD='test'
+        TIMESTAMP=$(date '+%Y%m%d-%H%M%S%Z')
+        curl \
+            -X POST \
+            -c cookie.jar \
+            -F email=${EMAIL} \
+            -F password=${PASSWORD} \
+            https://houston.dyn.wildme.io/api/v1/auth/sessions | jq
+        curl \
+            -X GET \
+            -b cookie.jar \
+            https://houston.dyn.wildme.io/api/v1/users/me | jq
+        curl \
+            -X POST \
+            -b cookie.jar \
+            -d "{\"site.name\": \"value-updated-${TIMESTAMP}\"}" \
+            https://houston.dyn.wildme.io/api/v1/passthroughs/edm/default/api/v0/configuration | jq
+        curl \
+            -X GET \
+            -b cookie.jar \
+            https://houston.dyn.wildme.io/api/v1/passthroughs/edm/default/api/v0/configuration/site.name | jq ".response.value"
+    """
+
+    def get(self, target, path):
+        """
+        List the possible EDM passthrough targets.
+        """
+        params = {}
+        params.update(request.args)
+        params.update(request.form)
+
+        response = current_app.acm.request_passthrough(
+            'passthrough.data', 'get', {'params': params}, path, target
+        )
+
+        return response
+
+    def post(self, target, path):
+        """
+        List the possible EDM passthrough targets.
+        """
+        data = {}
+        data.update(request.args)
+        data.update(request.form)
+        try:
+            data_ = json.loads(request.data)
+            data.update(data_)
+        except Exception:
+            pass
+
+        passthrough_kwargs = {'data': data}
+
+        files = request.files
+        if len(files) > 0:
+            passthrough_kwargs['files'] = files
+
+        response = current_app.acm.request_passthrough(
+            'passthrough.data', 'post', passthrough_kwargs, path, target
+        )
+
+        return response

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -139,7 +139,9 @@ class ModuleActionRule(DenyAbortMixin, Rule):
             if not has_permission and user.is_user_manager:
                 has_permission = self._is_module(User)
             if not has_permission and user.is_researcher:
-                has_permission = self._is_module((Encounter, Sighting, Individual))
+                has_permission = self._is_module(
+                    (Encounter, Sighting, Individual, Annotation)
+                )
 
         elif self._action is AccessOperation.WRITE:
             if self._is_module(HoustonConfig):

--- a/config.py
+++ b/config.py
@@ -199,13 +199,14 @@ class BaseConfig(object):
     }
 
 
-def parse_edm_config_items():
-    """Parse EDM configuration from environment variables"""
+def get_env_rest_config(interface):
+    """Parse ACM/EDM configuration from environment variables"""
     # Parse all uris from environment variables
-    # BBB assign a default URI
-    uris = {'default': 'https://nextgen.dev-wildbook.org/'}
-    for varname in [e for e in os.environ if e.startswith('EDM_AUTHENTICATIONS_URI__')]:
-        #: e.g. EDM_AUTHENTICATIONS_URI__DEFAULT
+    uris = {}
+    for varname in [
+        e for e in os.environ if e.startswith(f'{interface}_AUTHENTICATIONS_URI__')
+    ]:
+        #: e.g. ACM_AUTHENTICATIONS_URI__DEFAULT
         key = varname.split('__')[-1].lower()
         value = os.environ[varname]
         uris[key] = value
@@ -213,12 +214,12 @@ def parse_edm_config_items():
     # Parse all authentication info from environment variables
     authns = {}
     for varname in [
-        e for e in os.environ if e.startswith('EDM_AUTHENTICATIONS_USERNAME__')
+        e for e in os.environ if e.startswith(f'{interface}_AUTHENTICATIONS_USERNAME__')
     ]:
         key = varname.split('__')[-1].lower()
         authns.setdefault(key, {})
         username = os.environ[varname]
-        password_varname = f'EDM_AUTHENTICATIONS_PASSWORD__{key.upper()}'
+        password_varname = f'{interface}_AUTHENTICATIONS_PASSWORD__{key.upper()}'
         try:
             password = os.environ[password_varname]
         except KeyError:
@@ -232,8 +233,19 @@ def parse_edm_config_items():
     return uris, authns
 
 
+class ACMConfig(object):
+    # Read the config from the environment but ensure that there is always a default URI
+    ACM_URIS, ACM_AUTHENTICATIONS = get_env_rest_config('ACM')
+    if 'default' not in ACM_URIS:
+        # TODO this is definitely wrong but it at least allows a login
+        ACM_URIS['default'] = 'http://demo.wildbook.org/'
+
+
 class EDMConfig(object):
-    EDM_URIS, EDM_AUTHENTICATIONS = parse_edm_config_items()
+    # Read the config from the environment but ensure that there is always a default URI
+    EDM_URIS, EDM_AUTHENTICATIONS = get_env_rest_config('EDM')
+    if 'default' not in EDM_URIS:
+        EDM_URIS['default'] = 'http://demo.wildbook.org/'
 
 
 class SubmissionGitLabRemoteConfig(object):

--- a/config.py
+++ b/config.py
@@ -246,7 +246,7 @@ class EDMConfig(object):
     # Read the config from the environment but ensure that there is always a default URI
     EDM_URIS, EDM_AUTHENTICATIONS = get_env_rest_config('EDM')
     if 'default' not in EDM_URIS:
-        EDM_URIS['default'] = 'http://demo.wildbook.org/'
+        EDM_URIS['default'] = 'https://nextgen.dev-wildbook.org/'
 
 
 class SubmissionGitLabRemoteConfig(object):

--- a/config.py
+++ b/config.py
@@ -235,10 +235,11 @@ def get_env_rest_config(interface):
 
 class ACMConfig(object):
     # Read the config from the environment but ensure that there is always a default URI
+    # WBIA doesn't currently support authentications but no reason to not use the same function to read
+    # the env config.
     ACM_URIS, ACM_AUTHENTICATIONS = get_env_rest_config('ACM')
     if 'default' not in ACM_URIS:
-        # TODO this is definitely wrong but it at least allows a login
-        ACM_URIS['default'] = 'http://demo.wildbook.org/'
+        ACM_URIS['default'] = 'https://tier2.dyn.wildme.io:5010'
 
 
 class EDMConfig(object):
@@ -256,7 +257,7 @@ class SubmissionGitLabRemoteConfig(object):
 
 
 class ProductionConfig(
-    BaseConfig, EDMConfig, SubmissionGitLabRemoteConfig, SecretProductionConfig
+    BaseConfig, EDMConfig, ACMConfig, SubmissionGitLabRemoteConfig, SecretProductionConfig
 ):
     TESTING = False
 
@@ -274,6 +275,7 @@ class ProductionConfig(
 class DevelopmentConfig(
     BaseConfig,
     EDMConfig,
+    ACMConfig,
     SubmissionGitLabRemoteConfig,
     SecretDevelopmentConfig,
 ):

--- a/tests/modules/annotations/resources/test_create_annotation.py
+++ b/tests/modules/annotations/resources/test_create_annotation.py
@@ -44,7 +44,6 @@ def test_create_and_delete_annotation(
         clone.cleanup()
 
 
-# TODO doesn't work at the moment
 def test_annotation_permission(
     flask_app_client,
     admin_user,

--- a/tests/modules/annotations/resources/utils.py
+++ b/tests/modules/annotations/resources/utils.py
@@ -56,9 +56,14 @@ def read_annotation(flask_app_client, user, annotation_guid, expected_status_cod
     return response
 
 
-def read_all_annotations(flask_app_client, user, expected_status_code=200):
+def read_all_annotations(
+    flask_app_client, user, local_only=False, expected_status_code=200
+):
     with flask_app_client.login(user, auth_scopes=('annotations:read',)):
-        response = flask_app_client.get(PATH)
+        if local_only:
+            response = flask_app_client.get(f'{PATH}local/')
+        else:
+            response = flask_app_client.get(PATH)
 
     if expected_status_code == 200:
         test_utils.validate_list_response(response, 200)


### PR DESCRIPTION

## Pull Request Overview
 - EDM Manager basically moved to RestManager and EDMManager and ACMManager are derived classes. 
- UserMixin moved to RestManager.py, EndointMixin incorporated within RestManager (the Endpoint of a rest API is not a mixin, it's fundamental).
- Config of EDM tweaked and extended to support ACM. 
- Passthrough ACM written to do the same as for ECM 
- Annotations get used as a template to read from ACM

---
**REST API Updates**

Currently the annotations get returns all of the annotations on ACM but not the local ones, so a new interface was added to read just the local ones

```
[GET] /api/v1/annotations/local/
{
   
}
```

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [ x Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
