### PR TITLE
Fix GitRemoteLocal projects.list() without search term

### DIFF
--- a/app/extensions/git_remote.py
+++ b/app/extensions/git_remote.py
@@ -106,11 +106,13 @@ class LocalProjects:
                 except (json.decoder.JSONDecodeError, TypeError):
                     self.projects = {}
 
-    def list(self, search, **kwargs):
-        search = str(search)
-        if search in self.projects:
-            return [self.projects[search]]
-        return []
+    def list(self, search=None, **kwargs):
+        if search is not None:
+            search = str(search)
+            if search in self.projects:
+                return [self.projects[search]]
+            return []
+        return list(self.projects.values())
 
     def create(self, args, **kwargs):
         project = LocalProject(

--- a/tests/extensions/test_git_remote.py
+++ b/tests/extensions/test_git_remote.py
@@ -86,9 +86,26 @@ def test_git_remote_local(request):
     assert project.namespace == {'id': 'TEST', 'name': 'TEST'}
     assert project.tag_list == ['tag:pytest']
 
+    g.projects.create(
+        {
+            'path': 'different_project',
+            'description': 'project description',
+            'emails_disabled': True,
+            'namespace_id': 'TEST',
+            'visibility': 'private',
+            'merge_method': 'rebase_merge',
+            'tag_list': ['tag:pytest'],
+            'lfs_enabled': True,
+        },
+        retry_transient_errors=True,
+    )
+
     projects = g.projects.list('project_name')
     assert len(projects) == 1
     assert projects[0] == project
+
+    projects = g.projects.list()
+    assert len(projects) == 2
 
     g.projects.delete(project.id)
     assert g.projects.list('project_name') == []


### PR DESCRIPTION
When running `invoke app.integrations.check` with GitRemoteLocal:

```
root@a89ba8638d3b:/code# GITLAB_REMOTE_URI=/data/var/git_remote invoke app.integrations.check
2021-04-30 17:31:09,507 [INFO] [app] Using app.config 'docker_local_config.LocalConfig'
⭐ db (postgresql://houston:development@db/houston)
2021-04-30 17:31:10,060 [INFO] [app.extensions.asset_group] Logging into Asset Group GitLab...
2021-04-30 17:31:10,061 [INFO] [app.extensions.asset_group]      URI: '/data/var/git_remote'
2021-04-30 17:31:10,061 [INFO] [app.extensions.asset_group]      NS : 'TEST'
2021-04-30 17:31:10,062 [INFO] [app.extensions.asset_group] Logged in: <app.extensions.git_remote.GitRemoteLocal object at 0x7ff54c25f520>
2021-04-30 17:31:10,062 [INFO] [app.extensions.asset_group] Using namespace: LocalNamespace(id='TEST', name='TEST')
2021-04-30 17:31:10,062 [ERROR] [tasks.app.integrations]
Traceback (most recent call last):
  File "/code/tasks/app/integrations.py", line 38, in check_gitlab
    app.agm.gl.projects.list()
TypeError: list() missing 1 required positional argument: 'search'
❌ gitlab
```

Return all projects when `projects.list()` is called without a search term



**Pull Request Checklist**
- [x] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [x] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [x] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [x] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [x] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [x] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
- [ ] Ensure that the PR is properly reviewed
