### PR TITLE
Fix git commit hash in frontend dist filename

### DIFF
--- a/scripts/build.frontend.sh
+++ b/scripts/build.frontend.sh
@@ -3,8 +3,15 @@
 
 set -e
 
+function parse_git_hash() {
+    if [ -d _frontend ]; then
+        GIT_DIR='_frontend/.git'
+    fi
+    GIT_DIR=$GIT_DIR git rev-parse --short HEAD 2> /dev/null | sed "s/\(.*\)/\1/"
+}
+
 # Get last commit hash prepended with @ (i.e. @8a323d0)
-GIT_BRANCH=$(git rev-parse --short HEAD 2> /dev/null | sed "s/\(.*\)/\1/")
+GIT_BRANCH=$(parse_git_hash)
 # Copy dist packages out of _frontend repo and deploy
 BASE_INSTALL_PATH="app/static/"
 
@@ -16,7 +23,7 @@ function get_install_path() {
 
 function checkout() {
     # Look for a previous submodule checkout prior to initializing
-    if [ ! -d _frontend/package.json ]; then
+    if [ ! -f _frontend/package.json ]; then
         echo "Checking out  submodules..."
         git submodule update --init --recursive
     fi


### PR DESCRIPTION
`./scripts/build.frontend.sh` was creating a dist directory in
`app/static` using the commit hash from houston instead of from
_frontend.

We need to run `git rev-parse --short HEAD` with the correct context
(`_frontend/`) in order to get the correct commit hash.

Also fix `checkout()` always reinitializing `_frontend` by checking the
existence of the file (`-f`) `_frontend/package.json` instead of the
existence of the directory (`-d`) `_frontend/package.json`.

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
