### PR TITLE
Move non-critical path testing to nightly schedule

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,12 +45,186 @@ jobs:
 
       # Notify status in Slack
       - name: Slack Notification
-        if: ${{ failure() && github.event_name == 'schedule' }}
+        if: failure() && github.event_name == 'schedule'
         uses: rtCamp/action-slack-notify@master
         env:
-          SLACK_CHANNEL: ia-development
+          SLACK_CHANNEL: dev-houston
           SLACK_COLOR: '#FF0000'
           SLACK_ICON: https://avatars.slack-edge.com/2020-03-02/965719891842_db87aa21ccb61076f236_44.png
           SLACK_MESSAGE: 'nightly build failed :sob:'
+          SLACK_USERNAME: "Nightly"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  test_macos:
+    runs-on: macos-latest
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        python-version: [3.9, 3.8, 3.7]
+    steps:
+      # Checkout and env setup
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install libmagic on macOS
+        run: |
+          brew install libmagic
+
+      # Install and test - Test order is randomized, run three times to ensure correctness
+      - name: Reset local database
+        run: |
+          tar -zxvf _db.initial.tar.gz
+          mv _db.initial _db
+          ./scripts/install.sh
+
+      - name: Create frontend static directory (tests complains if static directory does not exist)
+        run: |
+          mkdir -p app/static/dist-latest
+          touch app/static/dist-latest/404.html
+          touch app/static/dist-latest/index.html
+
+      - name: Run tests (random x3)
+        run: |
+          source virtualenv/houston3.7/bin/activate
+          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
+          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
+          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
+
+      - name: Check DB migrations
+        run: |
+          source virtualenv/houston3.7/bin/activate
+          invoke app.db.downgrade
+          invoke app.db.upgrade
+
+      - name: Run tests after DB checks
+        run: |
+          source virtualenv/houston3.7/bin/activate
+          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
+
+      # Notify status in Slack
+      - name: Slack Notification
+        if: failure() && github.event_name == 'schedule'
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_CHANNEL: dev-houston
+          SLACK_COLOR: '#FF0000'
+          SLACK_ICON: https://avatars.slack-edge.com/2020-03-02/965719891842_db87aa21ccb61076f236_44.png
+          SLACK_MESSAGE: 'nightly test on MacOS failed :sob:'
+          SLACK_USERNAME: "Nightly"
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        python-version: [3.9, 3.8, 3.7]
+        db-uri: ["postgresql://postgres:testing@localhost/postgres", "sqlite://"]
+    services:
+      db:
+        image: postgres:10
+        env:
+          POSTGRES_PASSWORD: testing
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+      redis:
+        image: redis:latest
+        ports:
+          - 6379:6379
+    env:
+      OS: ubuntu-latest
+      PYTHON: ${{ matrix.python-version }}
+      SQLALCHEMY_DATABASE_URI: ${{ matrix.db-uri }}
+      GITLAB_REMOTE_LOGIN_PAT: ${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}
+    steps:
+      # Checkout and env setup
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install libmagic on Ubuntu
+        run: |
+          sudo apt install libmagic1
+
+      # Install and test - Test order is randomized, run three times to ensure correctness
+      - name: Reset local database
+        run: |
+          tar -zxvf _db.initial.tar.gz
+          mv _db.initial _db
+          ./scripts/install.sh
+
+      - name: Create frontend static directory (tests complains if static directory does not exist)
+        run: |
+          mkdir -p app/static/dist-latest
+          touch app/static/dist-latest/404.html
+          touch app/static/dist-latest/index.html
+
+      - name: Run tests (random x3)
+        run: |
+          source virtualenv/houston3.7/bin/activate
+          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
+          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
+          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
+
+      - name: Check DB migrations (sqlite)
+        if: matrix.db-uri == 'sqlite://'
+        run: |
+          source virtualenv/houston3.7/bin/activate
+          invoke app.db.downgrade
+          invoke app.db.upgrade
+        env:
+          # Don't use in memory sqlite database for database migration
+          SQLALCHEMY_DATABASE_URI: ''
+
+      - name: Check DB migrations (postgresql)
+        if: matrix.db-uri != 'sqlite://'
+        run: |
+          source virtualenv/houston3.7/bin/activate
+          invoke app.db.upgrade --no-backup
+          invoke app.db.downgrade
+          invoke app.db.upgrade --no-backup
+          if [ -n "$(invoke app.db.migrate)" ]; then echo Missing database migration; exit 1; fi
+
+      - name: Run tests after DB checks
+        run: |
+          source virtualenv/houston3.7/bin/activate
+          pytest --no-cov -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
+
+      # Notify status in Slack
+      - name: Slack Notification
+        if: failure() && github.event_name == 'schedule'
+        uses: rtCamp/action-slack-notify@master
+        env:
+          SLACK_CHANNEL: dev-houston
+          SLACK_COLOR: '#FF0000'
+          SLACK_ICON: https://avatars.slack-edge.com/2020-03-02/965719891842_db87aa21ccb61076f236_44.png
+          SLACK_MESSAGE: 'nightly tests on Linux failed :sob:'
           SLACK_USERNAME: "Nightly"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        # Use the same Python version used the Dockerfile
+        python-version: [3.9]
 
     steps:
       # Checkout and env setup
@@ -39,70 +40,14 @@ jobs:
           # exit-zero treats all errors as warnings.
           flake8 . --count --exit-zero --max-complexity=10 --statistics
 
-  test_macos:
-    runs-on: macos-latest
-    strategy:
-      max-parallel: 1
-      fail-fast: false
-      matrix:
-        python-version: [3.9, 3.8, 3.7]
-    steps:
-      # Checkout and env setup
-      - uses: actions/checkout@v2
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'requirements/*.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      - name: Install libmagic on macOS
-        run: |
-          brew install libmagic
-
-      # Install and test - Test order is randomized, run three times to ensure correctness
-      - name: Reset local database
-        run: |
-          tar -zxvf _db.initial.tar.gz
-          mv _db.initial _db
-          ./scripts/install.sh
-
-      - name: Create frontend static directory (tests complains if static directory does not exist)
-        run: |
-          mkdir -p app/static/dist-latest
-          touch app/static/dist-latest/404.html
-          touch app/static/dist-latest/index.html
-
-      - name: Run tests (random x3)
-        run: |
-          source virtualenv/houston3.7/bin/activate
-          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
-          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
-          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
-
-      - name: Check DB migrations
-        run: |
-          source virtualenv/houston3.7/bin/activate
-          invoke app.db.downgrade
-          invoke app.db.upgrade
-
-      - name: Run tests after DB checks
-        run: |
-          source virtualenv/houston3.7/bin/activate
-          pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
-
   test:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 1
       fail-fast: false
       matrix:
-        python-version: [3.9, 3.8, 3.7]
+        # Use the same Python version used the Dockerfile
+        python-version: [3.9]
         db-uri: ["postgresql://postgres:testing@localhost/postgres", "sqlite://"]
     services:
       db:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -133,8 +133,7 @@ jobs:
           source virtualenv/houston3.7/bin/activate
           pytest --no-cov -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
 
-      - name: Run Codecov (3.9)
-        if: matrix.python-version == '3.9'
+      - name: Run Codecov
         continue-on-error: true
         run: |
           source virtualenv/houston3.7/bin/activate
@@ -143,14 +142,12 @@ jobs:
           pytest -s -v -m separate tests/test_transactions.py::test_transactions[None-commit_or_abort] --cov-append
 
       - name: Run other invoke tasks for coverage and errors
-        if: matrix.python-version == '3.9'
         run: |
           source virtualenv/houston3.7/bin/activate
           ./scripts/run_tasks_for_coverage.sh
           coverage xml
 
-      - name: Upload coverage to Codecov (3.9)
-        if: matrix.python-version == '3.9'
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,7 +43,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 1
       fail-fast: false
       matrix:
         # Use the same Python version used the Dockerfile


### PR DESCRIPTION
## Pull Request Overview

This changes our PR tests to run critical path testing that focuses on the following environments:
- Python 3.9 with SQLite
- Python 3.9 with Postgres

The goal is to test the critical path--that which we deploy with--for change acceptance.
The focus is on producing deployable code and a more responsive development workflow that concentrates on producing deployable code.

This moves the non-critical testing paths to the nightly scheduled workflow. We'll still be notified in the event that PR changes do cause problems on the mac or in other versions of python.

---

We're moving in this direction because _soon_ we'll be pulling in externally run and deployed services as services setup and local to these tests. For example, we'll be pulling in a local instance of EDM as a service running alongside the tests. This will mean that the developer can move to a new version of EDM without needing to bump the externally deployed service. Thus we're able to isolate the changes without effecting other developers in the process (enabling better parallel working).

---

**Review Notes**

Not much to review... just ensure all the CI bits are running through successfully.

The slack notification to the `#dev-houston` channel is working, I've tested it.

**Pull Request Checklist**
- [X] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [X] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [X] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [X] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [X] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [X] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [x] Ensure that the PR is properly reviewed
