### PR TITLE
Circumvent issues with flask_restx Api object storing the app

### DIFF
--- a/app/extensions/api/__init__.py
+++ b/app/extensions/api/__init__.py
@@ -17,7 +17,9 @@ import logging
 log = logging.getLogger(__name__)
 
 
+api_v1_blueprint = Blueprint('api', __name__, url_prefix='/api/v1')
 api_v1 = Api(  # pylint: disable=invalid-name
+    api_v1_blueprint,
     version='1.0.0',
     title='Houston',
     description=(
@@ -43,3 +45,4 @@ def init_app(app, **kwargs):
     """
     # Prevent config variable modification with runtime changes
     api_v1.authorizations = deepcopy(app.config['AUTHORIZATIONS'])
+    app.register_blueprint(api_v1_blueprint)

--- a/app/modules/api/__init__.py
+++ b/app/modules/api/__init__.py
@@ -3,18 +3,10 @@
 Houston API registration module
 ===============================
 """
-
-from flask import Blueprint
-
 from app.extensions import api
 
 
 def init_app(app, **kwargs):
-    # pylint: disable=unused-argument
-    api_v1_blueprint = Blueprint('api', __name__, url_prefix='/api/v1')
-    api.api_v1.init_app(api_v1_blueprint)
-    app.register_blueprint(api_v1_blueprint)
-
     # Touch underlying modules
     from . import resources
 


### PR DESCRIPTION
## Pull Request Overview

Changes the Api object to use a blueprint instead of waiting for the
app to be given. This has two known benefits IMO. One, you ensure the
Api object isn't deeply associated with a particular app instance,
because the Api code has a design flaw where they store the app
instance. Two, you can init the api in the exact location it's
created. (And a possible third reason is because you can setup multiple flask apps in the same runtime using this operation; though we aren't doing that and may never do that.)

The intended goal of this change is towards a less global testing
setup.

Keep in mind that this change is supported by restx_plus. I've pulled this fix directly from one of their examples. Also this kind of procedure is recommended by the Flask documentation (see "Becoming Big" section of the docs).

---

**Review Notes**

The app continues to function as it should. I've had a difficult time writing tests that show this works correctly as opposed to the incorrect way it was used before. This is partly due to our test fixtures being setup for 'session' use. I'd rather not sit on this change any longer, so I'm asking you to take me at my word that it is indeed the better way to do this. 😁

**Pull Request Checklist**
- [X] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [X] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [X] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [X] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [X] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [X] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [x] Ensure that the PR is properly reviewed
