### PR TITLE
Add debug steps and allow more roles in chatops-rebase workflow

### DIFF
--- a/.github/workflows/chatops-rebase.yml
+++ b/.github/workflows/chatops-rebase.yml
@@ -18,3 +18,27 @@ jobs:
         uses: cirrus-actions/rebase@1.4
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+
+  debug:
+    runs-on: ubuntu-latest
+    steps:
+      - if: github.event.issue.pull_request == ''
+        run: echo 'Not pull request'
+      - if: contains(github.event.comment.body, '/rebase')
+        run: echo 'Comment body contains /rebase'
+      - if: github.event.comment.author_association == 'COLLABORATOR'
+        run: echo 'Comment author COLLABORATOR'
+      - if: github.event.comment.author_association == 'CONTRIBUTOR'
+        run: echo 'Comment author CONTRIBUTOR'
+      - if: github.event.comment.author_association == 'FIRST_TIMER'
+        run: echo 'Comment author FIRST_TIMER'
+      - if: github.event.comment.author_association == 'FIRST_TIME_CONTRIBUTOR'
+        run: echo 'Comment author FIRST_TIME_CONTRIBUTOR'
+      - if: github.event.comment.author_association == 'MANNEQUIN'
+        run: echo 'Comment author MANNEQUIN'
+      - if: github.event.comment.author_association == 'MEMBER'
+        run: echo 'Comment author MEMBER'
+      - if: github.event.comment.author_association == 'NONE'
+        run: echo 'Comment author NONE'
+      - if: github.event.comment.author_association == 'OWNER'
+        run: echo 'Comment author OWNER'

--- a/.github/workflows/chatops-rebase.yml
+++ b/.github/workflows/chatops-rebase.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   rebase:
     name: Rebase
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase') && github.event.comment.author_association == 'MEMBER'
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/rebase') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code


### PR DESCRIPTION
- Add debug steps in chatops-rebase workflow

  It would be useful to know which of the conditions is not matching.
  Right now the workflow is always skipped and we don't know why.

- Allow more roles to use /rebase in PRs

  We were allowing only "MEMBER"s, but I think we also want to allow
  "COLLABORATOR"s, and "OWNER"s

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [x] Ensure that the PR is properly reviewed
