### PR TITLE
DEX-260 Add development docker-compose to remove gitlab

### DIFF
--- a/deploy/codex/README.md
+++ b/deploy/codex/README.md
@@ -45,6 +45,23 @@ Precision nuke example:
 
     docker-compose stop houston && docker-compose rm -f houston && docker volume rm codex_houston-var
 
+#### Running without gitlab
+
+Running the gitlab service takes up lots of memory and if you are unable to run
+it , it is possible to use the development local git alternative.  If you
+already started gitlab and houston, you can stop them by doing:
+
+    docker-compose rm --stop -f houston gitlab
+    docker volume rm $(docker volume ls -q -f dangling=true | grep gitlab-var)
+    docker volume rm $(docker volume ls -q -f dangling=true | grep houston-var)
+
+Use the development docker-compose file:
+
+    ln -s docker-compose.dev.yml docker-compose.override.yml
+    docker-compose up -d
+
+This should create the houston service again but not the gitlab one.
+
 #### Running the tests
 
 During development, we mount the code directory and by default run commands as

--- a/deploy/codex/docker-compose.dev.yml
+++ b/deploy/codex/docker-compose.dev.yml
@@ -1,0 +1,11 @@
+version: "3.8"
+
+services:
+
+  gitlab:  # disable gitlab
+    deploy:
+      replicas: 0
+
+  houston:
+    environment:
+      GITLAB_REMOTE_URI: /data/var/git_remote

--- a/deploy/codex/houston/docker-entrypoint-init.d/set_up_gitlab.sh
+++ b/deploy/codex/houston/docker-entrypoint-init.d/set_up_gitlab.sh
@@ -23,6 +23,11 @@ gitlab() {
 }
 
 _main() {
+    if [ "${GITLAB_REMOTE_URI:0:4}" != "http" ]; then
+        echo "Not using gitlab, exit"
+        exit
+    fi
+
     # Wait for gitlab to come online... this takes awhile, so we give feedback
     while ! $(wait-for -t 10 "${GITLAB_HOST}:${GITLAB_PORT}"); do
         echo "Waiting for the GitLab instance to come online"


### PR DESCRIPTION
Running the gitlab service takes up lots of memory and if you are unable to run
it, it is possible to use the development local git alternative.  If you
already started gitlab and houston, you can stop them by doing:

    docker-compose rm --stop -f houston gitlab
    docker volume rm $(docker volume ls -q -f dangling=true | grep gitlab-var)
    docker volume rm $(docker volume ls -q -f dangling=true | grep houston-var)

Use the development docker-compose file:

    ln -s docker-compose.dev.yml docker-compose.override.yml
    docker-compose up -d

This should create the houston service again but not the gitlab one.

**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
