### PR TITLE
Dex 233 - add IA config files to Codex

### DIFF
--- a/ia-configs/IA.GLOBALS.json
+++ b/ia-configs/IA.GLOBALS.json
@@ -1,0 +1,17 @@
+{
+    "_global_endpoints": {
+        "_note": "The common WBIA endpoints targeted by all WBIA configs.",
+        "add_images": "/api/image/json/",
+        "add_annotations": "/api/annot/json/",
+        "start_identify": "/api/engine/query/graph/",
+        "identify_review": "/api/review/query/graph/",
+        "start_detect": {
+            "default": "@_global_endpoints.start_detect.lightnet",
+            "lightnet": "/api/engine/detect/cnn/lightnet/",
+            "yolo": "/api/engine/detect/cnn/yolo/"
+        },
+        "detect_review": "/api/review/detect/cnn/yolo/",
+        "get_job_status": "/api/engine/job/status/",
+        "get_job_result": "/api/engine/job/result/"
+    }
+}

--- a/ia-configs/IA.amphibian-reptile.json
+++ b/ia-configs/IA.amphibian-reptile.json
@@ -1,0 +1,50 @@
+{
+    "_note": "The hierarchy of this file is genus->species->ia_class->_id_conf (id config). detect_config is under Genus->species. Keys with a leading underscore and their children are non-biological categories of config, like _id_conf and _detection_conf. Keys without leading underscores are semantic lookups that are derived from Wildbook data, e.g. Megaptera.novaeangliae.whale_fluke.",
+    "_default": "@Salamandra.salamandra",
+    "Salamandra": {
+      "salamandra": {
+        "_default":{
+          "_id_conf": "@Salamandra.salamandra.fire_sal._id_conf"
+        },
+        "_detect_conf": [
+          {
+            "labeler_algo": "densenet",
+            "model_tag": "salanader_fire_v0",
+            "labeler_model_tag": "salanader_fire_v0",
+            "nms_thresh": 0.40,
+            "sensitivity": 0.50
+          }
+        ],
+        "fire_sal":{
+          "_id_conf": [
+            {
+              "query_config_dict": {
+                "sv_on":true
+              },
+              "description": "HotSpotter pattern-matcher"
+            }
+          ]
+        },
+        "salanader_fire": {
+          "_id_conf": [
+            {
+              "query_config_dict": {
+                "sv_on": true
+              },
+              "description": "HotSpotter pattern-matcher"
+            }
+          ]
+        },
+        "salanader_fire_adult": {
+          "_id_conf": [
+            {
+              "query_config_dict": {
+                "sv_on": true
+              },
+              "description": "HotSpotter pattern-matcher"
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/ia-configs/IA.carnivore.json
+++ b/ia-configs/IA.carnivore.json
@@ -1,0 +1,150 @@
+{
+    "_note":"The hierarchy of this file is genus->species->ia_class->_id_conf (id config). detect_config is under Genus->species. Keys with a leading underscore and their children are non-biological categories of config, like _id_conf and _detection_conf. Keys without leading underscores are semantic lookups that are derived from Wildbook data, e.g. Megaptera.novaeangliae.whale_fluke.",
+    "_default":"@Lycaon.pictus",
+    "Lycaon": {
+       "pictus": {
+          "_detect_conf": [
+             {
+                "model_tag":"wilddog_v0",
+                "labeler_model_tag":"wilddog_v3+wilddog_v2+wilddog_v1",
+                "labeler_algo":"densenet",
+                "nms_aware":"ispart",
+                "nms_thresh": 0.50,
+                "sensitivity": 0.48,
+                "use_labeler_species": true,
+                "assigner_algo": "wd_v0"
+             }
+          ],
+          "wild_dog": {
+             "_id_conf": [
+                {
+                   "query_config_dict": {
+                      "sv_on": true,
+                      "n": 20
+                   }
+                }
+             ]
+          },
+          "wild_dog_standard": {
+             "_id_conf": "@Lycaon.pictus.wild_dog._id_conf",
+             "_save_keyword": "BodyStandard"
+          },
+          "wild_dog_tan": {
+             "_id_conf": "@Lycaon.pictus.wild_dog._id_conf",
+             "_save_keyword": "BodyTan"
+          },
+          "wild_dog_dark": {
+             "_id_conf": "@Lycaon.pictus.wild_dog._id_conf",
+             "_save_keyword": "BodyDark"
+          },
+          "wild_dog_ambiguous": {
+             "_id_conf": "@Lycaon.pictus.wild_dog._id_conf",
+             "_save_keyword": "BodyAmbiguous"
+          },
+          "wild_dog_general": {
+             "_id_conf": "@Lycaon.pictus.wild_dog._id_conf",
+             "_save_as": "wild_dog_general",
+             "_save_keyword": "BodyGeneral"
+          },
+          "wild_dog_puppy": {
+             "_id_conf": "@Lycaon.pictus.wild_dog._id_conf",
+             "_save_keyword": "Puppy"
+          },
+          "wild_dog+tail_general": {
+             "_id_conf": [],
+             "_save_as": "wild_dog+tail_general",
+             "_save_keyword": "TailGeneral"
+          },
+          "wild_dog+tail_double_black_brown": {
+             "_id_conf": [],
+             "_save_keyword": "TailDoubleBlackBrown"
+          },
+          "wild_dog+tail_double_black_white": {
+             "_id_conf": [],
+             "_save_keyword": "TailDoubleBlackWhite"
+          },
+          "wild_dog+tail_long_black": {
+             "_id_conf": [],
+             "_save_keyword": "TailLongBlack"
+          },
+          "wild_dog+tail_long_white": {
+             "_id_conf": [],
+             "_save_keyword": "TailLongWhite"
+          },
+          "wild_dog+tail_short_black": {
+             "_id_conf": [],
+             "_save_keyword": "TailShortBlack"
+          },
+          "wild_dog+tail_triple_black": {
+             "_id_conf": [],
+             "_save_keyword": "TailTripleBlack"
+          },
+          "wild_dog+tail_ambiguous": {
+             "_id_conf": [],
+             "_save_keyword": "TailAmbiguous"
+          },
+          "wild_dog+tail_standard": {
+             "_id_conf": [],
+             "_save_keyword": "TailStandard"
+          }
+
+       }
+    },
+    "Panthera": {
+       "pardus": {
+          "_detect_conf": [
+             {
+                "model_tag":"leopard_v0",
+                "viewpoint_model_tag":"leopard_v0",
+                "labeler_algo":"densenet",
+                "nms_aware": null,
+                "nms_thresh": 0.50,
+                "sensitivity": 0.73
+             }
+          ],
+          "leopard": {
+             "_id_conf": [
+               {"query_config_dict": {"sv_on": true} }
+             ]
+          }
+       }
+    },
+    "Acinonyx": {
+       "jubatus": {
+          "_detect_conf": [
+             {
+                "model_tag":"cheetah_v1",
+                "labeler_model_tag":"cheetah_v1",
+                "labeler_algo":"densenet",
+                "nms_aware": "byclass",
+                "nms_thresh": 0.60,
+                "sensitivity": 0.62
+             }
+          ],
+          "cheetah": {
+             "_id_conf": [
+               {"query_config_dict": {"sv_on": true} }
+             ]
+          }
+       }
+    },
+    "Crocuta": {
+       "crocuta": {
+          "_detect_conf": [
+                {
+                   "model_tag": "hyaena_v0",
+                   "labeler_model_tag": "hyaena_v0",
+                   "labeler_algo": "densenet",
+                   "nms_aware": null,
+                   "nms_thresh": 0.70,
+                   "sensitivity": 0.74
+                 }
+          ],
+          "hyaena": {
+             "_id_conf": [
+               {"query_config_dict": {"sv_on": true} }
+             ]
+          }
+       }
+    }
+ }

--- a/ia-configs/IA.flukebook.json
+++ b/ia-configs/IA.flukebook.json
@@ -1,0 +1,890 @@
+{
+    "_note":"The hierarchy of this file is genus->species->ia_class->_id_conf (id config). detect_config is under Genus->species. Keys with a leading underscore and their children are non-biological categories of config, like _id_conf and _detection_conf. Keys without leading underscores are semantic lookups that are derived from Wildbook data, e.g. Megaptera.novaeangliae.whale_fluke.",
+    "_default": {
+       "_id_conf": [],
+       "_default": {
+          "_id_conf": []
+       }
+    },
+    "Megaptera":{
+       "novaeangliae":{
+         "whale_humpback+fin_dorsal":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Finfindr"
+                   },
+                   "description":"finFindR dorsal matcher",
+                   "default": false
+                },
+                {
+                    "query_config_dict":{
+                        "pipeline_root":"CurvRankTwoDorsal"
+                    },
+                    "description":"CurvRank v2 dorsal edge-matcher"
+                }
+             ],
+             "_save_as":"whale_humpback+fin_dorsal"
+          },
+          "whale_fluke":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "sv_on":false
+                   },
+                   "description":"HotSpotter fluke pattern-matcher"
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Pie"
+                   },
+                   "description": "Pose-Invariant Embedding pattern-matcher"
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"OC_WDTW"
+                   },
+                   "description":"Dynamic Time-Warping fluke edge-matcher"
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"CurvRankTwoFluke"
+                   },
+                   "description":"CurvRank v2 fluke edge-matcher",
+                   "default": false
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"KaggleSeven"
+                   },
+                   "description":"Kaggle7 (fluke classifier trained on CRC data only)",
+                   "default": false
+                }
+             ],
+             "_save_as":"whale_fluke"
+          },
+          "dolphin_spotted+fin_dorsal":"@Megaptera.novaeangliae.whale_humpback+fin_dorsal",
+          "dolphin_bottlenose+fin_dorsal":"@Megaptera.novaeangliae.whale_humpback+fin_dorsal",
+          "whale_orca+fin_dorsal":"@Megaptera.novaeangliae.whale_humpback+fin_dorsal",
+          "whale_fin+fin_dorsal":"@Megaptera.novaeangliae.whale_humpback+fin_dorsal",
+          "whale_pilot+fin_dorsal":"@Megaptera.novaeangliae.whale_humpback+fin_dorsal",
+          "whale_humpback+fluke":"@Megaptera.novaeangliae.whale_fluke",
+          "right_whale+fluke":"@Megaptera.novaeangliae.whale_fluke",
+          "_default":"@Megaptera.novaeangliae.whale_fluke",
+
+          "_detect_conf":[
+             {
+               "labeler_algo": "densenet",
+               "labeler_model_tag": "fins_v1",
+               "model_tag": "fins_v1",
+
+               "nms_thresh": 0.53,
+               "sensitivity": 0.4,
+               "use_labeler_species": true
+             }
+          ],
+          "_common_name":"humpback whale"
+       }
+    },
+    "Physeter":{
+       "macrocephalus":{
+          "whale_sperm+fluke":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"OC_WDTW"
+                   },
+                   "description":"Dynamic Time-Warping fluke edge-matcher",
+                   "exclude_viewpoint":[
+                      "left",
+                      "right"
+                   ]
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"CurvRankTwoFluke"
+                   },
+                   "description":"CurvRank v2 fluke edge-matcher",
+                   "exclude_viewpoint":[
+                      "left",
+                      "right"
+                   ]
+                }
+             ],
+             "_save_as":"whale_sperm+fluke"
+          },
+          "whale_humpback+fluke":"@Physeter.macrocephalus.whale_sperm+fluke",
+          "right_whale+fluke":"@Physeter.macrocephalus.whale_sperm+fluke",
+          "_default":"@Physeter.macrocephalus.whale_sperm+fluke",
+          "_detect_conf":[
+             {
+
+               "labeler_algo": "densenet",
+               "labeler_model_tag": "fins_v1",
+               "model_tag": "fins_v1_fluke",
+               "nms_aware": null,
+               "nms_thresh": 0.8,
+               "sensitivity": 0.09,
+               "use_labeler_species": true
+             }
+          ],
+          "_common_name":"sperm whale"
+       }
+    },
+    "Eschrichtius":{
+       "robustus":{
+          "whale_grey":{
+             "_id_conf":[
+                {
+                   "query_config_dict": {
+                      "pipeline_root": "Pie"
+                   },
+                   "description": "Pose-Invariant Embedding pattern-matcher"
+                },
+                {
+                   "query_config_dict":{
+                      "sv_on":false
+                   },
+                   "description":"HotSpotter pattern-matcher"
+                }
+             ],
+             "_save_as":"whale_grey"
+          },
+          "whale_grey+fluke":{
+             "_id_conf":[
+
+             ],
+             "_save_as":"whale_grey+fluke"
+          },
+          "whale_humpback+fluke":"@Eschrichtius.robustus.whale_grey+fluke",
+          "right_whale+fluke":"@Eschrichtius.robustus.whale_grey+fluke",
+          "_detect_conf":[
+             {
+
+               "model_tag": "grey_whale_v0",
+               "sensitivity": 0.66,
+               "nms_thresh": 0.50,
+               "nms_aware": "None",
+               "labeler_algo": "densenet",
+               "labeler_model_tag": "grey_whale_v0"
+         }
+          ],
+          "_common_name":"gray whale"
+       }
+    },
+    "Tursiops":{
+       "truncatus":{
+          "tursiops_truncatus":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Finfindr"
+                   }
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"CurvRankTwoDorsal"
+                   },
+                   "description":"CurvRank v2 dorsal edge-matcher"
+                }
+             ],
+             "_save_as":"tursiops_truncatus"
+          },
+          "dolphin_bottlenose+fin_dorsal":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Finfindr"
+                   }
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"CurvRankTwoDorsal"
+                   },
+                   "description": "CurvRank v2 dorsal edge-matcher"
+                }
+             ],
+             "_save_as":"tursiops_truncatus"
+          },
+          "dolphin_spotted+fin_dorsal":"@Tursiops.truncatus.tursiops_truncatus",
+          "whale_orca+fin_dorsal":"@Tursiops.truncatus.tursiops_truncatus",
+          "whale_fin+fin_dorsal":"@Tursiops.truncatus.tursiops_truncatus",
+          "whale_pilot+fin_dorsal":"@Tursiops.truncatus.tursiops_truncatus",
+          "whale_humpback+fin_dorsal":"@Tursiops.truncatus.tursiops_truncatus",
+          "_default":"@Tursiops.truncatus.tursiops_truncatus",
+          "_detect_conf":[
+              {
+
+               "labeler_algo": "densenet",
+               "labeler_model_tag": "fins_v1",
+               "model_tag": "fins_v1_dorsal",
+               "nms_aware": "byclass",
+               "nms_thresh": 0.6,
+               "sensitivity": 0.53,
+               "use_labeler_species": true,
+               "viewpoints_to_keywords":{
+                     "left":"Left Dorsal Fin",
+                     "right":"Right Dorsal Fin"
+               }
+ }
+          ],
+          "match_trivial":true,
+          "common_name":"bottlenose dolphin"
+       },
+       "sp":"@Tursiops.truncatus",
+       "aduncus":"@Tursiops.truncatus"
+    },
+
+
+
+     "Sousa":{
+       "plumbea":{
+          "sousa_plumbea":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Finfindr"
+                   }
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"CurvRankTwoDorsal"
+                   },
+                   "description":"CurvRank v2 dorsal edge-matcher"
+                }
+             ],
+             "_save_as":"sousa_plumbea"
+          },
+          "whale_humpback+fin_dorsal":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Finfindr"
+                   }
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"CurvRankTwoDorsal"
+                   },
+                   "description":"CurvRank v2 dorsal edge-matcher"
+                }
+             ],
+             "_save_as":"sousa_plumbea"
+          },
+          "dolphin_bottlenose+fin_dorsal":"@Sousa.plumbea.sousa_plumbea",
+          "dolphin_spotted+fin_dorsal":"@Sousa.plumbea.sousa_plumbea",
+          "whale_orca+fin_dorsal":"@Sousa.plumbea.sousa_plumbea",
+          "whale_fin+fin_dorsal":"@Sousa.plumbea.sousa_plumbea",
+          "whale_pilot+fin_dorsal":"@Sousa.plumbea.sousa_plumbea",
+          "_default":"@Sousa.plumbea.sousa_plumbea",
+          "_detect_conf":[
+                 {
+
+                   "labeler_algo": "densenet",
+                   "labeler_model_tag": "fins_v1",
+                   "model_tag": "fins_v1_dorsal",
+                   "nms_aware": "byclass",
+                   "nms_thresh": 0.6,
+                   "sensitivity": 0.53,
+                   "use_labeler_species": true,
+                   "viewpoints_to_keywords":{
+                         "left":"Left Dorsal Fin",
+                         "right":"Right Dorsal Fin"
+                   }
+                 }
+          ],
+          "match_trivial":true,
+          "common_name":"humpback dolphin"
+       }
+    },
+
+
+
+    "Delphinus":{
+       "delphis":"@Tursiops.truncatus"
+    },
+
+
+    "Balaenoptera":{
+       "physalus":{
+          "whale_fin+fin_dorsal":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Finfindr"
+                   }
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"CurvRankTwoDorsal"
+                   },
+                   "description":"CurvRank v2 dorsal edge-matcher"
+                }
+             ],
+             "_save_as":"whale_fin+fin_dorsal"
+          },
+
+          "dolphin_spotted+fin_dorsal":"@Balaenoptera.physalus.whale_fin+fin_dorsal",
+          "whale_orca+fin_dorsal":"@Balaenoptera.physalus.whale_fin+fin_dorsal",
+          "dolphin_bottlenose+fin_dorsal":"@Balaenoptera.physalus.whale_fin+fin_dorsal",
+          "whale_pilot+fin_dorsal":"@Balaenoptera.physalus.whale_fin+fin_dorsal",
+          "whale_humpback+fin_dorsal":"@Balaenoptera.physalus.whale_fin+fin_dorsal",
+          "_default":"@Balaenoptera.physalus.whale_fin+fin_dorsal",
+          "_detect_conf":[
+             {
+
+               "labeler_algo": "densenet",
+               "labeler_model_tag": "fins_v1",
+               "model_tag": "fins_v1_dorsal",
+               "nms_aware": "byclass",
+               "nms_thresh": 0.6,
+               "sensitivity": 0.53,
+               "use_labeler_species": true,
+               "viewpoints_to_keywords":{
+                     "left":"Left Dorsal Fin",
+                     "right":"Right Dorsal Fin"
+               }
+             }
+          ],
+          "match_trivial":true,
+          "common_name":"fin whale"
+       }
+    },
+
+    "Stenella":{
+       "frontalis":{
+          "dolphin_spotted":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "sv_on":true
+                   },
+                   "description": "HotSpotter pattern-matcher"
+                }
+             ],
+             "_save_as":"dolphin_spotted"
+          },
+          "dolphin_spotted+fin_dorsal":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Finfindr"
+                   },
+                   "description": "Finfindr dorsal edge-matcher"
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"CurvRankTwoDorsal"
+                   },
+                   "description": "CurvRank v2 dorsal edge-matcher"
+                }
+             ],
+             "_save_as":"dolphin_spotted+fin_dorsal"
+          },
+          "dolphin_bottlenose+fin_dorsal":"@Stenella.frontalis.dolphin_spotted+fin_dorsal",
+          "whale_orca+fin_dorsal":"@Stenella.frontalis.dolphin_spotted+fin_dorsal",
+          "whale_fin+fin_dorsal":"@Stenella.frontalis.dolphin_spotted+fin_dorsal",
+          "whale_pilot+fin_dorsal":"@Stenella.frontalis.dolphin_spotted+fin_dorsal",
+          "whale_humpback+fin_dorsal":"@Stenella.frontalis.dolphin_spotted+fin_dorsal",
+          "dolphin_bottlenose":"@Stenella.frontalis.dolphin_spotted",
+          "whale_orca":"@Stenella.frontalis.dolphin_spotted",
+          "whale_fin":"@Stenella.frontalis.dolphin_spotted",
+          "whale_pilot":"@Stenella.frontalis.dolphin_spotted",
+          "whale_humpback":"@Stenella.frontalis.dolphin_spotted",
+          "_detect_conf":[
+             {
+                "detection_class":"dolphin_spotted",
+
+                "model_tag":"spotted_dolphin_v1",
+                "labeler_algo":"densenet",
+                "labeler_model_tag":"spotted_dolphin_v1",
+                "sensitivity":0.85,
+                "nms_thresh":0.3
+             }
+          ]
+       },
+            "longirostris":{
+          "spinner_dolphin":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Finfindr"
+                   }
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"CurvRankTwoDorsal"
+                   },
+                   "description":"CurvRank v2 dorsal edge-matcher"
+                }
+             ],
+             "_save_as":"spinner_dolphin"
+          },
+          "whale_humpback+fin_dorsal":"@Stenella.longirostris.spinner_dolphin",
+          "dolphin_bottlenose+fin_dorsal":"@Stenella.longirostris.spinner_dolphin",
+          "dolphin_spotted+fin_dorsal":"@Stenella.longirostris.spinner_dolphin",
+          "whale_orca+fin_dorsal":"@Stenella.longirostris.spinner_dolphin",
+          "whale_fin+fin_dorsal":"@Stenella.longirostris.spinner_dolphin",
+          "whale_pilot+fin_dorsal":"@Stenella.longirostris.spinner_dolphin",
+          "tursiops_truncatus":"@Stenella.longirostris.spinner_dolphin",
+          "_default":"@Stenella.longirostris.spinner_dolphin",
+          "_detect_conf":[
+                 {
+
+                   "labeler_algo": "densenet",
+                   "labeler_model_tag": "fins_v1",
+                   "model_tag": "fins_v1_dorsal",
+                   "nms_aware": "byclass",
+                   "nms_thresh": 0.6,
+                   "sensitivity": 0.53,
+                   "use_labeler_species": true,
+                   "viewpoints_to_keywords":{
+                         "left":"Left Dorsal Fin",
+                         "right":"Right Dorsal Fin"
+                   }
+                 }
+          ],
+          "match_trivial":true,
+          "common_name":"Spinner dolphin"
+       },
+       "attenuata":"@Stenella.frontalis"
+    },
+    "Orcinus": {
+       "orca": {
+          "whale_orca+fin_dorsal":{
+             "_id_conf":[
+                {
+                   "query_config_dict": {
+                      "pipeline_root":"Finfindr"
+                   },
+                   "description": "Finfindr dorsal edge-matcher",
+                   "default": false
+                },
+                {
+                   "query_config_dict": {
+                      "pipeline_root": "Pie"
+                   },
+                   "description": "Pose-Invariant Embedding pattern-matcher",
+                   "default": false
+                },
+                {
+                   "query_config_dict": {
+                      "pipeline_root":"CurvRankTwoDorsal"
+                   },
+                   "description": "CurvRank v2 dorsal edge-matcher"
+                }
+             ],
+             "_save_as":"whale_orca+fin_dorsal"
+          },
+          "whale_orca":{
+             "_note": "this corresponds to a lateral body annotation",
+             "_id_conf":[
+                {
+                   "query_config_dict": {
+                      "pipeline_root": "Pie"
+                   },
+                   "description": "FAST: Pose-Invariant Embedding pattern-matcher"
+                },
+                   {
+                   "query_config_dict": {
+                      "sv_on":false
+                   },
+                   "description":"SLOW: HotSpotter body pattern-matcher",
+                   "default": false
+                }
+             ]
+          },
+          "whale_pilot+fin_dorsal":"@Orcinus.orca.whale_orca+fin_dorsal",
+          "whale_humpback+fin_dorsal":"@Orcinus.orca.whale_orca+fin_dorsal",
+          "_detect_conf":[
+             {
+               "detection_class":"whale_orca+fin_dorsal",
+                "model_tag":"orca_v0",
+                "labeler_model_tag":"orca_v0",
+                "nms_thresh":0.40,
+                "sensitivity":0.49,
+                "labeler_algo":"densenet",
+                "nms_aware":"ispart"
+             }
+          ],
+          "_common_name":"killer whale"
+       }
+    },
+
+    "Lagenorhynchus":{
+       "obliquidens":{
+          "dolphin_whitesided":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "sv_on":true
+                   },
+                   "description": "HotSpotter pattern-matcher"
+                }
+             ],
+             "_save_as":"dolphin_whitesided"
+          },
+          "dolphin_whitesided+fin_dorsal":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Finfindr"
+                   },
+                   "description": "Finfindr dorsal edge-matcher"
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"CurvRankTwoDorsal"
+                   },
+                   "description": "CurvRank v2 dorsal edge-matcher"
+                }
+             ],
+             "_save_as":"dolphin_whitesided+fin_dorsal"
+          },
+          "dolphin_spotted+fin_dorsal":"@Lagenorhynchus.obliquidens.dolphin_whitesided+fin_dorsal",
+          "dolphin_bottlenose+fin_dorsal":"@Lagenorhynchus.obliquidens.dolphin_whitesided+fin_dorsal",
+          "whale_orca+fin_dorsal":"@Lagenorhynchus.obliquidens.dolphin_whitesided+fin_dorsal",
+          "whale_fin+fin_dorsal":"@Lagenorhynchus.obliquidens.dolphin_whitesided+fin_dorsal",
+          "whale_pilot+fin_dorsal":"@Lagenorhynchus.obliquidens.dolphin_whitesided+fin_dorsal",
+          "whale_humpback+fin_dorsal":"@Lagenorhynchus.obliquidens.dolphin_whitesided+fin_dorsal",
+          "dolphin_spotted":"@Lagenorhynchus.obliquidens.dolphin_whitesided",
+          "dolphin_bottlenose":"@Lagenorhynchus.obliquidens.dolphin_whitesided",
+          "whale_orca":"@Lagenorhynchus.obliquidens.dolphin_whitesided",
+          "whale_fin":"@Lagenorhynchus.obliquidens.dolphin_whitesided",
+          "whale_pilot":"@Lagenorhynchus.obliquidens.dolphin_whitesided",
+          "whale_humpback":"@Lagenorhynchus.obliquidens.dolphin_whitesided",
+          "_detect_conf":[
+             {
+                "detection_class":"dolphin_spotted",
+
+                "model_tag":"spotted_dolphin_v1",
+                "labeler_algo":"densenet",
+                "labeler_model_tag":"spotted_dolphin_v1",
+                "sensitivity":0.85,
+                "nms_thresh":0.3
+             },
+             {
+
+               "labeler_algo": "densenet",
+               "labeler_model_tag": "fins_v1",
+               "model_tag": "fins_v1_dorsal",
+               "nms_aware": "byclass",
+               "nms_thresh": 0.6,
+               "sensitivity": 0.53,
+               "use_labeler_species": true,
+               "viewpoints_to_keywords":{
+                     "left":"Left Dorsal Fin",
+                     "right":"Right Dorsal Fin"
+               }
+             }
+
+          ]
+       }
+    },
+
+    "Eubalaena": {
+       "glacialis": {
+          "right_whale+head_aerial": {
+             "_id_conf": [
+                {
+                   "query_config_dict": {
+                      "pipeline_root":"Deepsense"
+                   },
+                   "description": "Deepsense aerial classifier (NARW catalog only)"
+                }
+             ]
+          },
+          "right_whale+head_lateral":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Pie"
+                   },
+                   "description": "Pose-Invariant Embedding pattern-matcher"
+                }
+             ]
+
+          },
+          "right_whale":{
+             "_note": "this corresponds to a belly/body annotation",
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "sv_on":false
+                   },
+                   "description":"HotSpotter body pattern-matcher",
+                   "default": false
+                }
+
+             ]
+          },
+          "right_whale+fluke":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"OC_WDTW"
+                   },
+                   "description":"Dynamic Time-Warping fluke edge-matcher"
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"CurvRankTwoFluke"
+                    },
+                    "description":"CurvRank v2 fluke edge-matcher"
+                }
+             ]
+          },
+          "right_whale+peduncle":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "sv_on":false
+                   },
+                   "description":"HotSpotter body pattern-matcher"
+                }
+             ]
+          },
+          "_default" : "@Eubalaena.glacialis.right_whale+head_aerial",
+          "_detect_conf":[
+             {
+                "model_tag"           : "rightwhale_v5",
+                "sensitivity"         : 0.36,
+                "nms_thresh"          : 0.60,
+                "nms_aware"           : "ispart",
+                "labeler_algo"        : "densenet",
+                "labeler_model_tag"   : "rightwhale_v5",
+                "use_labeler_species" : true,
+                "apply_nms_post_use_labeler_species" : true
+             }
+          ]
+       },
+       "australis":{
+          "right_whale+head_aerial":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Deepsense"
+                   },
+                   "description": "Deepsense aerial classifier (fixed matching set)"
+                }
+             ]
+          },
+          "right_whale+head_lateral":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Pie"
+                   },
+                   "description": "Pose-Invariant Embedding pattern-matcher"
+                }
+             ]
+
+          },
+          "right_whale":{
+             "_note": "this corresponds to a belly/body annotation",
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "sv_on":false
+                   },
+                   "description":"HotSpotter body pattern-matcher",
+               "default": false
+                }
+             ]
+          },
+          "right_whale+fluke":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"OC_WDTW"
+                   },
+                   "description":"Dynamic Time-Warping fluke edge-matcher"
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"CurvRankTwoFluke"
+                   },
+                   "description":"CurvRank v2 fluke edge-matcher"
+                }
+             ]
+          },
+          "right_whale+peduncle":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "sv_on":false
+                   },
+                   "description":"HotSpotter body pattern-matcher"
+                }
+             ]
+          },
+          "_default" : "@Eubalaena.australis.right_whale+head_aerial",
+          "_detect_conf":"@Eubalaena.glacialis._detect_conf"
+       }
+    },
+    "Pseudorca":{
+       "crassidens":{
+          "whale_falsekiller":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Finfindr"
+                   }
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"CurvRankTwoDorsal"
+                   },
+                   "description":"CurvRank v2 dorsal edge-matcher"
+                }
+             ],
+             "_save_as":"whale_falsekiller"
+          },
+          "whale_humpback+fin_dorsal":"@Pseudorca.crassidens.whale_falsekiller",
+          "dolphin_bottlenose+fin_dorsal":"@Pseudorca.crassidens.whale_falsekiller",
+          "dolphin_spotted+fin_dorsal":"@Pseudorca.crassidens.whale_falsekiller",
+          "whale_orca+fin_dorsal":"@Pseudorca.crassidens.whale_falsekiller",
+          "whale_fin+fin_dorsal":"@Pseudorca.crassidens.whale_falsekiller",
+          "whale_pilot+fin_dorsal":"@Pseudorca.crassidens.whale_falsekiller",
+          "_default":"@Pseudorca.crassidens.whale_falsekiller",
+          "_detect_conf":[
+                 {
+
+                   "labeler_algo": "densenet",
+                   "labeler_model_tag": "fins_v1",
+                   "model_tag": "fins_v1_dorsal",
+                   "nms_aware": "byclass",
+                   "nms_thresh": 0.6,
+                   "sensitivity": 0.53,
+                   "use_labeler_species": true,
+                   "viewpoints_to_keywords":{
+                         "left":"Left Dorsal Fin",
+                         "right":"Right Dorsal Fin"
+                   }
+                 }
+          ],
+          "match_trivial":true,
+          "common_name":"false killer whale"
+       }
+    },
+    "Grampus":{
+       "griseus":{
+          "dolphin_rissos":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "sv_on":true
+                   },
+                   "description": "HotSpotter pattern-matcher"
+                }
+             ],
+             "_save_as":"dolphin_rissos"
+          },
+          "dolphin_rissos+fin_dorsal":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Finfindr"
+                   },
+                   "description": "Finfindr dorsal edge-matcher"
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"CurvRankTwoDorsal"
+                   },
+                   "description": "CurvRank v2 dorsal edge-matcher"
+                }
+             ],
+             "_save_as":"dolphin_rissos+fin_dorsal"
+          },
+          "dolphin_spotted+fin_dorsal":"@Grampus.griseus.dolphin_rissos+fin_dorsal",
+          "dolphin_bottlenose+fin_dorsal":"@Grampus.griseus.dolphin_rissos+fin_dorsal",
+          "whale_orca+fin_dorsal":"@Grampus.griseus.dolphin_rissos+fin_dorsal",
+          "whale_fin+fin_dorsal":"@Grampus.griseus.dolphin_rissos+fin_dorsal",
+          "whale_pilot+fin_dorsal":"@Grampus.griseus.dolphin_rissos+fin_dorsal",
+          "whale_humpback+fin_dorsal":"@Grampus.griseus.dolphin_rissos+fin_dorsal",
+          "dolphin_spotted":"@Grampus.griseus.dolphin_rissos",
+          "dolphin_bottlenose":"@Grampus.griseus.dolphin_rissos",
+          "whale_orca":"@Grampus.griseus.dolphin_rissos",
+          "whale_fin":"@Grampus.griseus.dolphin_rissos",
+          "whale_pilot":"@Grampus.griseus.dolphin_rissos",
+          "whale_humpback":"@Grampus.griseus.dolphin_rissos",
+          "_detect_conf":[
+             {
+               "labeler_algo": "densenet",
+               "labeler_model_tag": "fins_v1",
+               "model_tag": "fins_v1_dorsal",
+               "nms_aware": "byclass",
+               "nms_thresh": 0.6,
+               "sensitivity": 0.53,
+               "use_labeler_species": true,
+               "viewpoints_to_keywords":{
+                     "left":"Left Dorsal Fin",
+                     "right":"Right Dorsal Fin"
+               }
+             }
+
+          ]
+       }
+    },
+    "Sotalia":{
+       "guianensis":{
+          "sotalia_guianensis":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Finfindr dorsal edge-matcher"
+                   }
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"CurvRankTwoDorsal"
+                   },
+                   "description":"CurvRank v2 dorsal edge-matcher"
+                }
+
+             ],
+             "_save_as":"sotalia_guianensis"
+          },
+          "whale_humpback+fin_dorsal":{
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"Finfindr"
+                   }
+                },
+                {
+                   "query_config_dict":{
+                      "pipeline_root":"CurvRankTwoDorsal"
+                   },
+                   "description":"CurvRank v2 dorsal edge-matcher"
+                }
+             ],
+             "_save_as":"sotalia_guianensis"
+          },
+          "dolphin_bottlenose+fin_dorsal":"@Sotalia.guianensis.sotalia_guianensis",
+          "dolphin_spotted+fin_dorsal":"@Sotalia.guianensis.sotalia_guianensis",
+          "whale_orca+fin_dorsal":"@Sotalia.guianensis.sotalia_guianensis",
+          "whale_fin+fin_dorsal":"@Sotalia.guianensis.sotalia_guianensis",
+          "whale_pilot+fin_dorsal":"@Sotalia.guianensis.sotalia_guianensis",
+          "_default":"@Sotalia.guianensis.sotalia_guianensis",
+          "_detect_conf":[
+                 {
+                   "labeler_algo": "densenet",
+                   "labeler_model_tag": "fins_v1",
+                   "model_tag": "fins_v1_dorsal",
+                   "nms_aware": "byclass",
+                   "nms_thresh": 0.6,
+                   "sensitivity": 0.53,
+                   "use_labeler_species": true,
+                   "viewpoints_to_keywords":{
+                         "left":"Left Dorsal Fin",
+                         "right":"Right Dorsal Fin"
+                   }
+                 }
+          ],
+          "match_trivial":true,
+          "common_name":"Guiana dolphin"
+       }
+    }
+ }

--- a/ia-configs/IA.giraffe.json
+++ b/ia-configs/IA.giraffe.json
@@ -1,0 +1,64 @@
+{
+	"_note": "The hierarchy of this file is genus->species->ia_class->_id_conf (id config). detect_config is under Genus->species. Keys with a leading underscore and their children are non-biological categories of config, like _id_conf and _detection_conf. Keys without leading underscores are semantic lookups that are derived from Wildbook data, e.g. Megaptera.novaeangliae.whale_fluke.",
+	"_default": "@Giraffa.camelopardalis.reticulata",
+	"Giraffa": {
+		"reticulata": "@Giraffa.tippelskirchii",
+
+		"giraffa": {
+			"angolensis": "@Giraffa.tippelskirchii",
+			"giraffa": "@Giraffa.tippelskirchii",
+
+			"_note": "below this is to handle the case where taxonomy = 'Giraffa.giraffa' (no 3rd term)",
+			"_detect_conf": "@Giraffa.tippelskirchii._detect_conf",
+			"giraffe_reticulated": "@Giraffa.tippelskirchii.giraffe_reticulated",
+			"giraffe_masai": "@Giraffa.tippelskirchii.giraffe_masai",
+			"giraffe_whole": "@Giraffa.tippelskirchii.giraffe_whole"
+		},
+
+		"camelopardalis": {
+			"camelopardalis": "@Giraffa.tippelskirchii",
+			"antiquorum": "@Giraffa.tippelskirchii",
+			"peralta": "@Giraffa.tippelskirchii",
+
+			"_note": "below this is to handle the case where taxonomy = 'Giraffa.camelopardalis' (no 3rd term)",
+			"_detect_conf": "@Giraffa.tippelskirchii._detect_conf",
+			"giraffe_reticulated": "@Giraffa.tippelskirchii.giraffe_reticulated",
+			"giraffe_masai": "@Giraffa.tippelskirchii.giraffe_masai",
+			"giraffe_whole": "@Giraffa.tippelskirchii.giraffe_whole"
+		},
+
+		"tippelskirchii": {
+			"_detect_conf": [
+				{
+					"xclass": "giraffe_reticulated",
+					"labeler_algo": "densenet",
+                    			"labeler_model_tag": "giraffe_v1",
+                    			"model_tag": "giraffe_v1",
+                    			"nms_thresh": 0.5,
+                    			"sensitivity": 0.58
+				}
+			],
+			"_id_conf": "@Giraffa.tippelskirchii.giraffe_whole._id_conf",
+
+			"giraffe_reticulated": {
+				"_save_as": "giraffe_whole",
+				"_id_conf": "@Giraffa.tippelskirchii.giraffe_whole._id_conf"
+			},
+			"giraffe_masai": {
+				"_save_as": "giraffe_whole",
+				"_id_conf": "@Giraffa.tippelskirchii.giraffe_whole._id_conf"
+			},
+
+			"giraffe_whole": {
+				"_id_conf": [
+					{
+						"query_config_dict": {
+							"sv_on": false
+						},
+						"description": "HotSpotter pattern-matcher"
+					}
+				]
+			}
+		}
+	}
+}

--- a/ia-configs/IA.grouper.json
+++ b/ia-configs/IA.grouper.json
@@ -1,0 +1,41 @@
+{
+    "_note": "The hierarchy of this file is genus->species->ia_class->_id_conf (id config). detect_config is under Genus->species. Keys with a leading underscore and their children are non-biological categories of config, like _id_conf and _detection_conf. Keys without leading underscores are semantic lookups that are derived from Wildbook data, e.g. Megaptera.novaeangliae.whale_fluke.",
+    "_default": "@Epinephelus.striatus",
+    "Epinephelus": {
+      "striatus": {
+        "_default":{
+          "_id_conf": "@Epinephelus.striatus.grouper_nassau._id_conf"
+        },
+        "_detect_conf": [
+          {
+            "model_tag": "nassau_grouper_v3",
+            "labeler_model_tag": "nassau_grouper_v3",
+            "labeler_algo": "densenet",
+            "nms_aware": null,
+            "nms_thresh": 0.40,
+            "sensitivity": 0.46
+          }
+        ],
+        "nassau_grouper":{
+          "_id_conf": [
+            {
+              "query_config_dict": {
+                "sv_on":true
+              },
+              "description": "HotSpotter pattern-matcher"
+            }
+          ]
+        },
+        "grouper_nassau":{
+          "_id_conf": [
+            {
+              "query_config_dict": {
+                "sv_on":true
+              },
+              "description": "HotSpotter pattern-matcher"
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/ia-configs/IA.lynx.json
+++ b/ia-configs/IA.lynx.json
@@ -1,0 +1,78 @@
+{
+    "_note":"The hierarchy of this file is genus->species->ia_class->_id_conf (id config). detect_config is under Genus->species. Keys with a leading underscore and their children are non-biological categories of config, like _id_conf and _detection_conf. Keys without leading underscores are semantic lookups that are derived from Wildbook data, e.g. Megaptera.novaeangliae.whale_fluke.",
+    "_default":"@Lynx.pardinus",
+    "Lynx": {
+        "pardinus": {
+            "_detect_conf": [
+                {
+                    "model_tag":"lynx",
+                    "labeler_model_tag":"lynx_v3",
+                    "labeler_algo":"densenet",
+                    "nms_aware": null,
+                    "nms_thresh": 0.41,
+                    "sensitivity": 0.41
+                }
+            ],
+            "lynx_pardinus": {
+                "_id_conf": [
+                {"query_config_dict": {"sv_on": false} }
+                ]
+            },
+            "lynx": {
+                "_id_conf": [
+                {"query_config_dict": {"sv_on": false} }
+                ]
+            }
+        },
+        "_note":"I know, I know....",
+        "Pardinus": {
+            "_detect_conf": [
+                {
+                    "model_tag":"lynx",
+                    "labeler_model_tag":"lynx_v3",
+                    "labeler_algo":"densenet",
+                    "nms_aware": null,
+                    "nms_thresh": 0.41,
+                    "sensitivity": 0.41
+                }
+            ],
+            "lynx_pardinus": {
+                "_id_conf": [
+                {"query_config_dict": {"sv_on": false} }
+                ]
+            },
+            "lynx": {
+                "_id_conf": [
+                {"query_config_dict": {"sv_on": false} }
+                ]
+            }
+        },
+        "lynx": {
+            "_detect_conf": [
+                {
+                    "model_tag":"lynx",
+                    "labeler_model_tag":"lynx_v3",
+                    "labeler_algo":"densenet",
+                    "nms_aware": null,
+                    "nms_thresh": 0.41,
+                    "sensitivity": 0.41
+                }
+            ],
+            "lynx_pardinus": {
+                "_id_conf": [
+                {"query_config_dict": {"sv_on": false} }
+                ]
+            },
+            "lynx_lynx": {
+                "_id_conf": [
+                {"query_config_dict": {"sv_on": false} }
+                ]
+            },
+            "lynx": {
+                "_id_conf": [
+                {"query_config_dict": {"sv_on": false} }
+                ]
+            }
+        }
+    }
+}

--- a/ia-configs/IA.sea_turtle.json
+++ b/ia-configs/IA.sea_turtle.json
@@ -1,0 +1,77 @@
+{
+    "_note":"The hierarchy of this file is genus->species->ia_class->_id_conf (id config). detect_config is under Genus->species. Keys with a leading underscore and their children are non-biological categories of config, like _id_conf and _detection_conf. Keys without leading underscores are semantic lookups that are derived from Wildbook data, e.g. Megaptera.novaeangliae.whale_fluke.",
+    "_default":"@Eretmochelys.imbricata",
+    "Eretmochelys": {
+       "imbricata": {
+          "_detect_conf": [
+             {
+                "model_tag":"iot_v0",
+                "labeler_model_tag":"iot_v0",
+                "labeler_algo":"densenet",
+                "nms_aware":"ispart",
+                "nms_thresh": 0.50,
+                "sensitivity": 0.36
+             }
+          ],
+          "turtle_green+head": {
+            "_id_conf": [
+              {"query_config_dict": {"sv_on": true} }
+            ]
+          },
+          "turtle_hawksbill+head": {
+             "_id_conf": [
+               {"query_config_dict": {"sv_on": true} }
+             ]
+          }
+
+       }
+    },
+    "Chelonia": {
+       "mydas": {
+          "_detect_conf": [
+             {
+                "model_tag":"iot_v0",
+                "labeler_model_tag":"iot_v0",
+                "labeler_algo":"densenet",
+                "nms_aware": "ispart",
+                "nms_thresh": 0.50,
+                "sensitivity": 0.36
+             }
+          ],
+          "turtle_green+head": {
+             "_id_conf": [
+               {"query_config_dict": {"sv_on": true} }
+             ]
+          },
+          "turtle_hawksbill+head": {
+            "_id_conf": [
+              {"query_config_dict": {"sv_on": true} }
+            ]
+         }
+       }
+    },
+    "Lepidochelys": {
+       "olivacea": {
+          "_detect_conf": [
+             {
+                "model_tag":"iot_v0",
+                "labeler_model_tag":"iot_v0",
+                "labeler_algo":"densenet",
+                "nms_aware": "ispart",
+                "nms_thresh": 0.50,
+                "sensitivity": 0.36
+             }
+          ],
+          "turtle_oliveridley+head": {
+             "_id_conf": [
+               {"query_config_dict": {"sv_on": true} }
+             ]
+          },
+          "turtle_hawksbill+head": {
+            "_id_conf": [
+              {"query_config_dict": {"sv_on": true} }
+            ]
+          }
+       }
+    }
+ }

--- a/ia-configs/IA.seadragon.json
+++ b/ia-configs/IA.seadragon.json
@@ -1,0 +1,93 @@
+{
+    "_note":"The hierarchy of this file is genus->species->ia_class->_id_conf (id config). detect_config is under Genus->species. Keys with a leading underscore and their children are non-biological categories of config, like _id_conf and _detection_conf. Keys without leading underscores are semantic lookups that are derived from Wildbook data, e.g. Megaptera.novaeangliae.whale_fluke.",
+    "_default":"@Phycodurus.eques",
+
+    "Phycodurus":{
+
+       "eques":{
+
+          "seadragon_leafy+head":{
+             "_note": "this corresponds to a head annotation",
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "sv_on":true
+                   },
+                   "description":"HotSpotter head pattern-matcher"
+                }
+             ]
+          },
+          "seadragon_leafy":{
+             "_note": "this corresponds to a body annotation",
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "sv_on":true
+                   },
+                   "description":"HotSpotter body pattern-matcher",
+                   "default": false
+                }
+             ]
+          },
+          "seadragon_weedy":"@Phycodurus.eques.seadragon_leafy",
+          "seadragon_weedy+head":"@Phycodurus.eques.seadragon_leafy+head",
+          "_default" : "@Phycodurus.eques.seadragon_leafy+head",
+          "_detect_conf":[
+             {
+                "model_tag"           : "seadragon_v1",
+                "sensitivity"         : 0.55,
+                "nms_thresh"          : 0.40,
+                "nms_aware"           : "ispart",
+                "labeler_algo"        : "densenet",
+                "labeler_model_tag"   : "seadragon_v2",
+                "use_labeler_species" : true,
+                "apply_nms_post_use_labeler_species" : true
+             }
+          ]
+       }
+    },
+       "Phyllopteryx":{
+
+       "taeniolatus":{
+
+          "seadragon_weedy+head":{
+             "_note": "this corresponds to a head annotation",
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "sv_on":true
+                   },
+                   "description":"HotSpotter head pattern-matcher"
+                }
+             ]
+          },
+          "seadragon_weedy":{
+             "_note": "this corresponds to a body annotation",
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "sv_on":true
+                   },
+                   "description":"HotSpotter body pattern-matcher",
+                   "default": false
+                }
+             ]
+          },
+          "seadragon_leafy":"@Phyllopteryx.taeniolatus.seadragon_weedy",
+          "seadragon_leafy+head":"@Phyllopteryx.taeniolatus.seadragon_weedy+head",
+          "_default" : "@Phyllopteryx.taeniolatus.seadragon_leafy+head",
+          "_detect_conf":[
+             {
+                "model_tag"           : "seadragon_v1",
+                "sensitivity"         : 0.55,
+                "nms_thresh"          : 0.40,
+                "nms_aware"           : "ispart",
+                "labeler_algo"        : "densenet",
+                "labeler_model_tag"   : "seadragon_v2",
+                "use_labeler_species" : true,
+                "apply_nms_post_use_labeler_species" : true
+             }
+          ]
+       }
+    }
+ }

--- a/ia-configs/IA.skunk.json
+++ b/ia-configs/IA.skunk.json
@@ -1,0 +1,30 @@
+{
+    "_note": "The hierarchy of this file is genus->species->ia_class->_id_conf (id config). detect_config is under Genus->species. Keys with a leading underscore and their children are non-biological categories of config, like _id_conf and _detection_conf. Keys without leading underscores are semantic lookups that are derived from Wildbook data, e.g. Megaptera.novaeangliae.whale_fluke.",
+    "_default": "@Spilogale.gracilis",
+    "Spilogale": {
+      "gracilis": {
+        "_default":{
+          "_id_conf": "@Spilogale.gracilis.skunk_spotted._id_conf"
+        },
+        "_detect_conf": [
+          {
+            "labeler_algo": "densenet",
+            "labeler_model_tag": "spotted_skunk_v0",
+            "model_tag": "spotted_skunk_v0",
+            "nms_thresh": 0.40,
+            "sensitivity": 0.62
+          }
+        ],
+        "skunk_spotted":{
+          "_id_conf": [
+            {
+              "query_config_dict": {
+                "sv_on":false
+              },
+              "description": "HotSpotter pattern-matcher"
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/ia-configs/IA.whaleshark.json
+++ b/ia-configs/IA.whaleshark.json
@@ -1,0 +1,42 @@
+{
+    "_note":"The hierarchy of this file is genus->species->ia_class->_id_conf (id config). detect_config is under Genus->species. Keys with a leading underscore and their children are non-biological categories of config, like _id_conf and _detection_conf. Keys without leading underscores are semantic lookups that are derived from Wildbook data, e.g. Megaptera.novaeangliae.whale_fluke.",
+    "_default":"@Rhincodon.typus",
+    "Rhincodon":{
+
+       "typus":{
+
+          "whalesharkCR":{
+
+             "_id_conf":[
+                {
+                   "query_config_dict":{
+                      "pipeline_root": "PieTwo"
+                   },
+                   "description":"PIE v2 pattern-matcher"
+                },
+                {
+                   "query_config_dict":{
+                      "sv_on":false
+                   },
+                   "description":"SLOW: HotSpotter body pattern-matcher",
+                   "default": false
+                }
+             ]
+          },
+          "whaleshark":{
+             "_id_conf":[
+             ]
+          },
+          "_default" : "@Rhincodon.typus.whaleshark",
+          "_detect_conf":[
+             {
+
+                "start_detect": "yolo",
+                "model_tag": "sea"
+
+             }
+          ]
+       }
+
+    }
+ }

--- a/ia-configs/IA.whiskerbook.json
+++ b/ia-configs/IA.whiskerbook.json
@@ -1,0 +1,109 @@
+{
+    "_note": "The hierarchy of this file is genus->species->ia_class->_id_conf (id config). detect_config is under Genus->species. Keys with a leading underscore and their children are non-biological categories of config, like _id_conf and _detection_conf. Keys without leading underscores are semantic lookups that are derived from Wildbook data, e.g. Megaptera.novaeangliae.whale_fluke.",
+    "_default": "@Panthera.onca",
+    "Panthera": {
+      "uncia": {
+        "_default":{
+          "_id_conf": "@Panthera.uncia.snow_leopard._id_conf"
+        },
+        "_detect_conf": [
+          {
+            "labeler_algo": "densenet",
+            "model_tag": "snow_leopard_v0",
+            "nms_thresh": 0.40,
+            "sensitivity": 0.44
+          }
+        ],
+        "snow_leopard":{
+          "_id_conf": [
+            {
+              "query_config_dict": {
+                "sv_on":true
+              },
+              "description": "HotSpotter pattern-matcher"
+            }
+          ]
+        }
+      },
+      "onca": {
+        "_default":{
+          "_id_conf": "@Panthera.onca.jaguar._id_conf"
+        },
+        "_detect_conf": [
+          {
+            "labeler_algo": "densenet",
+            "model_tag": "jaguar_v2",
+            "nms_thresh": 0.50,
+            "sensitivity": 0.50
+          }
+        ],
+        "onca": "@Panthera.onca.jaguar",
+        "jaguar":{
+          "_id_conf": [
+            {
+              "query_config_dict": {
+                "sv_on":true
+              },
+              "description": "HotSpotter pattern-matcher"
+            }
+          ]
+        }
+      },
+      "pardus": {
+           "_detect_conf": [
+              {
+                 "model_tag":"leopard_v0",
+                 "viewpoint_model_tag":"leopard_v0",
+                 "labeler_algo":"densenet",
+                 "nms_aware": null,
+                 "nms_thresh": 0.50,
+                 "sensitivity": 0.73
+              }
+           ],
+           "leopard": {
+              "_id_conf": [
+                {"query_config_dict": {"sv_on": true} }
+              ]
+           }
+        }
+    },
+    "Acinonyx": {
+        "jubatus": {
+           "_detect_conf": [
+              {
+                 "model_tag":"cheetah_v1",
+                 "labeler_model_tag":"cheetah_v1",
+                 "labeler_algo":"densenet",
+                 "nms_aware": "byclass",
+                 "nms_thresh": 0.60,
+                 "sensitivity": 0.62
+              }
+           ],
+           "cheetah": {
+              "_id_conf": [
+                {"query_config_dict": {"sv_on": true} }
+              ]
+           }
+        }
+     },
+
+     "Lynx": {
+          "lynx": {
+              "_detect_conf": [
+                  {
+                      "model_tag":"lynx",
+                      "labeler_model_tag":"lynx_v3",
+                      "labeler_algo":"densenet",
+                      "nms_aware": null,
+                      "nms_thresh": 0.41,
+                      "sensitivity": 0.41
+                  }
+              ],
+              "lynx_pardinus": {
+                  "_id_conf": [
+                  {"query_config_dict": {"sv_on": false} }
+                  ]
+              }
+          }
+      }
+  }

--- a/ia-configs/IA.zebra.json
+++ b/ia-configs/IA.zebra.json
@@ -1,0 +1,33 @@
+{
+    "_note": "The hierarchy of this file is genus->species->ia_class->_id_conf (id config). detect_config is under Genus->species. Keys with a leading underscore and their children are non-biological categories of config, like _id_conf and _detection_conf. Keys without leading underscores are semantic lookups that are derived from Wildbook data, e.g. Megaptera.novaeangliae.whale_fluke.",
+    "_default": "@Equus.quagga",
+    "Equus": {
+      "grevyi": "@Equus.quagga",
+      "quagga+quagga": "@Equus.quagga",
+      "quagga": {
+        "_default":{
+          "_id_conf": "@Equus.quagga.zebra._id_conf"
+        },
+        "_detect_conf": [
+          {
+            "labeler_algo": "densenet",
+            "labeler_model_tag": "zebra_v1",
+            "model_tag": "ggr2",
+            "nms_thresh": 0.4,
+            "sensitivity": 0.4
+          }
+        ],
+        "zebra_grevys": "@Equus.quagga.zebra",
+        "zebra":{
+          "_id_conf": [
+            {
+              "query_config_dict": {
+                "sv_on":false
+              },
+              "description": "HotSpotter pattern-matcher"
+            }
+          ]
+        }
+      }
+    }
+}

--- a/ia-configs/ia-config.md
+++ b/ia-configs/ia-config.md
@@ -1,0 +1,22 @@
+# IA Config Setup
+
+## Historical IA.json
+
+IA.json files are how Codex and Wildbook retrieves parameters for detection and Id jobs sent to WBIA.
+Each one targets various species with a scientific name and gets back things like ```model_name``` or ```sensitivity```
+to include in a JSON payload.
+
+In Wildbook, an encounter to be submitted via encounter form or bulk upload usually has been set with a species and genus to target one of
+these configs. If there is no species and genus, typically in a single species Wildbook we can target a default.
+
+## Changes in IA.json for porting to Codex
+
+* Omit the URLs from all IA json files. This should be gleaned from the ```.env``` configuration for the WBIA instance being used.
+* Rename each file to a unique name like changing IOT IA.json to IA.sea_turtle.json
+* Add a IA.GLOBAL.json file to hold global API endpoints. (Not complete URLs)
+* The globals file will split the ```start_detect``` value into another object with both "yolo" and "lightnet" keys.
+    * A key will be added to detect blocks to specify something other than lightnet.
+
+Since some IA.json files contain many species (looking at you, Flukebook) it would be a burden to tease every IA.json file for every
+Wildbook apart into separate IA.\<genus_species\>.json. Since the genus resides at the top level of each of these files,
+they should be able to be traversed quickly near as-is.


### PR DESCRIPTION
## Pull Request Overview

Moves all production IA config files to Codex. This should allow selection of the species model you 
are targeting from the ones we actually use.

Mostly just a move of the existing json files, but with a couple changes:

* Added a unique platform tag to each file like ```IA.sea_turtle.json``` so they can exist in parallel without having a gigantic combined file.
* Added a GLOBAL file for WBIA endpoints to target. They are shared and only need to be defined once. The domain to target can be defined in ```.env```.
* Added a choice for detection endpoint to globals- yolo or lightnet
* Removed all URLs from the copied files.
* Added an in-progress readme to the /ia-configs/ folder to keep track of what's happening for myself and others.

---

**Review Notes**
Nothing is hooked up yet, this is just adding the configs. Review should include looking at the new globals file and verifying my excision of URLs will not be a problem.

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [x] Ensure that the PR is properly reviewed
