### PR TITLE
Fix /api/v1/*/wrong-uuid to return 404

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -72,6 +72,12 @@ jobs:
           mv _db.initial _db
           ./scripts/install.sh
 
+      - name: Create frontend static directory (tests complains if static directory does not exist)
+        run: |
+          mkdir -p app/static/dist-latest
+          touch app/static/dist-latest/404.html
+          touch app/static/dist-latest/index.html
+
       - name: Run tests (random x3)
         run: |
           source virtualenv/houston3.7/bin/activate
@@ -145,6 +151,12 @@ jobs:
           tar -zxvf _db.initial.tar.gz
           mv _db.initial _db
           ./scripts/install.sh
+
+      - name: Create frontend static directory (tests complains if static directory does not exist)
+        run: |
+          mkdir -p app/static/dist-latest
+          touch app/static/dist-latest/404.html
+          touch app/static/dist-latest/index.html
 
       - name: Run tests (random x3)
         run: |

--- a/app/modules/frontend/views_frontend.py
+++ b/app/modules/frontend/views_frontend.py
@@ -39,8 +39,7 @@ frontend_blueprint = Blueprint(
 
 
 @frontend_blueprint.route('/', defaults={'path': None}, methods=['GET'])
-@frontend_blueprint.route('/<path:path>', methods=['GET'])
-def home(path=None, *args, **kwargs):
+def home(*args, **kwargs):
     # pylint: disable=unused-argument
 
     """
@@ -56,12 +55,17 @@ def home(path=None, *args, **kwargs):
         )
         raise werkzeug.exceptions.InternalServerError
 
-    if path is None:
-        path = 'index.html'
-    try:
+    path = 'index.html'
+    return send_from_directory(frontend_blueprint.static_folder, path)
+
+
+@frontend_blueprint.route(
+    '/<path:path>', methods=['GET', 'POST', 'PUT', 'DELETE', 'HEAD', 'OPTIONS', 'PATCH']
+)
+def catchall(path, *args, **kwargs):
+    if request.method == 'GET':
         return send_from_directory(frontend_blueprint.static_folder, path)
-    except werkzeug.exceptions.NotFound:
-        return home(path=None, *args, **kwargs)
+    raise werkzeug.exceptions.NotFound
 
 
 @frontend_blueprint.route('/login', methods=['POST'])

--- a/tests/modules/annotations/resources/test_create_annotation.py
+++ b/tests/modules/annotations/resources/test_create_annotation.py
@@ -6,6 +6,11 @@ from tests.modules.annotations.resources import utils as annot_utils
 from tests.modules.submissions.resources import utils as sub_utils
 
 
+def test_get_annotation_not_found(flask_app_client):
+    response = flask_app_client.get('/api/v1/annotations/wrong-uuid')
+    assert response.status_code == 404
+
+
 def test_create_and_delete_annotation(
     flask_app_client, admin_user, researcher_1, test_clone_submission_data
 ):

--- a/tests/modules/assets/resources/test_assets.py
+++ b/tests/modules/assets/resources/test_assets.py
@@ -5,6 +5,11 @@ from tests import utils
 import tests.modules.submissions.resources.utils as submission_utils
 
 
+def test_get_asset_not_found(flask_app_client):
+    response = flask_app_client.get('/api/v1/assets/wrong-uuid')
+    assert response.status_code == 404
+
+
 def test_find_asset(
     flask_app_client,
     admin_user,

--- a/tests/modules/collaborations/test_resources.py
+++ b/tests/modules/collaborations/test_resources.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+def test_get_collaborations_not_found(flask_app_client):
+    response = flask_app_client.get('/api/v1/collaborations/wrong-uuid')
+    assert response.status_code == 404

--- a/tests/modules/encounters/resources/test_read_encounters.py
+++ b/tests/modules/encounters/resources/test_read_encounters.py
@@ -10,3 +10,8 @@ def test_read_encounters(flask_app_client, researcher_1):
     with flask_app_client.login(researcher_1, auth_scopes=('encounters:read',)):
         response = flask_app_client.get(PATH)
     utils.validate_list_response(response, 200)
+
+
+def test_get_encounter_not_found(flask_app_client):
+    response = flask_app_client.get(f'{PATH}not-found')
+    assert response.status_code == 404

--- a/tests/modules/fileuploads/test_resources.py
+++ b/tests/modules/fileuploads/test_resources.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+def test_get_fileupload_not_found(flask_app_client):
+    response = flask_app_client.get('/api/v1/fileuploads/src/wrong-uuid')
+    assert response.status_code == 404

--- a/tests/modules/frontend/test_views_frontend.py
+++ b/tests/modules/frontend/test_views_frontend.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+def test_home(flask_app_client):
+    response = flask_app_client.get('/')
+    assert response.status_code == 200
+
+
+def test_catchall_static_file(flask_app_client):
+    response = flask_app_client.get('/index.html')
+    assert response.status_code == 200
+
+
+def test_catchall_not_found(flask_app_client):
+    response = flask_app_client.get('/asdf')
+    assert response.status_code == 404

--- a/tests/modules/individuals/resources/test_individual_crud.py
+++ b/tests/modules/individuals/resources/test_individual_crud.py
@@ -10,6 +10,11 @@ from tests import utils
 log = logging.getLogger(__name__)
 
 
+def test_get_individual_not_found(flask_app_client):
+    response = flask_app_client.get('/api/v1/individuals/wrong-uuid')
+    assert response.status_code == 404
+
+
 def test_create_read_delete_individual(db, flask_app_client):
 
     temp_owner = utils.generate_user_instance(

--- a/tests/modules/notifications/test_resources.py
+++ b/tests/modules/notifications/test_resources.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+def test_get_notification_not_found(flask_app_client):
+    response = flask_app_client.get('/api/v1/notifications/wrong-uuid')
+    assert response.status_code == 404

--- a/tests/modules/organizations/resources/test_get_organization.py
+++ b/tests/modules/organizations/resources/test_get_organization.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+def test_get_organization_not_found(flask_app_client):
+    response = flask_app_client.get('/api/v1/organizations/wrong-uuid')
+    assert response.status_code == 404

--- a/tests/modules/projects/resources/test_get_project.py
+++ b/tests/modules/projects/resources/test_get_project.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+def test_get_project_not_found(flask_app_client):
+    response = flask_app_client.get('/api/v1/projects/wrong-uuid')
+    assert response.status_code == 404

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -5,6 +5,11 @@ from tests.modules.sightings.resources import utils as sighting_utils
 from tests import utils as test_utils
 
 
+def test_get_sighting_not_found(flask_app_client):
+    response = flask_app_client.get('/api/v1/sightings/wrong-uuid')
+    assert response.status_code == 404
+
+
 def test_create_failures(flask_app_client, researcher_1):
     transaction_id, test_filename = sighting_utils.prep_tus_dir()
 

--- a/tests/modules/submissions/resources/test_get_submission.py
+++ b/tests/modules/submissions/resources/test_get_submission.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+def test_get_submission_not_found(flask_app_client):
+    response = flask_app_client.get('/api/v1/submissions/wrong-uuid')
+    assert response.status_code == 404

--- a/tests/modules/users/resources/test_getting_users_info.py
+++ b/tests/modules/users/resources/test_getting_users_info.py
@@ -99,3 +99,15 @@ def test_getting_user_me_info(flask_app_client, regular_user):
     assert isinstance(response.json, dict)
     assert set(response.json.keys()) >= {'guid', 'email'}
     assert 'password' not in response.json.keys()
+
+
+def test_getting_user_id_not_found(flask_app_client, regular_user):
+    with flask_app_client.login(
+        regular_user,
+        auth_scopes=(
+            'users:read',
+            'users:write',
+        ),
+    ):
+        response = flask_app_client.get('/api/v1/users/wrong-uuid')
+        assert response.status_code == 404

--- a/tests/modules/users/resources/test_modifying_users_info.py
+++ b/tests/modules/users/resources/test_modifying_users_info.py
@@ -10,6 +10,30 @@ from app.modules.users.models import User
 from app.modules.fileuploads.models import FileUpload
 
 
+def test_user_id_not_found(flask_app_client, regular_user):
+    with flask_app_client.login(
+        regular_user,
+        auth_scopes=(
+            'users:read',
+            'users:write',
+        ),
+    ):
+        response = flask_app_client.patch(
+            '/api/v1/users/wrong-uuid',
+            content_type='application/json',
+            data=json.dumps(
+                [
+                    {
+                        'op': 'replace',
+                        'path': '/full_name',
+                        'value': 'Modified Full Name',
+                    }
+                ]
+            ),
+        )
+        assert response.status_code == 404
+
+
 def test_modifying_user_info_by_owner(flask_app_client, regular_user, db):
     # pylint: disable=invalid-name
     saved_full_name = regular_user.full_name


### PR DESCRIPTION
What happened when a request asks for `PATCH /api/v1/users/wrong-uuid`:

1. Did not match the route `/api/v1/users/<uuid:user_guid>`
   (`app.modules.users.resources.UserByID`) because "wrong-uuid" is not
   a valid uuid
2. Matched the route `/<path:path>`
   (`app.modules.frontend.views_frontend.home`) but this route only
   accepts "GET" as the method
3. Returned 405 Method Not Allowed

This is incorrect as it looks like the user exists but "PATCH" is not
allowed.  The code path taken is also probably not what we expected.

In this patch, I decided to split the routes `/` and `/<path:path>` into
`app.modules.frontend.views_frontend.home` and
`app.modules.frontend.catchall` so that it's more clear what those
routes are meant to return.

`/` is only meant to return "index.html".

`/<path:path>` now accepts all methods `GET`, `POST`, `PUT`, `DELETE`,
`HEAD`, `OPTIONS`, `PATCH`.  For `GET`, it will return something from
the static folder, for all other methods, it returns "not found".

Now `PATCH /api/v1/users/wrong-uuid` becomes:

1. Does not match the route `/api/v1/users/<uuid:user_guid>`
2. Matches the route `/<path:path>`
3. Returns 404 Not Found

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
