### PR TITLE
Fix the ChatOps rebase workflow

### DIFF
--- a/.github/workflows/chatops-rebase.yml
+++ b/.github/workflows/chatops-rebase.yml
@@ -12,9 +12,9 @@ jobs:
       - name: Checkout the latest code
         uses: actions/checkout@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT_TOKEN }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
       - name: Automatic Rebase
         uses: cirrus-actions/rebase@1.4
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
## Pull Request Overview

The `/rebase` command is working as seen in [a comment on a PR](https://github.com/WildMeOrg/houston/pull/86#issuecomment-802235421), but as mentioned in the project's [cirrus-actions/rebase readme](https://github.com/cirrus-actions/rebase#installation):

> NOTE: To ensure GitHub Actions is automatically re-run after a successful rebase action use a Personal Access Token for actions/checkout@v2 and cirrus-actions/rebase@1.4.

---

**Review Notes**

The action will right now, because the `PAT_TOKEN` secret isn't defined. Or at least I doubt it's defined.

Someone with admin access to the repo or org will need to add this secret and value. Then we should be good to go!

**Pull Request Checklist**
- [X] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [X] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [X] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [X] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [X] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [X] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
