### PR TITLE
DEX-260 Implement local alternative to gitlab

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -108,6 +108,10 @@ jobs:
           docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e SQLALCHEMY_DATABASE_URI=$SQLALCHEMY_DATABASE_URI houston pytest -s -v
           docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e SQLALCHEMY_DATABASE_URI=$SQLALCHEMY_DATABASE_URI houston pytest -s -v
 
+      - name: Run tests with local git
+        run: |
+          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e SQLALCHEMY_DATABASE_URI=$SQLALCHEMY_DATABASE_URI -e GITLAB_REMOTE_URI=/data/var/git_remote houston pytest -s -v
+
       - name: Check DB migrations (sqlite)
         if: matrix.db-uri == 'sqlite://'
         run: |

--- a/app/extensions/asset_group/__init__.py
+++ b/app/extensions/asset_group/__init__.py
@@ -8,7 +8,6 @@ import logging
 
 from flask import current_app, request, session, render_template  # NOQA
 from flask_login import current_user  # NOQA
-import gitlab
 import git
 import json
 import os
@@ -16,6 +15,8 @@ from pathlib import Path
 import utool as ut
 
 import keyword
+
+from .. import git_remote
 
 
 KEYWORD_SET = set(keyword.kwlist)
@@ -52,8 +53,8 @@ class AssetGroupManager(object):
         return self._mime_type_whitelist_guid
 
     @property
-    def _gitlab_group(self):
-        """Lookup the GitLab Group from the Namespace"""
+    def _git_remote_group(self):
+        """Lookup the Git remote Group from the Namespace"""
 
         self._ensure_initialized()
         # Lookup the cached group
@@ -65,16 +66,16 @@ class AssetGroupManager(object):
         self._gl_group = self.gl.groups.get(group_id, retry_transient_errors=True)
         return self._gl_group
 
-    def _get_gitlab_project(self, name):
-        """Lookup a specific gitlab project/repo by name that is within the preconfigured namespace/group"""
+    def _get_git_remote_project(self, name):
+        """Lookup a specific git remote project/repo by name that is within the preconfigured namespace/group"""
         self._ensure_initialized()
 
         # Try to find remote project by asset_group UUID
-        projects = self._gitlab_group.projects.list(
+        projects = self._git_remote_group.projects.list(
             search=name, retry_transient_errors=True
         )
         if len(projects) != 0:
-            assert len(projects) >= 1, 'Failed to create gitlab namespace!?'
+            assert len(projects) >= 1, 'Failed to create git remote namespace!?'
             return projects[0]
         else:
             return None
@@ -94,7 +95,7 @@ class AssetGroupManager(object):
             log.info('\t NS : %r' % (remote_namespace,))
 
             try:
-                self.gl = gitlab.Gitlab(
+                self.gl = git_remote.GitRemote(
                     remote_uri, private_token=remote_personal_access_token
                 )
                 self.gl.auth()
@@ -112,7 +113,7 @@ class AssetGroupManager(object):
                         )
                         namespace = self.gl.namespaces.get(id=group.id)
                         namespaces = self.gl.namespaces.list(search=remote_namespace)
-                    assert len(namespaces) >= 1, 'Failed to create gitlab namespace!?'
+                    assert len(namespaces) >= 1, 'Failed to create git remote namespace!?'
                     namespace = namespaces[0]
 
                 self.namespace = namespace
@@ -171,7 +172,7 @@ class AssetGroupManager(object):
         self._ensure_initialized()
 
         project_name = str(asset_group.guid)
-        project = self._get_gitlab_project(project_name)
+        project = self._get_git_remote_project(project_name)
 
         if project:
             log.info(
@@ -232,11 +233,11 @@ class AssetGroupManager(object):
         if not os.path.exists(git_path):
             repo = git.Repo.init(group_path)
             assert len(repo.remotes) == 0
-            gitlab_remote_public_name = current_app.config.get('GITLAB_PUBLIC_NAME', None)
-            gitlab_remote_email = current_app.config.get('GITLAB_EMAIL', None)
-            assert None not in [gitlab_remote_public_name, gitlab_remote_email]
-            repo.git.config('user.name', gitlab_remote_public_name)
-            repo.git.config('user.email', gitlab_remote_email)
+            git_remote_public_name = current_app.config.get('GITLAB_PUBLIC_NAME', None)
+            git_remote_email = current_app.config.get('GITLAB_EMAIL', None)
+            assert None not in [git_remote_public_name, git_remote_email]
+            repo.git.config('user.name', git_remote_public_name)
+            repo.git.config('user.email', git_remote_email)
         else:
             repo = git.Repo(group_path)
 
@@ -304,7 +305,7 @@ class AssetGroupManager(object):
 
     def assert_taglist(self, asset_group_uuid, whitelist_tag):
         project_name = str(asset_group_uuid)
-        project = self._get_gitlab_project(project_name)
+        project = self._get_git_remote_project(project_name)
         assert (
             whitelist_tag in project.tag_list
         ), 'Project %r needs to be re-provisioned: %r' % (
@@ -313,12 +314,12 @@ class AssetGroupManager(object):
         )
 
     def is_asset_group_on_remote(self, asset_group_uuid):
-        project = self._get_gitlab_project(asset_group_uuid)
+        project = self._get_git_remote_project(asset_group_uuid)
         return project is not None
 
     def delete_remote_asset_group(self, asset_group):
         self._ensure_initialized()
-        project = self._get_gitlab_project(asset_group)
+        project = self._get_git_remote_project(asset_group)
         if project:
             self.delete_remote_project(project)
 
@@ -327,7 +328,7 @@ class AssetGroupManager(object):
         try:
             self.gl.projects.delete(project.id)
             return True
-        except gitlab.GitlabDeleteError:
+        except git_remote.GitRemote.GitRemoteDeleteError:
             pass
         return False
 

--- a/app/extensions/git_remote.py
+++ b/app/extensions/git_remote.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+
+from collections import namedtuple
+import datetime
+import json
+from pathlib import Path
+
+import git
+
+
+class GitRemote:
+    def __new__(self, remote_uri, **kwargs):
+        if remote_uri.startswith('http'):
+            import gitlab
+
+            gl = gitlab.Gitlab(remote_uri, **kwargs)
+            gl.GitRemoteDeleteError = gitlab.GitlabDeleteError
+            return gl
+        else:
+
+            class GitRemoteDeleteError(Exception):
+                pass
+
+            gl = GitRemoteLocal(remote_uri, **kwargs)
+            gl.GitRemoteDeleteError = GitRemoteDeleteError
+            return gl
+
+
+class GitRemoteLocal:
+    def __init__(self, remote_uri, **kwargs):
+        self.root = Path(remote_uri)
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.namespaces = LocalNamespaces()
+        self.groups = LocalGroups(self)
+        self.projects = LocalProjects(self, self.root)
+        self.user = LocalUser('user_id')
+
+    def auth(self):
+        # Not implementing auth
+        pass
+
+
+LocalUser = namedtuple('LocalUser', ['id'])
+LocalNamespace = namedtuple('LocalNamespace', ['id', 'name'])
+
+
+class LocalNamespaces:
+    # Not implementing namespace
+
+    def get(self, id):
+        # namespace is always found
+        return LocalNamespace(id, id)
+
+    def list(self, search):
+        # namespace is always found
+        return [LocalNamespace(search, search)]
+
+
+class LocalGroup:
+    def __init__(self, id, git_remote):
+        self.id = id
+        # group projects is the same as the global projects
+        self.projects = git_remote.projects
+
+
+class LocalGroups:
+    # Not implementing groups
+    def __init__(self, git_remote):
+        self.git_remote = git_remote
+
+    def create(self, args):
+        return LocalGroup(args['name'], self.git_remote)
+
+    def get(self, id, **kwargs):
+        return LocalGroup(id, self.git_remote)
+
+
+LocalProject = namedtuple(
+    'LocalProject',
+    [
+        'path',
+        'description',
+        'namespace',
+        'tag_list',
+        'web_url',
+        'created_at',
+        'id',
+        'path_with_namespace',
+    ],
+)
+
+
+class LocalProjects:
+    def __init__(self, git_remote, root):
+        self.git_remote = git_remote
+        self.root = root
+        self.projects_path = self.root / 'projects.json'
+        self.projects = {}
+        if self.projects_path.exists():
+            with self.projects_path.open('r') as f:
+                try:
+                    projects = json.load(f)
+                    for key, project in projects.items():
+                        if (self.root / key).exists():
+                            self.projects[key] = LocalProject(*project)
+                except (json.decoder.JSONDecodeError, TypeError):
+                    self.projects = {}
+
+    def list(self, search, **kwargs):
+        search = str(search)
+        if search in self.projects:
+            return [self.projects[search]]
+        return []
+
+    def create(self, args, **kwargs):
+        project = LocalProject(
+            path=args['path'],
+            tag_list=sorted(args['tag_list']),
+            description=args['description'],
+            namespace={'id': args['namespace_id'], 'name': args['namespace_id']},
+            web_url=str(self.root / args['path']),
+            created_at=f'{datetime.datetime.now().isoformat()}Z',
+            id=args['path'],
+            path_with_namespace=f"{args['path']} {args['namespace_id']}",
+        )
+        git.Repo.init(project.web_url, bare=True)
+        self.projects[project.path] = project
+        with self.projects_path.open('w') as f:
+            json.dump(self.projects, f)
+        return project
+
+    def delete(self, id):
+        if id in self.projects:
+            self.projects.pop(id)
+            with self.projects_path.open('w') as f:
+                json.dump(self.projects, f)
+        else:
+            raise self.git_remote.GitRemoteDeleteError()

--- a/tests/extensions/test_git_remote.py
+++ b/tests/extensions/test_git_remote.py
@@ -1,0 +1,97 @@
+# -*- coding: utf-8 -*-
+from pathlib import Path
+import tempfile
+
+import pytest
+
+from app.extensions.git_remote import GitRemote
+
+
+def test_git_remote_local(request):
+    td = tempfile.TemporaryDirectory()
+
+    def clean_up_td():
+        if Path(td.name).exists():
+            td.cleanup()
+
+    request.addfinalizer(clean_up_td)
+
+    projects_json = Path(td.name) / 'projects.json'
+    with projects_json.open('w') as f:
+        f.write('not json')
+
+    g = GitRemote(td.name)
+    assert g.projects.list('TEST') == []
+
+    with projects_json.open('w') as f:
+        f.write(
+            """\
+{"00000000-0000-0000-0000-000000000002": [
+    "00000000-0000-0000-0000-000000000002",
+    "This is a required PyTest submission (do not delete)",
+    {"id": "TEST", "name": "TEST"},
+    ["type:pytest-required", "type:test"],
+    "/code/_db/git_remote/00000000-0000-0000-0000-000000000002",
+    "2021-04-18T21:17:22.880161Z",
+    "00000000-0000-0000-0000-000000000002",
+    "00000000-0000-0000-0000-000000000002 TEST"
+]}"""
+        )
+
+    g = GitRemote(td.name)
+    assert g.projects.list('00000000-0000-0000-0000-000000000002') == []
+
+    (Path(td.name) / '00000000-0000-0000-0000-000000000002').mkdir()
+    g = GitRemote(td.name)
+    projects = g.projects.list('00000000-0000-0000-0000-000000000002')
+    assert len(projects) == 1
+    assert projects[0].id == '00000000-0000-0000-0000-000000000002'
+
+    group_projects = g.groups.get('group_id').projects.list(
+        '00000000-0000-0000-0000-000000000002'
+    )
+    assert group_projects == projects
+
+    projects_json.unlink()
+
+    g = GitRemote(td.name)
+    g.auth()  # does not do anything
+
+    user_namespace = g.namespaces.get(id=g.user.id)
+    assert user_namespace.id == g.user.id
+    namespaces = g.namespaces.list(search='TEST')
+    assert len(namespaces) == 1
+    assert namespaces[0].id == 'TEST'
+
+    group = g.groups.get('TEST', retry_transient_errors=True)
+    assert group.id == 'TEST'
+    group = g.groups.create({'name': 'TEST2', 'path': 'test'})
+    assert group.id == 'TEST2'
+
+    project = g.projects.create(
+        {
+            'path': 'project_name',
+            'description': 'project description',
+            'emails_disabled': True,
+            'namespace_id': 'TEST',
+            'visibility': 'private',
+            'merge_method': 'rebase_merge',
+            'tag_list': ['tag:pytest'],
+            'lfs_enabled': True,
+        },
+        retry_transient_errors=True,
+    )
+    assert project.path == 'project_name'
+    assert project.description == 'project description'
+    assert project.namespace == {'id': 'TEST', 'name': 'TEST'}
+    assert project.tag_list == ['tag:pytest']
+
+    projects = g.projects.list('project_name')
+    assert len(projects) == 1
+    assert projects[0] == project
+
+    g.projects.delete(project.id)
+    assert g.projects.list('project_name') == []
+
+    with pytest.raises(g.GitRemoteDeleteError):
+        g.projects.delete(project.id)


### PR DESCRIPTION
If GITLAB_REMOTE_URI is set to a file path, the local alternative to
gitlab is used, for example:

```
GITLAB_REMOTE_URI=/code/_db/git_remote/ pytest
```

runs the tests using git repositories locally without gitlab.

This is currently only for development.  This was done to try to allow
local development without a gitlab instance which uses up a lot of
memory.



**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
