### PR TITLE
Retry gitlab project listing

### DIFF
--- a/app/extensions/submission/__init__.py
+++ b/app/extensions/submission/__init__.py
@@ -156,7 +156,9 @@ class SubmissionManager(object):
         if remote:
             self.ensure_initialized()
 
-            projects = self.gl.projects.list(search=str(submission.guid))
+            projects = self.gl.projects.list(
+                search=str(submission.guid), retry_transient_errors=True
+            )
             if len(projects) > 0:
                 assert len(projects) == 1
                 project_ = projects[0]
@@ -269,7 +271,9 @@ class SubmissionManager(object):
         self.ensure_initialized()
 
         # Try to find remote project by Submission UUID
-        projects = self.gl.projects.list(search=str(submission_uuid))
+        projects = self.gl.projects.list(
+            search=str(submission_uuid), retry_transient_errors=True
+        )
         return len(projects) == 1
 
     def ensure_submission(self, submission_uuid, owner=None):
@@ -282,7 +286,9 @@ class SubmissionManager(object):
             self.ensure_initialized()
 
             # Try to find remote project by Submission UUID
-            projects = self.gl.projects.list(search=str(submission_uuid))
+            projects = self.gl.projects.list(
+                search=str(submission_uuid), retry_transient_errors=True
+            )
             if len(projects) == 0:
                 # submission is not found either locally or remote, return None
                 return None

--- a/tasks/app/consistency.py
+++ b/tasks/app/consistency.py
@@ -100,7 +100,9 @@ def cleanup_gitlab(context, dryrun=False, clean=False):
             for page in tqdm.tqdm(
                 range(1, MAX_PAGES + 2), desc='Fetching GitLab Project Pages'
             ):
-                projects_page = group.projects.list(per_page=PER_PAGE, page=page)
+                projects_page = group.projects.list(
+                    per_page=PER_PAGE, page=page, retry_transient_errors=True
+                )
 
                 if len(projects_page) == 0:
                     log.warn('Reached maximum page: %d' % (page,))

--- a/tasks/app/initialize.py
+++ b/tasks/app/initialize.py
@@ -96,7 +96,9 @@ def initialize_gitlab_submissions(context, email, dryrun=False):
     for submission_guid, submission_data in submission_data:
 
         current_app.sub.ensure_initialized()
-        projects = current_app.sub.gl.projects.list(search=str(submission_guid))
+        projects = current_app.sub.gl.projects.list(
+            search=str(submission_guid), retry_transient_errors=True
+        )
 
         if len(projects) > 0:
             assert len(projects) == 1


### PR DESCRIPTION
## Pull Request Overview

We're running into a routine error associated with searching the
project list in gitlab. The error is a 502 from gitlab that suggests
retrying the request. So this retries the request (up to the default
10 times).

See also the python-gitlab [transient errors](https://python-gitlab.readthedocs.io/en/stable/api-usage.html?highlight=retry#transient-errors) info.

Example traceback from a test failure
```
________________________ test_asset_file_addition[None] ________________________

args = (<gitlab.v4.objects.ProjectManager object at 0x7f5eaefa5ac0>,)
kwargs = {'search': 'df6774ed-d78c-465c-a0eb-08e4500e109c'}

    @functools.wraps(f)
    def wrapped_f(*args, **kwargs):
        try:
>           return f(*args, **kwargs)

/usr/local/lib/python3.9/site-packages/gitlab/exceptions.py:279:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <gitlab.v4.objects.ProjectManager object at 0x7f5eaefa5ac0>
kwargs = {'search': 'df6774ed-d78c-465c-a0eb-08e4500e109c'}
data = {'search': 'df6774ed-d78c-465c-a0eb-08e4500e109c'}
types = {'avatar': <class 'gitlab.types.ImageAttribute'>}, attr_name = 'avatar'
type_cls = <class 'gitlab.types.ImageAttribute'>, path = '/projects'

    @exc.on_http_error(exc.GitlabListError)
    def list(self, **kwargs):
        """Retrieve a list of objects.

        Args:
            all (bool): If True, return all the items, without pagination
            per_page (int): Number of items to retrieve per request
            page (int): ID of the page to return (starts with page 1)
            as_list (bool): If set to False and no pagination option is
                defined, return a generator instead of a list
            **kwargs: Extra options to send to the server (e.g. sudo)

        Returns:
            list: The list of objects, or a generator if `as_list` is False

        Raises:
            GitlabAuthenticationError: If authentication is not correct
            GitlabListError: If the server cannot perform the request
        """

        # Duplicate data to avoid messing with what the user sent us
        data = kwargs.copy()
        if self.gitlab.per_page:
            data.setdefault("per_page", self.gitlab.per_page)

        # global keyset pagination
        if self.gitlab.pagination:
            data.setdefault("pagination", self.gitlab.pagination)

        if self.gitlab.order_by:
            data.setdefault("order_by", self.gitlab.order_by)

        # We get the attributes that need some special transformation
        types = getattr(self, "_types", {})
        if types:
            for attr_name, type_cls in types.items():
                if attr_name in data.keys():
                    type_obj = type_cls(data[attr_name])
                    data[attr_name] = type_obj.get_for_api()

        # Allow to overwrite the path, handy for custom listings
        path = data.pop("path", self.path)

>       obj = self.gitlab.http_list(path, **data)

/usr/local/lib/python3.9/site-packages/gitlab/mixins.py:141:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <gitlab.Gitlab object at 0x7f5eaef4abb0>, path = '/projects'
query_data = {}, as_list = True
kwargs = {'search': 'df6774ed-d78c-465c-a0eb-08e4500e109c'}, get_all = False
url = 'http://gitlab/api/v4/projects', page = None

    def http_list(self, path, query_data=None, as_list=None, **kwargs):
        """Make a GET request to the Gitlab server for list-oriented queries.

        Args:
            path (str): Path or full URL to query ('/projects' or
                        'http://whatever/v4/api/projects')
            query_data (dict): Data to send as query parameters
            **kwargs: Extra options to send to the server (e.g. sudo, page,
                      per_page)

        Returns:
            list: A list of the objects returned by the server. If `as_list` is
            False and no pagination-related arguments (`page`, `per_page`,
            `all`) are defined then a GitlabList object (generator) is returned
            instead. This object will make API calls when needed to fetch the
            next items from the server.

        Raises:
            GitlabHttpError: When the return code is not 2xx
            GitlabParsingError: If the json data could not be parsed
        """
        query_data = query_data or {}

        # In case we want to change the default behavior at some point
        as_list = True if as_list is None else as_list

        get_all = kwargs.pop("all", False)
        url = self._build_url(path)

        page = kwargs.get("page")

        if get_all is True and as_list is True:
            return list(GitlabList(self, url, query_data, **kwargs))

        if page or as_list is True:
            # pagination requested, we return a list
>           return list(GitlabList(self, url, query_data, get_next=False, **kwargs))

/usr/local/lib/python3.9/site-packages/gitlab/__init__.py:648:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <gitlab.GitlabList object at 0x7f5eae242610>
gl = <gitlab.Gitlab object at 0x7f5eaef4abb0>
url = 'http://gitlab/api/v4/projects', query_data = {}, get_next = False
kwargs = {'search': 'df6774ed-d78c-465c-a0eb-08e4500e109c'}

    def __init__(self, gl, url, query_data, get_next=True, **kwargs):
        self._gl = gl

        # Preserve kwargs for subsequent queries
        self._kwargs = kwargs.copy()

>       self._query(url, query_data, **self._kwargs)

/usr/local/lib/python3.9/site-packages/gitlab/__init__.py:779:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <gitlab.GitlabList object at 0x7f5eae242610>
url = 'http://gitlab/api/v4/projects', query_data = {}
kwargs = {'search': 'df6774ed-d78c-465c-a0eb-08e4500e109c'}

    def _query(self, url, query_data=None, **kwargs):
        query_data = query_data or {}
>       result = self._gl.http_request("get", url, query_data=query_data, **kwargs)

/usr/local/lib/python3.9/site-packages/gitlab/__init__.py:784:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <gitlab.Gitlab object at 0x7f5eaef4abb0>, verb = 'get'
path = 'http://gitlab/api/v4/projects', query_data = {}, post_data = None
streamed = False, files = None
kwargs = {'search': 'df6774ed-d78c-465c-a0eb-08e4500e109c'}
url = 'http://gitlab/api/v4/projects'
params = {'search': 'df6774ed-d78c-465c-a0eb-08e4500e109c'}
opts = {'auth': None, 'headers': {'Content-type': 'application/json', 'PRIVATE-TOKEN': 'aHLzy3yTLDXKzowZmR-p', 'User-Agent': 'python-gitlab/2.6.0'}}
verify = True, timeout = None, json = None

    def http_request(
        self,
        verb,
        path,
        query_data=None,
        post_data=None,
        streamed=False,
        files=None,
        **kwargs
    ):
        """Make an HTTP request to the Gitlab server.

        Args:
            verb (str): The HTTP method to call ('get', 'post', 'put',
                        'delete')
            path (str): Path or full URL to query ('/projects' or
                        'http://whatever/v4/api/projecs')
            query_data (dict): Data to send as query parameters
            post_data (dict): Data to send in the body (will be converted to
                              json)
            streamed (bool): Whether the data should be streamed
            files (dict): The files to send to the server
            **kwargs: Extra options to send to the server (e.g. sudo)

        Returns:
            A requests result object.

        Raises:
            GitlabHttpError: When the return code is not 2xx
        """
        query_data = query_data or {}
        url = self._build_url(path)

        params = {}
        utils.copy_dict(params, query_data)

        # Deal with kwargs: by default a user uses kwargs to send data to the
        # gitlab server, but this generates problems (python keyword conflicts
        # and python-gitlab/gitlab conflicts).
        # So we provide a `query_parameters` key: if it's there we use its dict
        # value as arguments for the gitlab server, and ignore the other
        # arguments, except pagination ones (per_page and page)
        if "query_parameters" in kwargs:
            utils.copy_dict(params, kwargs["query_parameters"])
            for arg in ("per_page", "page"):
                if arg in kwargs:
                    params[arg] = kwargs[arg]
        else:
            utils.copy_dict(params, kwargs)

        opts = self._get_session_opts(content_type="application/json")

        verify = opts.pop("verify")
        timeout = opts.pop("timeout")
        # If timeout was passed into kwargs, allow it to override the default
        timeout = kwargs.get("timeout", timeout)

        # We need to deal with json vs. data when uploading files
        if files:
            json = None
            post_data["file"] = files.get("file")
            post_data["avatar"] = files.get("avatar")
            data = MultipartEncoder(post_data)
            opts["headers"]["Content-type"] = data.content_type
        else:
            json = post_data
            data = None

        # Requests assumes that `.` should not be encoded as %2E and will make
        # changes to urls using this encoding. Using a prepped request we can
        # get the desired behavior.
        # The Requests behavior is right but it seems that web servers don't
        # always agree with this decision (this is the case with a default
        # gitlab installation)
        req = requests.Request(verb, url, json=json, data=data, params=params, **opts)
        prepped = self.session.prepare_request(req)
        prepped.url = utils.sanitized_url(prepped.url)
        settings = self.session.merge_environment_settings(
            prepped.url, {}, streamed, verify, None
        )

        # obey the rate limit by default
        obey_rate_limit = kwargs.get("obey_rate_limit", True)
        # do not retry transient errors by default
        retry_transient_errors = kwargs.get("retry_transient_errors", False)

        # set max_retries to 10 by default, disable by setting it to -1
        max_retries = kwargs.get("max_retries", 10)
        cur_retries = 0

        while True:
            result = self.session.send(prepped, timeout=timeout, **settings)

            self._check_redirects(result)

            if 200 <= result.status_code < 300:
                return result

            if (429 == result.status_code and obey_rate_limit) or (
                result.status_code in [500, 502, 503, 504] and retry_transient_errors
            ):
                if max_retries == -1 or cur_retries < max_retries:
                    wait_time = 2 ** cur_retries * 0.1
                    if "Retry-After" in result.headers:
                        wait_time = int(result.headers["Retry-After"])
                    cur_retries += 1
                    time.sleep(wait_time)
                    continue

            error_message = result.content
            try:
                error_json = result.json()
                for k in ("message", "error"):
                    if k in error_json:
                        error_message = error_json[k]
            except (KeyError, ValueError, TypeError):
                pass

            if result.status_code == 401:
                raise GitlabAuthenticationError(
                    response_code=result.status_code,
                    error_message=error_message,
                    response_body=result.content,
                )

>           raise GitlabHttpError(
                response_code=result.status_code,
                error_message=error_message,
                response_body=result.content,
            )
E           gitlab.exceptions.GitlabHttpError: 502: <!DOCTYPE html>
E           <html>
E           <head>
E             <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
E             <title>GitLab is not responding (502)</title>
E             <style>
E               body {
E                 color: #666;
E                 text-align: center;
E                 font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
E                 margin: auto;
E                 font-size: 14px;
E               }
E
E               h1 {
E                 font-size: 56px;
E                 line-height: 100px;
E                 font-weight: 400;
E                 color: #456;
E               }
E
E               h2 {
E                 font-size: 24px;
E                 color: #666;
E                 line-height: 1.5em;
E               }
E
E               h3 {
E                 color: #456;
E                 font-size: 20px;
E                 font-weight: 400;
E                 line-height: 28px;
E               }
E
E               hr {
E                 max-width: 800px;
E                 margin: 18px auto;
E                 border: 0;
E                 border-top: 1px solid #EEE;
E                 border-bottom: 1px solid white;
E               }
E
E               img {
E                 max-width: 40vw;
E                 display: block;
E                 margin: 40px auto;
E               }
E
E               a {
E                 line-height: 100px;
E                 font-weight: 400;
E                 color: #4A8BEE;
E                 font-size: 18px;
E                 text-decoration: none;
E               }
E
E               .container {
E                 margin: auto 20px;
E               }
E
E               .go-back {
E                 display: none;
E               }
E
E             </style>
E           </head>
E
E           <body>
E             <a href="/">
E               <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo="
E                  alt="GitLab Logo" />
E             </a>
E             <h1>
E               502
E             </h1>
E             <div class="container">
E               <h3>Whoops, GitLab is taking too much time to respond.</h3>
E               <hr />
E               <p>Try refreshing the page, or going back and attempting the action again.</p>
E               <p>Please contact your GitLab administrator if this problem persists.</p>
E               <a href="javascript:history.back()" class="js-go-back go-back">Go back</a>
E             </div>
E             <script>
E               (function () {
E                 var goBack = document.querySelector('.js-go-back');
E
E                 if (history.length > 1) {
E                   goBack.style.display = 'inline';
E                 }
E               })();
E             </script>
E           </body>
E           </html>

/usr/local/lib/python3.9/site-packages/gitlab/__init__.py:567: GitlabHttpError

The above exception was the direct cause of the following exception:

db = <SQLAlchemy engine=***db/houston>
flask_app_client = <AutoAuthFlaskClient <Flask 'app'>>
researcher_1 = <User(guid=ef5502bb-a9ed-4d00-a538-a03d60661d1f, email="researcher1@localhost", name="First Middle Last", state=Active, Alpha, roles=Contributor, Researcher)>

    def test_asset_file_addition(db, flask_app_client, researcher_1):
        # pylint: disable=invalid-name
        from app.modules.encounters.models import Encounter

        new_encounter = Encounter(owner=researcher_1)

        with db.session.begin():
            db.session.add(new_encounter)
        try:
            add_file_asset_to_encounter(
                flask_app_client,
                researcher_1,
                new_encounter,
                'new_stuff',
                'new_file.csv',
                '1,2,3,4,5',
            )
            assert len(new_encounter.assets) == 1
            add_file_asset_to_encounter(
                flask_app_client,
                researcher_1,
                new_encounter,
                'more_stuff',
                'next_file.csv',
                '5,4,3,2,1',
            )
            assert len(new_encounter.assets) == 2
            with flask_app_client.login(researcher_1, auth_scopes=('encounters:write',)):
                response = flask_app_client.delete(
                    '%s%s' % (PATH, new_encounter.guid),
                )

            # The Submission will be in gitlab but not on the EDM so the delete will "fail"
            assert response.status_code == 400
        except Exception as ex:
            raise ex
        finally:
            # Even though the REST API deletion fails, as it's not present, the Houston feather object remains.
            new_encounter.delete()
            # assets are only cleaned up once the submissions are cleaned up
            for submission in researcher_1.submissions:
>               current_app.sub.delete_remote_submission(submission)

tests/modules/encounters/resources/test_modify_encounter.py:159:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
app/extensions/submission/__init__.py:318: in delete_remote_submission
    repo, project = current_app.sub.ensure_repository(submission)
app/extensions/submission/__init__.py:159: in ensure_repository
    projects = self.gl.projects.list(search=str(submission.guid))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = (<gitlab.v4.objects.ProjectManager object at 0x7f5eaefa5ac0>,)
kwargs = {'search': 'df6774ed-d78c-465c-a0eb-08e4500e109c'}

    @functools.wraps(f)
    def wrapped_f(*args, **kwargs):
        try:
            return f(*args, **kwargs)
        except GitlabHttpError as e:
>           raise error(e.error_message, e.response_code, e.response_body) from e
E           gitlab.exceptions.GitlabListError: 502: <!DOCTYPE html>
E           <html>
E           <head>
E             <meta content="width=device-width, initial-scale=1, maximum-scale=1" name="viewport">
E             <title>GitLab is not responding (502)</title>
E             <style>
E               body {
E                 color: #666;
E                 text-align: center;
E                 font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
E                 margin: auto;
E                 font-size: 14px;
E               }
E
E               h1 {
E                 font-size: 56px;
E                 line-height: 100px;
E                 font-weight: 400;
E                 color: #456;
E               }
E
E               h2 {
E                 font-size: 24px;
E                 color: #666;
E                 line-height: 1.5em;
E               }
E
E               h3 {
E                 color: #456;
E                 font-size: 20px;
E                 font-weight: 400;
E                 line-height: 28px;
E               }
E
E               hr {
E                 max-width: 800px;
E                 margin: 18px auto;
E                 border: 0;
E                 border-top: 1px solid #EEE;
E                 border-bottom: 1px solid white;
E               }
E
E               img {
E                 max-width: 40vw;
E                 display: block;
E                 margin: 40px auto;
E               }
E
E               a {
E                 line-height: 100px;
E                 font-weight: 400;
E                 color: #4A8BEE;
E                 font-size: 18px;
E                 text-decoration: none;
E               }
E
E               .container {
E                 margin: auto 20px;
E               }
E
E               .go-back {
E                 display: none;
E               }
E
E             </style>
E           </head>
E
E           <body>
E             <a href="/">
E               <img src="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjEwIiBoZWlnaHQ9IjIxMCIgdmlld0JveD0iMCAwIDIxMCAyMTAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTVsMzguNjQtMTE4LjkyMWgtNzcuMjhsMzguNjQgMTE4LjkyMXoiIGZpbGw9IiNlMjQzMjkiLz4KICA8cGF0aCBkPSJNMTA1LjA2MTQgMjAzLjY1NDhsLTM4LjY0LTExOC45MjFoLTU0LjE1M2w5Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTIuMjY4NSA4NC43MzQxbC0xMS43NDIgMzYuMTM5Yy0xLjA3MSAzLjI5Ni4xMDIgNi45MDcgMi45MDYgOC45NDRsMTAxLjYyOSA3My44MzgtOTIuNzkzLTExOC45MjF6IiBmaWxsPSIjZmNhMzI2Ii8+CiAgPHBhdGggZD0iTTEyLjI2ODUgODQuNzM0Mmg1NC4xNTNsLTIzLjI3My03MS42MjVjLTEuMTk3LTMuNjg2LTYuNDExLTMuNjg1LTcuNjA4IDBsLTIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+CiAgPHBhdGggZD0iTTEwNS4wNjE0IDIwMy42NTQ4bDM4LjY0LTExOC45MjFoNTQuMTUzbC05Mi43OTMgMTE4LjkyMXoiIGZpbGw9IiNmYzZkMjYiLz4KICA8cGF0aCBkPSJNMTk3Ljg1NDQgODQuNzM0MWwxMS43NDIgMzYuMTM5YzEuMDcxIDMuMjk2LS4xMDIgNi45MDctMi45MDYgOC45NDRsLTEwMS42MjkgNzMuODM4IDkyLjc5My0xMTguOTIxeiIgZmlsbD0iI2ZjYTMyNiIvPgogIDxwYXRoIGQ9Ik0xOTcuODU0NCA4NC43MzQyaC01NC4xNTNsMjMuMjczLTcxLjYyNWMxLjE5Ny0zLjY4NiA2LjQxMS0zLjY4NSA3LjYwOCAwbDIzLjI3MiA3MS42MjV6IiBmaWxsPSIjZTI0MzI5Ii8+Cjwvc3ZnPgo="
E                  alt="GitLab Logo" />
E             </a>
E             <h1>
E               502
E             </h1>
E             <div class="container">
E               <h3>Whoops, GitLab is taking too much time to respond.</h3>
E               <hr />
E               <p>Try refreshing the page, or going back and attempting the action again.</p>
E               <p>Please contact your GitLab administrator if this problem persists.</p>
E               <a href="javascript:history.back()" class="js-go-back go-back">Go back</a>
E             </div>
E             <script>
E               (function () {
E                 var goBack = document.querySelector('.js-go-back');
E
E                 if (history.length > 1) {
E                   goBack.style.display = 'inline';
E                 }
E               })();
E             </script>
E           </body>
E           </html>

/usr/local/lib/python3.9/site-packages/gitlab/exceptions.py:281: GitlabListError
```


---

**Review Notes**

Not much to review. Take a look at the python-gitlab docs and my usage. This generally seems like a good idea, no?

**Pull Request Checklist**
- [X] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [X] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [X] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [X] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [X] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
