### PR TITLE
Change delete site setting permission to use AccessOperation.DELETE

### DIFF
--- a/app/modules/site_settings/resources.py
+++ b/app/modules/site_settings/resources.py
@@ -132,7 +132,7 @@ class SiteSettingByKey(Resource):
         permissions.ObjectAccessPermission,
         kwargs_on_request=lambda kwargs: {
             'obj': kwargs['site_setting'],
-            'action': AccessOperation.WRITE,
+            'action': AccessOperation.DELETE,
         },
     )
     @api.login_required(oauth_scopes=['site-settings:write'])

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -21,6 +21,7 @@ PERMISSION_ROLE_MAP = {
     ('SiteSetting', AccessOperation.WRITE, 'Module'): ['is_privileged', 'is_admin'],
     ('SiteSetting', AccessOperation.READ, 'Object'): ['is_privileged', 'obj_is_public'],
     ('SiteSetting', AccessOperation.WRITE, 'Object'): ['is_privileged', 'is_admin'],
+    ('SiteSetting', AccessOperation.DELETE, 'Object'): ['is_privileged', 'is_admin'],
 }
 
 


### PR DESCRIPTION
It was using `AccessOperation.WRITE` but since we do have a
`AccessOperation.DELETE`, we can use that instead.  The actual check is
the same.  The user needs to be either an admin or is privileged.


**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
