### PR TITLE
quick edm task fix

### DIFF
--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -103,6 +103,7 @@ class EDMManager(RestManager):
             json.dumps(edm_data),
             target=target,
         )
+        current_app.edm.initialized = False
         current_app.config['EDM_AUTHENTICATIONS'] = auth_orig
         if data.get('success', False):
             edm_auth = current_app.config.get('EDM_AUTHENTICATIONS', {})

--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -95,11 +95,15 @@ class EDMManager(RestManager):
             }
         }
         target = 'default'  # TODO will we create admin on other targets?
+        # we unset EDM_AUTHENTICATIONS here so the get_dict() request will *not* try to authenticate; then set it back after. hacktacular!
+        auth_orig = current_app.config.get('EDM_AUTHENTICATIONS', {})
+        current_app.config['EDM_AUTHENTICATIONS'] = None
         data = current_app.edm.get_dict(
             'configuration.init',
             json.dumps(edm_data),
             target=target,
         )
+        current_app.config['EDM_AUTHENTICATIONS'] = auth_orig
         if data.get('success', False):
             edm_auth = current_app.config.get('EDM_AUTHENTICATIONS', {})
             edm_auth[target] = {'username': email, 'password': password}

--- a/tasks/app/initialize.py
+++ b/tasks/app/initialize.py
@@ -17,8 +17,9 @@ def initialize_edm_admin_user(context):
     """Set up EDM admin user"""
     from flask import current_app
 
-    email = 'admin@example.com'
-    password = current_app.config['EDM_AUTHENTICATIONS']['default']['password']
+    def_vals = current_app.config.get('EDM_AUTHENTICATIONS', {}).get('default', {})
+    email = def_vals.get('username', 'admin@example.com')
+    password = def_vals.get('password', 'test1234')
     log.info('Initializing EDM admin user')
     success = current_app.edm.initialize_edm_admin_user(email, password)
     if not success:


### PR DESCRIPTION
:warning:  **_holding off on this ... @mmulich and i may have a workaround / better solution_**
## Pull Request Overview

- edm `initialize_edm_admin_user()` needs to function in 2 different scenarios:  when no `EDM_AUTHENTICATIONS` values are set via env variables; and when they are
- change allows this function to call `edm.get_dict()` in both cases, _but always with an unauthenticated edm session_
- this sidesteps the problem that when env vars are set `edm.get_dict()` wants to force an authenticated session but the username/password are for a user **not yet created** on edm.

**Pull Request Checklist**
- [ ] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [ ] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [ ] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [ ] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [ ] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [ ] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
