### PR TITLE
DEX-236 get sightings for user

### DIFF
--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -42,6 +42,7 @@ class EDMManager(RestManager):
         'user': {
             'list': '//v0/org.ecocean.User/list',
             'data': '//v0/org.ecocean.User/%s',
+            'data_complete': '//v0/org.ecocean.User/%s?detail-org.ecocean.User=max',
         },
         'encounter': {
             'list': '//v0/org.ecocean.Encounter/list',

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -30,7 +30,7 @@ class Sighting(db.Model, FeatherModel):
 
     def get_owners(self):
         owners = []
-        for encounter in self.owned_encounters:
+        for encounter in self.get_encounters():
             if encounter.get_owner() is not None and encounter.get_owner() not in owners:
                 owners.append(encounter.get_owner())
         return owners

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -30,7 +30,7 @@ class Sighting(db.Model, FeatherModel):
 
     def get_owners(self):
         owners = []
-        for encounter in self.get_encounters():
+        for encounter in self.owned_encounters:
             if encounter.get_owner() is not None and encounter.get_owner() not in owners:
                 owners.append(encounter.get_owner())
         return owners

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -622,3 +622,10 @@ class User(db.Model, FeatherModel, UserEDMMixin):
             full_name='Public User',
             is_internal=True,
         )
+
+    def get_sightings(self):
+        sightings = []
+        for encounter in self.owned_encounters:
+            if encounter.get_sighting() not in sightings:
+                sightings.append(encounter.get_sighting())
+        return sightings

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -626,6 +626,6 @@ class User(db.Model, FeatherModel, UserEDMMixin):
     def get_sightings(self):
         sightings = []
         for encounter in self.owned_encounters:
-            if encounter.get_sighting() not in sightings:
-                sightings.append(encounter.get_sighting())
-        return sightings
+            sightings.append(encounter.get_sighting())
+        sighting_set = set(sightings)
+        return list(sighting_set)

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -286,6 +286,13 @@ class UserSightings(Resource):
     """
 
     @api.login_required(oauth_scopes=['users:read'])
+    @api.permission_required(
+        permissions.ObjectAccessPermission,
+        kwargs_on_request=lambda kwargs: {
+            'obj': kwargs['user'],
+            'action': AccessOperation.READ,
+        },
+    )
     def get(self, user):
         """
         Get Sightings for user with EDM metadata

--- a/tests/modules/users/resources/test_getting_users_info.py
+++ b/tests/modules/users/resources/test_getting_users_info.py
@@ -130,7 +130,7 @@ def test_getting_sightings_for_user(flask_app_client, db, staff_user):
     }
 
     sighting_create_response = sighting_utils.create_sighting(
-        flask_app_client, temp_owner, expected_status_code=200, data_in=data_in
+        flask_app_client, temp_owner, data_in
     )
 
     from app.modules.sightings.models import Sighting

--- a/tests/modules/users/resources/test_getting_users_info.py
+++ b/tests/modules/users/resources/test_getting_users_info.py
@@ -114,12 +114,12 @@ def test_getting_user_id_not_found(flask_app_client, regular_user):
         assert response.status_code == 404
 
 
-def test_getting_sightings_for_user(flask_app_client, staff_user):
+def test_getting_sightings_for_user(flask_app_client, staff_user, db):
 
     from tests.modules.sightings.resources import utils as sighting_utils
 
     temp_owner = utils.generate_user_instance(
-        email='owner@localhost',
+        email='user_4_sightings@localhost',
         is_researcher=True,
     )
 
@@ -156,3 +156,5 @@ def test_getting_sightings_for_user(flask_app_client, staff_user):
 
     # cleanup time
     sighting_utils.delete_sighting(flask_app_client, staff_user, sighting_id)
+    with db.session.begin():
+        db.session.delete(temp_owner)

--- a/tests/modules/users/resources/test_getting_users_info.py
+++ b/tests/modules/users/resources/test_getting_users_info.py
@@ -114,7 +114,7 @@ def test_getting_user_id_not_found(flask_app_client, regular_user):
         assert response.status_code == 404
 
 
-def test_getting_sightings_for_user(flask_app_client, staff_user, db):
+def test_getting_sightings_for_user(flask_app_client, db, staff_user):
 
     from tests.modules.sightings.resources import utils as sighting_utils
 
@@ -155,6 +155,6 @@ def test_getting_sightings_for_user(flask_app_client, staff_user, db):
     assert response.json['success'] is True
 
     # cleanup time
-    sighting_utils.delete_sighting(flask_app_client, staff_user, sighting_id)
+    sighting_utils.delete_sighting(flask_app_client, temp_owner, sighting_id)
     with db.session.begin():
         db.session.delete(temp_owner)

--- a/tests/modules/users/resources/test_getting_users_info.py
+++ b/tests/modules/users/resources/test_getting_users_info.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 import pytest
+from tests import utils
 
 
 @pytest.mark.parametrize(
@@ -111,3 +112,47 @@ def test_getting_user_id_not_found(flask_app_client, regular_user):
     ):
         response = flask_app_client.get('/api/v1/users/wrong-uuid')
         assert response.status_code == 404
+
+
+def test_getting_sightings_for_user(flask_app_client, staff_user):
+
+    from tests.modules.sightings.resources import utils as sighting_utils
+
+    temp_owner = utils.generate_user_instance(
+        email='owner@localhost',
+        is_researcher=True,
+    )
+
+    data_in = {
+        'encounters': [{}],
+        'context': 'test',
+        'locationId': 'test',
+    }
+
+    sighting_create_response = sighting_utils.create_sighting(
+        flask_app_client, temp_owner, expected_status_code=200, data_in=data_in
+    )
+
+    from app.modules.sightings.models import Sighting
+
+    sighting_id = sighting_create_response.json['result']['id']
+    sighting = Sighting.query.get(sighting_id)
+
+    assert sighting_create_response.json['success']
+    assert sighting is not None
+    assert sighting.encounters[0].owner is temp_owner
+    assert str(temp_owner.get_sightings()[0].guid) == sighting_id
+
+    with flask_app_client.login(temp_owner, auth_scopes=('users:read',)):
+        response = flask_app_client.get('/api/v1/users/%s/sightings' % (temp_owner.guid))
+
+    assert response.status_code == 200
+    assert response.content_type == 'application/json'
+    assert isinstance(response.json, dict)
+
+    assert response.json['sightings'] is not None
+    assert response.json['sightings'][0]['id'] == sighting_id
+    assert response.json['success'] is True
+
+    # cleanup time
+    sighting_utils.delete_sighting(flask_app_client, staff_user, sighting_id)


### PR DESCRIPTION
## Pull Request Overview

Adds an endpoint to retrieve sighting JSON for all sightings owned by a user.

DEX-236

---

**Review Notes**
- Test should cover behavior with passthrough and cleanup.

```
[GET] /api/v1/users/<user guid>/sightings

```

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
