### PR TITLE
DEX-254: "simple" sighting update passthrough via patch

### DIFF
--- a/app/modules/encounters/models.py
+++ b/app/modules/encounters/models.py
@@ -151,20 +151,20 @@ class Encounter(db.Model, FeatherModel):
         edm_json['updatedHouston'] = self.updated.isoformat()
         from app.modules.users.schemas import PublicUserSchema
 
-        usch = PublicUserSchema(many=False)
-        json, err = usch.dump(self.get_owner())
+        user_schema = PublicUserSchema(many=False)
+        json, err = user_schema.dump(self.get_owner())
         edm_json['owner'] = json
         if self.submitter_guid is not None:
-            json, err = usch.dump(self.submitter)
+            json, err = user_schema.dump(self.submitter)
             edm_json['submitter'] = json
 
         if self.assets is None or len(self.assets) < 1:
             return edm_json
         from app.modules.assets.schemas import DetailedAssetSchema
 
-        sch = DetailedAssetSchema(many=False, only=('guid', 'filename', 'src'))
+        asset_schema = DetailedAssetSchema(many=False, only=('guid', 'filename', 'src'))
         edm_json['assets'] = []
         for asset in self.get_assets():
-            json, err = sch.dump(asset)
+            json, err = asset_schema.dump(asset)
             edm_json['assets'].append(json)
         return edm_json

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -103,9 +103,18 @@ class Sighting(db.Model, FeatherModel):
         if self.encounters is not None and edm_json['encounters'] is not None:
             if len(self.encounters) != len(edm_json['encounters']):
                 log.warning('Imbalanced encounters between edm/feather objects!')
+                raise ValueError('imbalanced encounter count between edm/feather')
             else:
                 i = 0
                 while i < len(self.encounters):  # now we augment each encounter
-                    self.encounters[i].augment_edm_json(edm_json['encounters'][i])
+                    found_edm = None
+                    for edm_enc in edm_json['encounters']:
+                        if edm_enc['id'] == str(self.encounters[i].guid):
+                            found_edm = edm_enc
+                    if found_edm is None:
+                        raise ValueError(
+                            f'could not find edm encounter matching {self.encounters[i]}'
+                        )
+                    self.encounters[i].augment_edm_json(edm_enc)
                     i += 1
         return edm_json

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -94,6 +94,8 @@ class Sighting(db.Model, FeatherModel):
     # given edm_json (verbose json from edm) will populate with houston-specific data from feather object
     # note: this modifies the passed in edm_json, so not sure how legit that is?
     def augment_edm_json(self, edm_json):
+        edm_json['createdHouston'] = self.created.isoformat()
+        edm_json['updatedHouston'] = self.updated.isoformat()
         if (self.encounters is not None and edm_json['encounters'] is None) or (
             self.encounters is None and edm_json['encounters'] is not None
         ):

--- a/app/modules/sightings/parameters.py
+++ b/app/modules/sightings/parameters.py
@@ -20,4 +20,7 @@ class PatchSightingDetailsParameters(PatchJSONParameters):
     # pylint: disable=abstract-method,missing-docstring
     OPERATION_CHOICES = (PatchJSONParameters.OP_REPLACE,)
 
-    PATH_CHOICES = tuple('/%s' % field for field in (Sighting.guid.key,))
+    PATH_CHOICES_EDM = ('/locationId',)
+    PATH_CHOICES = (
+        tuple('/%s' % field for field in (Sighting.guid.key,)) + PATH_CHOICES_EDM
+    )

--- a/app/modules/sightings/parameters.py
+++ b/app/modules/sightings/parameters.py
@@ -8,7 +8,6 @@ Input arguments (Parameters) for Sightings resources RESTful API
 from flask_restx_patched import Parameters, PatchJSONParameters
 
 from . import schemas
-from .models import Sighting
 
 
 class CreateSightingParameters(Parameters, schemas.DetailedSightingSchema):
@@ -18,9 +17,17 @@ class CreateSightingParameters(Parameters, schemas.DetailedSightingSchema):
 
 class PatchSightingDetailsParameters(PatchJSONParameters):
     # pylint: disable=abstract-method,missing-docstring
-    OPERATION_CHOICES = (PatchJSONParameters.OP_REPLACE,)
+    OPERATION_CHOICES = (
+        PatchJSONParameters.OP_ADD,
+        PatchJSONParameters.OP_REPLACE,
+        PatchJSONParameters.OP_REMOVE,
+    )
 
-    PATH_CHOICES_EDM = ('/locationId',)
+    PATH_CHOICES_EDM = (
+        '/locationId',
+        '/startTime',
+        '/endTime',
+    )
     PATH_CHOICES = (
-        tuple('/%s' % field for field in (Sighting.guid.key,)) + PATH_CHOICES_EDM
+        PATH_CHOICES_EDM  # for now, no patching on houston sighting needed/supported
     )

--- a/app/modules/sightings/parameters.py
+++ b/app/modules/sightings/parameters.py
@@ -27,6 +27,10 @@ class PatchSightingDetailsParameters(PatchJSONParameters):
         '/locationId',
         '/startTime',
         '/endTime',
+        '/taxonomies',
+        '/context',
+        '/decimalLatitude',
+        '/decimalLongitude',
     )
     PATH_CHOICES = (
         PATH_CHOICES_EDM  # for now, no patching on houston sighting needed/supported

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -430,6 +430,10 @@ class SightingByID(Resource):
         """
         Patch Sighting details by ID.
         """
+        if args[0]['path'] in parameters.PatchSightingDetailsParameters.PATH_CHOICES_EDM:
+            log.warning('wanting to do edm patch on path=%r' % args[0]['path'])
+            return {}
+
         context = api.commit_or_abort(
             db.session, default_error_message='Failed to update Sighting details.'
         )

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -424,15 +424,42 @@ class SightingByID(Resource):
     )
     @api.login_required(oauth_scopes=['sightings:write'])
     @api.parameters(parameters.PatchSightingDetailsParameters())
-    @api.response(schemas.DetailedSightingSchema())
     @api.response(code=HTTPStatus.CONFLICT)
     def patch(self, args, sighting):
         """
         Patch Sighting details by ID.
         """
-        if args[0]['path'] in parameters.PatchSightingDetailsParameters.PATH_CHOICES_EDM:
-            log.warning('wanting to do edm patch on path=%r' % args[0]['path'])
-            return {}
+
+        edm_count = 0
+        for arg in args:
+            if (
+                'path' in arg
+                and arg['path']
+                in parameters.PatchSightingDetailsParameters.PATH_CHOICES_EDM
+            ):
+                edm_count += 1
+        if edm_count > 0 and edm_count != len(args):
+            log.error(f'Mixed edm/houston patch called with args {args}')
+            abort(
+                success=False,
+                passed_message='Cannot mix EDM patch paths and houston patch paths',
+                message='Error',
+                code=400,
+            )
+
+        if edm_count > 0:
+            log.debug(f'wanting to do edm patch on args={args}')
+            response = current_app.edm.request_passthrough(
+                'sighting.data', 'patch', {'data': args}, sighting.guid
+            )
+            rdata = response.json()
+            if not response.ok or response.status_code != 200 or not rdata['success']:
+                code = response.status_code
+                if code == 601:
+                    code = 400  # flask doesnt like us to use "invalid" codes. :(
+                log.warning(f'EDM patch got {response.status_code} response of {rdata}')
+                abort(success=False, passed_message=rdata['message'], code=code)
+            return rdata
 
         context = api.commit_or_abort(
             db.session, default_error_message='Failed to update Sighting details.'

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -238,6 +238,8 @@ class ObjectActionRule(DenyAbortMixin, Rule):
 
         # Sightings depend on if user is the _only_ owner of referenced Encounters
         if not has_permission and isinstance(self._obj, Sighting):
+            if self._action == AccessOperation.WRITE:
+                has_permission = self._obj.single_encounter_owner() == user
             if self._action == AccessOperation.DELETE:
                 has_permission = self._obj.user_can_edit_all_encounters(user)
             if self._action == AccessOperation.READ:

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -102,7 +102,7 @@ def test_create_and_modify_and_delete_sighting(
 
     # test some modification (should succeed)
     new_loc_id = 'test_2'
-    response = sighting_utils.update_sighting(
+    response = sighting_utils.patch_sighting(
         flask_app_client,
         researcher_1,
         sighting_id,
@@ -118,7 +118,7 @@ def test_create_and_modify_and_delete_sighting(
     assert response.json['locationId'] == new_loc_id
 
     # test some modification (should fail due to invalid data)
-    response = sighting_utils.update_sighting(
+    response = sighting_utils.patch_sighting(
         flask_app_client,
         researcher_1,
         sighting_id,
@@ -175,7 +175,7 @@ def test_create_anon_and_delete_sighting(db, flask_app_client, staff_user):
 
     # test some modification; this should fail (401) cuz anon should not be allowed
     new_loc_id = 'test_2_fail'
-    response = sighting_utils.update_sighting(
+    response = sighting_utils.patch_sighting(
         flask_app_client,
         None,
         sighting_id,

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -110,7 +110,13 @@ def test_create_and_modify_and_delete_sighting(
             {'op': 'replace', 'path': '/locationId', 'value': new_loc_id},
         ],
     )
-    assert response.json['xid'] == sighting_id
+
+    # check that change was made
+    response = sighting_utils.read_sighting(
+        flask_app_client, researcher_1, sighting_id, expected_status_code=200
+    )
+    assert response.json['id'] == sighting_id
+    # assert response.json['locationId'] == new_loc_id  # FIXME not yet functional in edm .... soon!
 
     # upon success (yay) we clean up our mess
     sighting_utils.cleanup_tus_dir(transaction_id)

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -57,7 +57,9 @@ def test_create_failures(flask_app_client, researcher_1):
     sighting_utils.cleanup_tus_dir(transaction_id)
 
 
-def test_create_and_delete_sighting(db, flask_app_client, researcher_1, staff_user):
+def test_create_and_modify_and_delete_sighting(
+    db, flask_app_client, researcher_1, staff_user
+):
     from app.modules.sightings.models import Sighting
     from app.modules.encounters.models import Encounter
     from app.modules.assets.models import Asset
@@ -97,6 +99,18 @@ def test_create_and_delete_sighting(db, flask_app_client, researcher_1, staff_us
         flask_app_client, researcher_1, sighting_id, expected_status_code=200
     )
     assert response.json['id'] == sighting_id
+
+    # test some modification
+    new_loc_id = 'test_2'
+    response = sighting_utils.update_sighting(
+        flask_app_client,
+        researcher_1,
+        sighting_id,
+        patch_data=[
+            {'op': 'replace', 'path': '/locationId', 'value': new_loc_id},
+        ],
+    )
+    assert response.json['xid'] == sighting_id
 
     # upon success (yay) we clean up our mess
     sighting_utils.cleanup_tus_dir(transaction_id)

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -116,7 +116,7 @@ def test_create_and_modify_and_delete_sighting(
         flask_app_client, researcher_1, sighting_id, expected_status_code=200
     )
     assert response.json['id'] == sighting_id
-    # assert response.json['locationId'] == new_loc_id  # FIXME not yet functional in edm .... soon!
+    assert response.json['locationId'] == new_loc_id
 
     # upon success (yay) we clean up our mess
     sighting_utils.cleanup_tus_dir(transaction_id)

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -100,7 +100,7 @@ def test_create_and_modify_and_delete_sighting(
     )
     assert response.json['id'] == sighting_id
 
-    # test some modification
+    # test some modification (should succeed)
     new_loc_id = 'test_2'
     response = sighting_utils.update_sighting(
         flask_app_client,
@@ -110,13 +110,23 @@ def test_create_and_modify_and_delete_sighting(
             {'op': 'replace', 'path': '/locationId', 'value': new_loc_id},
         ],
     )
-
     # check that change was made
     response = sighting_utils.read_sighting(
         flask_app_client, researcher_1, sighting_id, expected_status_code=200
     )
     assert response.json['id'] == sighting_id
     assert response.json['locationId'] == new_loc_id
+
+    # test some modification (should fail due to invalid data)
+    response = sighting_utils.update_sighting(
+        flask_app_client,
+        researcher_1,
+        sighting_id,
+        patch_data=[
+            {'op': 'add', 'path': '/decimalLatitude', 'value': 999.9},
+        ],
+        expected_status_code=400,
+    )
 
     # upon success (yay) we clean up our mess
     sighting_utils.cleanup_tus_dir(transaction_id)
@@ -162,6 +172,18 @@ def test_create_anon_and_delete_sighting(db, flask_app_client, staff_user):
     sighting_id = response.json['result']['id']
     sighting = Sighting.query.get(sighting_id)
     assert sighting is not None
+
+    # test some modification; this should fail (401) cuz anon should not be allowed
+    new_loc_id = 'test_2_fail'
+    response = sighting_utils.update_sighting(
+        flask_app_client,
+        None,
+        sighting_id,
+        patch_data=[
+            {'op': 'replace', 'path': '/locationId', 'value': new_loc_id},
+        ],
+        expected_status_code=401,
+    )
 
     # upon success (yay) we clean up our mess (but need staff_user to do it)
     sighting_utils.cleanup_tus_dir(transaction_id)

--- a/tests/modules/sightings/resources/utils.py
+++ b/tests/modules/sightings/resources/utils.py
@@ -83,6 +83,21 @@ def read_sighting(flask_app_client, user, sight_guid, expected_status_code=200):
     return response
 
 
+def update_sighting(
+    flask_app_client, user, sighting_guid, expected_status_code=200, patch_data=[]
+):
+    with flask_app_client.login(user, auth_scopes=('sightings:write',)):
+        response = flask_app_client.patch(
+            '%s%s' % (PATH, sighting_guid),
+            data=json.dumps(patch_data),
+            content_type='application/javascript',
+        )
+
+    assert isinstance(response.json, dict)
+    assert response.status_code == expected_status_code
+    return response
+
+
 def delete_sighting(flask_app_client, user, sight_guid, expected_status_code=204):
     with flask_app_client.login(user, auth_scopes=('sightings:write',)):
         response = flask_app_client.delete('%s%s' % (PATH, sight_guid))

--- a/tests/modules/sightings/resources/utils.py
+++ b/tests/modules/sightings/resources/utils.py
@@ -50,8 +50,8 @@ def cleanup_tus_dir(tid):
 def create_sighting(
     flask_app_client,
     user,
-    expected_status_code=200,
     data_in={'locationId': 'PYTEST', 'context': 'test'},
+    expected_status_code=200,
 ):
     if user is not None:
         with flask_app_client.login(user):
@@ -84,7 +84,7 @@ def read_sighting(flask_app_client, user, sight_guid, expected_status_code=200):
 
 
 def update_sighting(
-    flask_app_client, user, sighting_guid, expected_status_code=200, patch_data=[]
+    flask_app_client, user, sighting_guid, patch_data=[], expected_status_code=200
 ):
     with flask_app_client.login(user, auth_scopes=('sightings:write',)):
         response = flask_app_client.patch(

--- a/tests/modules/sightings/resources/utils.py
+++ b/tests/modules/sightings/resources/utils.py
@@ -83,7 +83,7 @@ def read_sighting(flask_app_client, user, sight_guid, expected_status_code=200):
     return response
 
 
-def update_sighting(
+def patch_sighting(
     flask_app_client, user, sighting_guid, patch_data=[], expected_status_code=200
 ):
     with flask_app_client.login(user, auth_scopes=('sightings:write',)):


### PR DESCRIPTION
## Pull Request Overview

- Implement basic passhtrough modification (via PATCH) to edm on sightings
- Simple-valued properties (e.g. no lists like path=/encounters) values changed via add/replace/remove

---

**Review Notes**
- Complex (looking at you, /encounters) up next
- Permissions based on user owning _all_ nested encounters (or having super powers)

**REST API Updates**

Example:
```
PATCH  /api/v1/sightings/GUID
[
  {
      "op": "replace",
      "path": "/locationId",
      "value": "fubar"
  },
  {
      "op": "add",
      "path": "/taxonomies",
      "value": "82edd00c-dbe2-463d-a42c-a4f95c17bf1a"
  }
]
```

**Pull Request Checklist**
- [ ] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [ ] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [ ] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [ ] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [ ] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [ ] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
