### PR TITLE
DEX-124: admin user initial creation (for edm)

### DIFF
--- a/app/extensions/acm/__init__.py
+++ b/app/extensions/acm/__init__.py
@@ -36,7 +36,7 @@ class ACMManager(RestManager):
     # fmt: on
 
     def __init__(self, pre_initialize=False, *args, **kwargs):
-        super(ACMManager, self).__init__(False, pre_initialize, *args, **kwargs)
+        super(ACMManager, self).__init__(pre_initialize, *args, **kwargs)
 
 
 def init_app(app, **kwargs):

--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -73,6 +73,7 @@ class EDMManager(RestManager):
         },
         'configuration': {
             'data': '//v0/configuration/%s',
+            'init': '//v0/init?content=%s',
         },
         'configurationDefinition': {
             'data': '//v0/configurationDefinition/%s',

--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -82,7 +82,7 @@ class EDMManager(RestManager):
     # fmt: on
 
     def __init__(self, pre_initialize=False, *args, **kwargs):
-        super(EDMManager, self).__init__(True, pre_initialize, *args, **kwargs)
+        super(EDMManager, self).__init__(pre_initialize, *args, **kwargs)
 
 
 class EDMObjectMixin(object):

--- a/app/extensions/restManager/RestManager.py
+++ b/app/extensions/restManager/RestManager.py
@@ -151,7 +151,7 @@ class RestManager(RestManagerUserMixin):
             and authns['default'].get('username')
             and authns['default'].get('password')
         )
-        assertion_msg = f"Missing {self.NAME}_AUTHENTICATION credentials for 'default'"
+        assertion_msg = f"Missing {self.NAME}_AUTHENTICATIONS credentials for 'default'"
         assert has_required_default_authn, assertion_msg
 
         # Check URIs have matching credentials

--- a/app/extensions/restManager/RestManager.py
+++ b/app/extensions/restManager/RestManager.py
@@ -194,6 +194,19 @@ class RestManager(RestManagerUserMixin):
 
             log.info(f'Created authenticated session for {self.NAME} target {target}')
 
+    def pseudo_initialize(self, target):
+        """
+        Basically gives us the ability to create a session for a target which _does not_ rely
+        on actually having authentication credentials.  This is useful for requests to the EDM which
+        do not need authentication, like configuration reading and first-time admin creation.
+
+        """
+        if not self.initialized:
+            log.debug('Pseudo-initializing')
+            self.sessions = {}
+            self.sessions[target] = requests.Session()
+            self._parse_config_uris()
+
     def _ensure_initialized(self):
         if not self.initialized:
             log.info('Initializing %s' % self.NAME)

--- a/app/extensions/restManager/RestManager.py
+++ b/app/extensions/restManager/RestManager.py
@@ -155,6 +155,8 @@ class RestManager(RestManagerUserMixin):
 
             if not authns:
                 log.info(f'No authentication for {self.NAME}, using anonymous sessions')
+                return
+
             has_required_default_authn = (
                 isinstance(authns.get('default'), dict)
                 and authns['default'].get('username')

--- a/app/modules/configuration/resources.py
+++ b/app/modules/configuration/resources.py
@@ -9,9 +9,7 @@ import logging
 
 from flask import current_app, request
 from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 from app.extensions.api import Namespace
-from app.extensions.api import abort
 
 from app.modules.users.models import User
 
@@ -35,22 +33,17 @@ class EDMConfigurationDefinition(Resource):
     """
 
     def get(self, target, path):
-        response = current_app.edm.request_passthrough(
-            'configurationDefinition.data', 'get', {}, path, target
+        current_app.edm.pseudo_initialize(target)
+        data = current_app.edm._get(
+            'configurationDefinition.data',
+            path,
+            target=target,
+            ensure_initialized=False,
+            decode_as_object=False,
+            decode_as_dict=True,
         )
-
-        data = response.json()
-        if (
-            response.ok
-            and 'response' in data
-            and 'isPrivate' in data['response']
-            and data['response']['isPrivate']
-            and 'value' in data['response']
-        ):
-            data['response'].pop('value')
-            return data
-
-        return response
+        # TODO also traverse private here FIXME
+        return data
 
 
 @edm_configuration.route('/<string:target>', defaults={'path': ''}, doc=False)
@@ -93,29 +86,25 @@ class EDMConfiguration(Resource):
         params.update(request.args)
         params.update(request.form)
 
-        response = current_app.edm.request_passthrough(
-            'configuration.data', 'get', {'params': params}, path, target
+        current_app.edm.pseudo_initialize(target)
+        data = current_app.edm._get(
+            'configuration.data',
+            path,
+            target=target,
+            ensure_initialized=False,
+            decode_as_object=False,
+            decode_as_dict=True,
         )
 
+        # TODO make private private - traverse bundles too
         # private means cannot be read other than admin
-        ####@edm_configuration.login_required(oauth_scopes=['configuration:write'])  TODO somehow need to *allow* private if has auth!!!
-        data = response.json()
-        if (
-            response.ok
-            and 'response' in data
-            and 'private' in data['response']
-            and data['response']['private']
-        ):
-            abort(code=HTTPStatus.FORBIDDEN, message='unavailable')
+        # abort(code=HTTPStatus.FORBIDDEN, message='unavailable')
 
         if path == '__bundle_setup':
-            data = response.json()
             data['response']['configuration'][
                 'site.adminUserInitialized'
             ] = User.admin_user_initialized()
-            return data
-
-        return response
+        return data
 
     @edm_configuration.login_required(oauth_scopes=['configuration:write'])
     def post(self, target, path):

--- a/app/modules/configuration/resources.py
+++ b/app/modules/configuration/resources.py
@@ -37,7 +37,6 @@ class EDMConfigurationDefinition(Resource):
             'configurationDefinition.data',
             path,
             target=target,
-            ensure_initialized=False,
         )
         # TODO also traverse private here FIXME
         return data
@@ -87,7 +86,6 @@ class EDMConfiguration(Resource):
             'configuration.data',
             path,
             target=target,
-            ensure_initialized=False,
         )
 
         # TODO make private private - traverse bundles too

--- a/app/modules/configuration/resources.py
+++ b/app/modules/configuration/resources.py
@@ -33,14 +33,11 @@ class EDMConfigurationDefinition(Resource):
     """
 
     def get(self, target, path):
-        current_app.edm.pseudo_initialize(target)
-        data = current_app.edm._get(
+        data = current_app.edm.get_dict(
             'configurationDefinition.data',
             path,
             target=target,
             ensure_initialized=False,
-            decode_as_object=False,
-            decode_as_dict=True,
         )
         # TODO also traverse private here FIXME
         return data
@@ -86,14 +83,11 @@ class EDMConfiguration(Resource):
         params.update(request.args)
         params.update(request.form)
 
-        current_app.edm.pseudo_initialize(target)
-        data = current_app.edm._get(
+        data = current_app.edm.get_dict(
             'configuration.data',
             path,
             target=target,
             ensure_initialized=False,
-            decode_as_object=False,
-            decode_as_dict=True,
         )
 
         # TODO make private private - traverse bundles too

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -256,7 +256,6 @@ class AdminUserInitialized(Resource):
                 'configuration.init',
                 json.dumps(edm_data),
                 target=target,
-                ensure_initialized=False,
             )
             if data.get('success', False):
                 edm_auth = current_app.config.get('EDM_AUTHENTICATIONS', {})

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -252,14 +252,11 @@ class AdminUserInitialized(Resource):
                 }
             }
             target = 'default'  # TODO will we create admin on other targets?
-            current_app.edm.pseudo_initialize(target)
-            data = current_app.edm._get(
+            data = current_app.edm.get_dict(
                 'configuration.init',
                 json.dumps(edm_data),
                 target=target,
                 ensure_initialized=False,
-                decode_as_object=False,
-                decode_as_dict=True,
             )
             if data.get('success', False):
                 edm_auth = current_app.config.get('EDM_AUTHENTICATIONS', {})

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -263,9 +263,7 @@ class AdminUserInitialized(Resource):
             )
             if data.get('success', False):
                 edm_auth = current_app.config.get('EDM_AUTHENTICATIONS', {})
-                log.warning(f'BEFORE edm_auth => {edm_auth}')
-                edm_auth[target] = {'email': email, 'password': password}
-                log.warning(f'AFTER  edm_auth => {edm_auth}')
+                edm_auth[target] = {'username': email, 'password': password}
                 from app.extensions.config.models import HoustonConfig
 
                 HoustonConfig.set('EDM_AUTHENTICATIONS', edm_auth)

--- a/tasks/app/initialize.py
+++ b/tasks/app/initialize.py
@@ -16,17 +16,13 @@ log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 def initialize_edm_admin_user(context):
     """Set up EDM admin user"""
     from flask import current_app
-    import requests
 
-    log.info('Initializing EDM admin user')
-    base_url = current_app.config['EDM_URIS']['default']
+    email = 'admin@example.com'
     password = current_app.config['EDM_AUTHENTICATIONS']['default']['password']
-    payload = {'adminPassword': password}
-    url = f'{base_url}/edm/init.jsp'
-    # Contact EDM to initialize
-    resp = requests.get(url, params=payload)
-    if not resp.ok:
-        raise RuntimeError(f'Failed to initialize EDM admin user: {resp.reason}')
+    log.info('Initializing EDM admin user')
+    success = current_app.edm.initialize_edm_admin_user(email, password)
+    if not success:
+        raise RuntimeError('Failed to initialize EDM admin user')
     log.info('Initialized EDM admin user')
 
 

--- a/tests/extensions/edm/test_edm.py
+++ b/tests/extensions/edm/test_edm.py
@@ -14,3 +14,11 @@ def test_edm_initializes(flask_app):
     # a 401 or 403 means valid login for edm, but that login has bad permissions!
     # if you get a 200 here, see jon for a prize
     assert response.status_code == 404
+
+
+def test_initialize_admin_user(flask_app):
+    # this should fail as admin_user should exist and/or email address is invalid
+    email = None
+    password = 'test'
+    success = flask_app.edm.initialize_edm_admin_user(email, password)
+    assert not success

--- a/tests/modules/users/resources/test_admin_init.py
+++ b/tests/modules/users/resources/test_admin_init.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-docstring
+import json
+from app.modules.users.models import User
+
+
+def test_admin_creation(flask_app_client):
+    response = flask_app_client.get('/api/v1/users/admin_user_initialized')
+    assert response.status_code == 200
+    assert not response.json['initialized']  # False cuz we have no admin
+
+    # fails due to bad email address
+    data = json.dumps({'email': 'fail', 'password': 'test1234'})
+    response = flask_app_client.post('/api/v1/users/admin_user_initialized', data=data)
+    assert response.status_code == 422
+
+    # create one
+    valid_email = 'test-admin@example.com'
+    data = json.dumps({'email': valid_email, 'password': 'test1234'})
+    response = flask_app_client.post('/api/v1/users/admin_user_initialized', data=data)
+    assert response.status_code == 200
+    assert response.json['initialized']
+
+    response = flask_app_client.get('/api/v1/users/admin_user_initialized')
+    assert response.status_code == 200
+    assert response.json['initialized']  # now we True
+
+    # clean up
+    user = User.find(email=valid_email)
+    assert user is not None
+    user.delete()


### PR DESCRIPTION
## Pull Request Overview

- houston api for initial admin-user-creation now also calls back to EDM to do same there
- Updates config locally (_i.e._ in db) with these new username/password override values
- Allows connection to (some) edm functionality _without_ any EDM authentication set (for initial case)
- Also contains some refactoring of auth/request in RestManager via @hwindsor 

---

**Review Notes**
- Functionality is demonstrated by having an _empty_ database in both houston and EDM (or at least no admin users).
- houston api call will still show success if _houston_ had no admin user, but EDM _does_ have one.  This state will not happen in a newly created codex; but this behavior may wish to be modified.

**REST API Updates**

Calls are still the same: `GET/POST /api/v1/users/admin_user_initialized`, but POST now returns a secondary `edmInitialized` boolean value.

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
