### PR TITLE
DEX-274 Add /api/v1/site-info/ to show version

### DIFF
--- a/app/modules/site_info.py
+++ b/app/modules/site_info.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+import app.version
+from app.extensions.api import api_v1, Namespace
+from flask_restx_patched import Resource
+
+
+site_info_api = Namespace('site-info', description='Site Info')
+
+
+def init_app(app, **kwargs):
+    api_v1.add_namespace(site_info_api)
+
+
+@site_info_api.route('/')
+class SiteInfo(Resource):
+    def get(self):
+        return {
+            'houston': {
+                'version': app.version.version,
+                'git_version': app.version.git_revision,
+            },
+        }

--- a/config.py
+++ b/config.py
@@ -141,6 +141,7 @@ class BaseConfig(object):
         'individuals',
         'annotations',
         'site_settings',
+        'site_info',
 
         # Front-end
         #   Dependencies: Users, Auth, Assets

--- a/tests/modules/test_site_info.py
+++ b/tests/modules/test_site_info.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+import app.version
+
+
+def test_site_info(flask_app_client):
+    resp = flask_app_client.get('/api/v1/site-info/')
+    assert resp.status_code == 200
+    assert resp.content_type == 'application/json'
+    assert resp.json == {
+        'houston': {
+            'version': app.version.version,
+            'git_version': app.version.git_revision,
+        },
+    }


### PR DESCRIPTION
```
GET /api/v1/site-info/
```

returns

```
{
    "version": "0.1.0.69064a81",
    "git_version": "69064a81dc498dcb688e2a8ef0d889c270b9226d"
}
```


**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
