### PR TITLE
Use mkdtemp in site setting test for python3.7

### DIFF
--- a/tests/modules/site_settings/test_resources.py
+++ b/tests/modules/site_settings/test_resources.py
@@ -67,60 +67,60 @@ def test_site_settings(admin_user, flask_app_client, flask_app, db, request):
 
         # Edit site setting using transactionId
         upload_dir = flask_app.config['UPLOADS_DATABASE_PATH']
-        with tempfile.TemporaryDirectory(prefix='trans-', dir=upload_dir) as td:
-            transaction_id = Path(td).name[len('trans-') :]
+        td = tempfile.mkdtemp(prefix='trans-', dir=upload_dir)
+        transaction_id = Path(td).name[len('trans-') :]
 
-            with (Path(td) / 'image.jpg').open('wb') as f:
-                with zebra_path.open('rb') as g:
-                    f.write(g.read())
-            resp = flask_app_client.post(
-                '/api/v1/site-settings/',
-                data={
-                    'key': 'header_image',
-                    'transactionId': transaction_id,
-                },
-            )
-            assert resp.status_code == 200, resp.data
-            assert resp.json['key'] == 'header_image'
-            assert resp.json['file_upload_guid'] != str(fup.guid)
+        with (Path(td) / 'image.jpg').open('wb') as f:
+            with zebra_path.open('rb') as g:
+                f.write(g.read())
+        resp = flask_app_client.post(
+            '/api/v1/site-settings/',
+            data={
+                'key': 'header_image',
+                'transactionId': transaction_id,
+            },
+        )
+        assert resp.status_code == 200, resp.data
+        assert resp.json['key'] == 'header_image'
+        assert resp.json['file_upload_guid'] != str(fup.guid)
 
         # Edit site setting using transactionId with 2 files
-        with tempfile.TemporaryDirectory(prefix='trans-', dir=upload_dir) as td:
-            transaction_id = Path(td).name[len('trans-') :]
-            with (Path(td) / 'a.txt').open('w') as f:
-                f.write('1234')
-            with (Path(td) / 'b.txt').open('w') as f:
-                f.write('5678')
-            resp = flask_app_client.post(
-                '/api/v1/site-settings/',
-                data={
-                    'key': 'header_image',
-                    'transactionId': transaction_id,
-                },
-            )
-            assert resp.status_code == 422
-            assert (
-                resp.json['message']
-                == f'Transaction {transaction_id} has 2 files, need exactly 1.'
-            )
+        td = tempfile.mkdtemp(prefix='trans-', dir=upload_dir)
+        transaction_id = Path(td).name[len('trans-') :]
+        with (Path(td) / 'a.txt').open('w') as f:
+            f.write('1234')
+        with (Path(td) / 'b.txt').open('w') as f:
+            f.write('5678')
+        resp = flask_app_client.post(
+            '/api/v1/site-settings/',
+            data={
+                'key': 'header_image',
+                'transactionId': transaction_id,
+            },
+        )
+        assert resp.status_code == 422
+        assert (
+            resp.json['message']
+            == f'Transaction {transaction_id} has 2 files, need exactly 1.'
+        )
 
         # Edit site setting using transactionId and transactionPath
-        with tempfile.TemporaryDirectory(prefix='trans-', dir=upload_dir) as td:
-            transaction_id = Path(td).name[len('trans-') :]
-            with (Path(td) / 'a.txt').open('w') as f:
-                f.write('1234')
-            with (Path(td) / 'b.txt').open('w') as f:
-                f.write('5678')
-            resp = flask_app_client.post(
-                '/api/v1/site-settings/',
-                data={
-                    'key': 'header_image',
-                    'transactionId': transaction_id,
-                    'transactionPath': 'a.txt',
-                },
-            )
-            assert resp.status_code == 200
-            assert resp.json['key'] == 'header_image'
+        td = tempfile.mkdtemp(prefix='trans-', dir=upload_dir)
+        transaction_id = Path(td).name[len('trans-') :]
+        with (Path(td) / 'a.txt').open('w') as f:
+            f.write('1234')
+        with (Path(td) / 'b.txt').open('w') as f:
+            f.write('5678')
+        resp = flask_app_client.post(
+            '/api/v1/site-settings/',
+            data={
+                'key': 'header_image',
+                'transactionId': transaction_id,
+                'transactionPath': 'a.txt',
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json['key'] == 'header_image'
 
         # Delete site setting
         resp = flask_app_client.delete('/api/v1/site-settings/header_image')


### PR DESCRIPTION
When using the `TemporaryDirectory` context manager in python 3.7 and
the directory is not there, it returns an error:

```
            with tempfile.TemporaryDirectory(prefix='trans-', dir=upload_dir) as td:
                transaction_id = Path(td).name[len('trans-') :]

                ...
>               assert resp.json['file_upload_guid'] != str(fup.guid)

tests/modules/site_settings/test_resources.py:85:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/lib/python3.7/tempfile.py:944: in __exit__
    self.cleanup()
/usr/lib/python3.7/tempfile.py:948: in cleanup
    _rmtree(self.name)
/usr/lib/python3.7/shutil.py:482: in rmtree
    onerror(os.lstat, path, sys.exc_info())
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

path = '/data/var/uploads/trans-o1acga7j', ignore_errors = False
onerror = <function rmtree.<locals>.onerror at 0x7f7104e05598>

    def rmtree(path, ignore_errors=False, onerror=None):
            ...
            try:
>               orig_st = os.lstat(path)
E               FileNotFoundError: [Errno 2] No such file or directory: '/data/var/uploads/trans-o1acga7j'

/usr/lib/python3.7/shutil.py:480: FileNotFoundError
```

To avoid this, just use `mkdtemp` instead which doesn't automatically
clean up.  The transaction directory is should be deleted once it is
processed.


**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
