### PR TITLE
Fix set_up_gitlab no such option error in docker-compose

### DIFF
--- a/deploy/codex/houston/docker-entrypoint-init.d/set_up_gitlab.sh
+++ b/deploy/codex/houston/docker-entrypoint-init.d/set_up_gitlab.sh
@@ -54,7 +54,7 @@ EOF
     group_resp_json=$(gitlab -g local-user group create --name TEST --path test)
 
     echo "Write 'houston' PAT to ${HOUSTON_DOTENV}"
-    dotenv -f ${HOUSTON_DOTENV} set GITLAB_REMOTE_LOGIN_PAT "${houston_pat}"
+    dotenv -f ${HOUSTON_DOTENV} set GITLAB_REMOTE_LOGIN_PAT -- "${houston_pat}"
 
     # Fix permissions on files
     chmod 644 ${HOUSTON_DOTENV} ${PYTHON_GITLAB_CFG}


### PR DESCRIPTION
If the `GITLAB_REMOTE_LOGIN_PAT` happens to start with a dash / hyphen,
it's treated as an option for dotenv:

```
Write the python-gitlab configuration file to: /data/var/.python-gitlab.cfg
Create the 'houston' user
Create a PAT for the 'houston' user
Append 'houston' user PAT info to the python-gitlab configuration file
Create the 'test' group
Write 'houston' PAT to /data/var/.env
Usage: dotenv set [OPTIONS] KEY VALUE
Try 'dotenv set --help' for help.

Error: no such option: -4
```

It is possible to reproduce this error on the command line:

```
root@86b973f9000a:/data/var# dotenv -f .env set GITLAB_REMOTE_LOGIN_PAT "-abcd"
Usage: dotenv set [OPTIONS] KEY VALUE
Try 'dotenv set --help' for help.

Error: no such option: -a
```

It can be fixed by adding `--` to say that anything after that isn't an option:

```
root@86b973f9000a:/data/var# dotenv -f .env set GITLAB_REMOTE_LOGIN_PAT -- "-abcd"
GITLAB_REMOTE_LOGIN_PAT=-abcd
```

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [x] Ensure that the PR is properly reviewed
