### PR TITLE
Add check for signing into GitLab service

### DIFF
--- a/deploy/codex/houston/docker-entrypoint-init.d/_set_up_gitlab.py
+++ b/deploy/codex/houston/docker-entrypoint-init.d/_set_up_gitlab.py
@@ -31,7 +31,14 @@ def parse_form(session, url, form_id):
     try:
         form = html.get_element_by_id(form_id)
     except KeyError:  # NoneType
-        raise RuntimeError(f'form not found in {resp} for {url}')
+        formatted_forms = '\n'.join(
+            [f"{f.attrib.get('id', '?no-id?')} ({f})" for f in html.forms]
+        )
+        print(
+            f"ERROR: form '{form_id}' not found in {resp} for '{url}'; found the following forms: "
+        )
+        print(formatted_forms)
+        sys.exit(1)
     return dict(form.fields), form.action
 
 


### PR DESCRIPTION
## Pull Request Overview

This attempts to further diagnose the following error.

```
Traceback (most recent call last):
  File "/docker-entrypoint-init.d/_set_up_gitlab.py", line 89, in <module>
    main()
  File "/docker-entrypoint-init.d/_set_up_gitlab.py", line 76, in main
    form_data, action = parse_form(session, url, 'new_personal_access_token')
  File "/docker-entrypoint-init.d/_set_up_gitlab.py", line 27, in parse_form
    raise RuntimeError(f'form not found in {resp} for {url}')
RuntimeError: form not found in <Response [200]> for http://gitlab/-/profile/personal_access_tokens
```

Attempting to diagnose whether the user is even signed into the
service prior to hitting the PAT creation URL.

---

**Review Notes**
n/a

**Pull Request Checklist**
- [X] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [X] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [X] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [X] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [X] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [X] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
