### PR TITLE
Refactor EDM init admin user logic

### DIFF
--- a/.dockerfiles/docker-entrypoint.sh
+++ b/.dockerfiles/docker-entrypoint.sh
@@ -114,8 +114,6 @@ _main() {
 			# FIXME: `--no-backup` is necessary because this apparently has the side-effect
 			#        of doing doing a backup for a database it may not know how to backup.
 			gosu nobody invoke app.db.upgrade --no-backup
-			# Assume a possible need to initialize the EDM admin user
-			gosu nobody invoke app.initialize.initialize-edm-admin-user
 
 			if [ -d /docker-entrypoint-init.d ]; then
 				docker_process_init_files /docker-entrypoint-init.d/*

--- a/deploy/codex/docker-compose.yml
+++ b/deploy/codex/docker-compose.yml
@@ -91,6 +91,10 @@ services:
       DB_USER: "${WILDBOOK_DB_USER}"
       DB_PASSWORD: "${WILDBOOK_DB_PASSWORD}"
       DB_CONNECTION_URL: "${WILDBOOK_DB_CONNECTION_URL}"
+      # Admin user created on startup,
+      # https://github.com/WildMeOrg/Wildbook/commit/6d65e70e43691f1b281bb76edf151e5c7cdb7403
+      ADMIN_EMAIL: "${EDM_AUTHENTICATIONS_USERNAME__DEFAULT}"
+      ADMIN_PASSWORD: "${EDM_AUTHENTICATIONS_PASSWORD__DEFAULT}"
 
   houston:
     # https://github.com/WildMeOrg/houston


### PR DESCRIPTION
## Pull Request Overview

This initialization logic is now moved into the EDM container.

See also,
https://github.com/WildMeOrg/Wildbook/commit/6d65e70e43691f1b281bb76edf151e5c7cdb7403

Basically, EDM can tie their own shoes now and doesn't need Houston to
do that for them.

Addresses a similar issue as resolved in #114, just in a different area of the system. Instead of Houston defining the initial admin user, Houston can now assume that the EDM is ready to be acted upon with the credentials it has been given.

---

**Review Notes**

Mostly looking to verify the understanding on the moving parts. This change is not currently tested, but will be as part of #109 

**Pull Request Checklist**
- [X] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [X] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [X] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [X] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [X] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [X] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
