### PR TITLE
DEX-239 Add acm and edm versions to /api/v1/site-info/

### DIFF
--- a/app/extensions/acm/__init__.py
+++ b/app/extensions/acm/__init__.py
@@ -31,7 +31,10 @@ class ACMManager(RestManager):
         },
         'assets': {
             'list': '//image/json/',
-        }
+        },
+        'version': {
+            'dict': '//version/',
+        },
     }
     # fmt: on
 

--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -78,6 +78,9 @@ class EDMManager(RestManager):
         },
         'configurationDefinition': {
             'data': '//v0/configurationDefinition/%s',
+        },
+        'version': {
+            'dict': '/wildbook/edm/json/git-info.json',
         }
     }
     # fmt: on

--- a/app/modules/site_info.py
+++ b/app/modules/site_info.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from flask import current_app
+
 import app.version
 from app.extensions.api import api_v1, Namespace
 from flask_restx_patched import Resource
@@ -14,9 +16,21 @@ def init_app(app, **kwargs):
 @site_info_api.route('/')
 class SiteInfo(Resource):
     def get(self):
+        acm_version = current_app.acm.get_dict('version.dict', None)
+        if isinstance(acm_version, dict):
+            acm_version = acm_version['response']
+        else:
+            # acm returns a non 200 response
+            acm_version = repr(acm_version)
+        edm_version = current_app.edm.get_dict('version.dict', None)
+        if not isinstance(edm_version, dict):
+            # edm returns a non 200 response
+            edm_version = repr(edm_version)
         return {
             'houston': {
                 'version': app.version.version,
                 'git_version': app.version.git_revision,
             },
+            'acm': acm_version,
+            'edm': edm_version,
         }

--- a/tests/modules/test_site_info.py
+++ b/tests/modules/test_site_info.py
@@ -1,9 +1,32 @@
 # -*- coding: utf-8 -*-
+from unittest import mock
+
+from requests import Response
+
 import app.version
 
 
 def test_site_info(flask_app_client):
-    resp = flask_app_client.get('/api/v1/site-info/')
+    with mock.patch('flask.current_app.acm.get_dict') as acm_get_dict:
+        with mock.patch('flask.current_app.edm.get_dict') as edm_get_dict:
+            acm_get_dict.return_value = {
+                'status': {
+                    'success': True,
+                    'code': 200,
+                    'message': '',
+                    'cache': -1,
+                },
+                'response': {
+                    'version': '3.5.1.dev23',
+                },
+            }
+            edm_get_dict.return_value = {
+                'date': '2021-04-07 02:23:04 -0700',
+                'built': '2021-04-07 09:25:46+00:00',
+                'hash': '477dac40056d1f722579bffa949b8979fc7e6e31',
+                'branch': 'next-gen',
+            }
+            resp = flask_app_client.get('/api/v1/site-info/')
     assert resp.status_code == 200
     assert resp.content_type == 'application/json'
     assert resp.json == {
@@ -11,4 +34,35 @@ def test_site_info(flask_app_client):
             'version': app.version.version,
             'git_version': app.version.git_revision,
         },
+        'acm': {
+            'version': '3.5.1.dev23',
+        },
+        'edm': {
+            'date': '2021-04-07 02:23:04 -0700',
+            'built': '2021-04-07 09:25:46+00:00',
+            'hash': '477dac40056d1f722579bffa949b8979fc7e6e31',
+            'branch': 'next-gen',
+        },
+    }
+
+
+def test_site_info_api_error(flask_app_client):
+    with mock.patch('flask.current_app.acm.get_dict') as acm_get_dict:
+        with mock.patch('flask.current_app.edm.get_dict') as edm_get_dict:
+            not_found = Response()
+            not_found.status_code = 404
+            acm_get_dict.return_value = not_found
+            edm_get_dict.return_value = not_found
+            # both acm and edm returns 404
+            resp = flask_app_client.get('/api/v1/site-info/')
+
+    assert resp.status_code == 200
+    assert resp.content_type == 'application/json'
+    assert resp.json == {
+        'houston': {
+            'version': app.version.version,
+            'git_version': app.version.git_revision,
+        },
+        'acm': '<Response [404]>',
+        'edm': '<Response [404]>',
     }


### PR DESCRIPTION
## Pull Request Overview

- Set ACM URI to docker-compose wbia

  It was previously not set and was using the default which points to
  "https://tier2.dyn.wildme.io:5010" when it should be using the wbia
  instance in docker-compose.
  
  Set `ACM_AUTHENTICATIONS_URI__DEFAULT` to `http://wbia:5000/`.

- Add acm and edm versions to /api/v1/site-info/

  `GET /api/v1/site-info/` returns:
  
  ```
  {
      "houston": {
          "version": "0.1.0.63c39b04",
          "git_version": "63c39b04519f5146cd8d641576b3bbfed697c6d8"
      },
      "acm": {
          "version": "3.5.1.dev23"
      },
      "edm": {
          "date": "2021-04-07 02:23:04 -0700",
          "built": "2021-04-07 09:25:46+00:00",
          "hash": "477dac40056d1f722579bffa949b8979fc7e6e31",
          "branch": "next-gen"
      }
  }
  ```
  
  The acm and edm apis are fetched whenever `/api/v1/site-info/` is requested.


**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [x] Ensure that the PR is properly reviewed
