### PR TITLE
DEX-231: sighting validation

### DIFF
--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -44,7 +44,9 @@ class SightingCleanup(object):
     ):
         if log_message is None:
             log_message = message
-        log.error('Bailing on sighting creation: %r' % log_message)
+        log.error(
+            f'Bailing on sighting creation: {log_message} (error_fields {error_fields})'
+        )
         if self.sighting_guid is not None:
             log.warning('Cleanup removing Sighting %r from EDM' % self.sighting_guid)
             Sighting.delete_from_edm_by_guid(current_app, self.sighting_guid)

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -36,7 +36,11 @@ class SightingCleanup(object):
         self.submission = None
 
     def rollback_and_abort(
-        self, message='Unknown error', log_message=None, status_code=400, error_fields=None
+        self,
+        message='Unknown error',
+        log_message=None,
+        status_code=400,
+        error_fields=None,
     ):
         if log_message is None:
             log_message = message
@@ -48,7 +52,13 @@ class SightingCleanup(object):
             log.warning('Cleanup removing %r' % self.submission)
             self.submission.delete()
             self.submission = None
-        abort(success=False, passed_message=message, message='Error', errorFields=error_fields, code=status_code)
+        abort(
+            success=False,
+            passed_message=message,
+            message='Error',
+            errorFields=error_fields,
+            code=status_code,
+        )
 
 
 def _validate_asset_references(enc_list):
@@ -221,7 +231,7 @@ class Sightings(Resource):
                     cleanup.rollback_and_abort(
                         'Invalid submitter data',
                         f'Anonymous submitter using active user email {submitter_email}; rejecting',
-                        error_code=403,
+                        status_code=403,
                     )
         else:  # logged-in user
             owner = current_user
@@ -251,7 +261,9 @@ class Sightings(Resource):
                 passed_message = response_data['message']
             if response_data is not None and 'errorFields' in response_data:
                 error_fields = response_data['errorFields']
-            cleanup.rollback_and_abort(passed_message, 'Sighting.post failed', error_fields=error_fields)
+            cleanup.rollback_and_abort(
+                passed_message, 'Sighting.post failed', error_fields=error_fields
+            )
 
         # Created it, need to clean it up if we rollback
         cleanup.sighting_guid = result_data['id']

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -20,7 +20,7 @@ def test_create_failures(flask_app_client, researcher_1):
     assert response.json['passed_message'] == 'Must have at least one encounter'
     assert not response.json['success']
 
-    # has encounters, zero assetReferences, but fails on bad taxonomy
+    # has encounters, zero assetReferences, but fails on bad (missing) context value
     data_in = {'encounters': [{'taxonomy': {'id': '0000000'}}]}
     response = sighting_utils.create_sighting(
         flask_app_client, researcher_1, expected_status_code=400, data_in=data_in
@@ -29,7 +29,11 @@ def test_create_failures(flask_app_client, researcher_1):
     assert not response.json['success']
 
     # has encounters, but bunk assetReferences
-    data_in = {'encounters': [{'assetReferences': [{'fail': 'fail'}]}]}
+    data_in = {
+        'encounters': [{'assetReferences': [{'fail': 'fail'}]}],
+        'context': 'test',
+        'locationId': 'test',
+    }
     response = sighting_utils.create_sighting(
         flask_app_client, researcher_1, expected_status_code=400, data_in=data_in
     )
@@ -67,6 +71,8 @@ def test_create_and_delete_sighting(db, flask_app_client, researcher_1, staff_us
     transaction_id, test_filename = sighting_utils.prep_tus_dir()
     data_in = {
         'startTime': timestamp,
+        'context': 'test',
+        'locationId': 'test',
         'encounters': [
             {
                 'assetReferences': [
@@ -115,6 +121,8 @@ def test_create_anon_and_delete_sighting(db, flask_app_client, staff_user):
     transaction_id, test_filename = sighting_utils.prep_tus_dir()
     data_in = {
         'startTime': timestamp,
+        'context': 'test',
+        'locationId': 'test',
         'encounters': [
             {
                 'assetReferences': [
@@ -142,6 +150,8 @@ def test_create_anon_and_delete_sighting(db, flask_app_client, staff_user):
     # anonymous, but using valid (active) user - should be blocked with 403
     data_in = {
         'startTime': timestamp,
+        'context': 'test',
+        'locationId': 'test',
         'submitterEmail': 'public@localhost',
         'encounters': [{}],
     }
@@ -153,6 +163,8 @@ def test_create_anon_and_delete_sighting(db, flask_app_client, staff_user):
     test_email = 'test_anon_123@example.com'
     data_in = {
         'startTime': timestamp,
+        'context': 'test',
+        'locationId': 'test',
         'submitterEmail': test_email,
         'encounters': [{}],
     }

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -25,7 +25,7 @@ def test_create_failures(flask_app_client, researcher_1):
     response = sighting_utils.create_sighting(
         flask_app_client, researcher_1, expected_status_code=400, data_in=data_in
     )
-    assert 'invalid taxonomy' in response.json['passed_message']['details']
+    assert response.json['errorFields'][0] == 'context'
     assert not response.json['success']
 
     # has encounters, but bunk assetReferences

--- a/tests/modules/sightings/resources/utils.py
+++ b/tests/modules/sightings/resources/utils.py
@@ -48,7 +48,10 @@ def cleanup_tus_dir(tid):
 
 # note: default data_in will fail
 def create_sighting(
-    flask_app_client, user, expected_status_code=200, data_in={'location_id': 'PYTEST'}
+    flask_app_client,
+    user,
+    expected_status_code=200,
+    data_in={'locationId': 'PYTEST', 'context': 'test'},
 ):
     if user is not None:
         with flask_app_client.login(user):


### PR DESCRIPTION
## Pull Request Overview

- EDM now validates data coming in for sighting (etc) creation -- e.g. required fields, invalid values (lat/lon out of range) etc. -- and has a standard way to response (a **601** status code and listing of `errorFields`)
- houston will pass this through on api response (currently a **400** status code) as `errorFields: [ fieldName1, .... ]` property

---

**Review Notes**
- Some tests have been updated accordingly
- This update **_requires_ the most current EDM next-gen code** to be deployed in order for tests to pass  :warning: 



**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [ ] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
