### PR TITLE
Move the test failure report to a separate job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -129,19 +129,7 @@ jobs:
           source virtualenv/houston3.7/bin/activate
           pytest -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
 
-      # Notify status in Slack
-      - name: Slack Notification
-        if: failure() && github.event_name == 'schedule'
-        uses: rtCamp/action-slack-notify@master
-        env:
-          SLACK_CHANNEL: dev-houston
-          SLACK_COLOR: '#FF0000'
-          SLACK_ICON: https://avatars.slack-edge.com/2020-03-02/965719891842_db87aa21ccb61076f236_44.png
-          SLACK_MESSAGE: 'nightly test on MacOS failed :sob:'
-          SLACK_USERNAME: "Nightly"
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
-  test:
+  test_linux:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 1
@@ -250,14 +238,19 @@ jobs:
           source virtualenv/houston3.7/bin/activate
           pytest --no-cov -s -v --gitlab-remote-login-pat "${{ secrets.GITLAB_REMOTE_LOGIN_PAT }}"
 
+  report_failure:
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [test_macos, test_linux]
+    steps:
       # Notify status in Slack
       - name: Slack Notification
-        if: failure() && github.event_name == 'schedule'
+        if: (needs.test_macos.result == 'failure' || needs.test_linux.result == 'failure') && github.event_name == 'schedule'
         uses: rtCamp/action-slack-notify@master
         env:
           SLACK_CHANNEL: dev-houston
           SLACK_COLOR: '#FF0000'
           SLACK_ICON: https://avatars.slack-edge.com/2020-03-02/965719891842_db87aa21ccb61076f236_44.png
-          SLACK_MESSAGE: 'nightly tests on Linux failed :sob:'
+          SLACK_MESSAGE: 'nightly tests failed :sob:'
           SLACK_USERNAME: "Nightly"
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Pull Request Overview

The nightly test failures will now only notify slack once rather than
for each failure in the test matrix. See the "Nightly" workflow item associated with this PR. It should now show a fourth job that will report to the Slack channel any failures in either of the two testing jobs (against macos and linux).

**Pull Request Checklist**
- [X] Ensure that the PR is properly formatted
  - Example: All lint checks are passing
- [X] Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
- [X] Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- [X] Ensure that the PR is properly tested
  - Example: All automated tests are passing
- [X] Ensure that the PR is properly covered
  - Example: The percentage of the code covered by tests has not decreased
- [X] Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR
