### PR TITLE
Add docker-compose invoke tasks for rebuilding services

### DIFF
--- a/deploy/codex/docker-compose.yml
+++ b/deploy/codex/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   db:
     image: postgres:10
     volumes:
-      - pgdata-var:/var/lib/postgresql/data
+      - db-pgdata-var:/var/lib/postgresql/data
       # DB initialization scripts
       - ./db/initdb.d/:/docker-entrypoint-initdb.d/
     environment:
@@ -166,10 +166,10 @@ networks:
   frontend:
 
 volumes:
+  db-pgdata-var:
   edm-var:
   redis-var:
   pgadmin-var:
-  pgdata-var:
   acm-var:
   houston-var:
   gitlab-var-config:

--- a/deploy/codex/docker-compose.yml
+++ b/deploy/codex/docker-compose.yml
@@ -24,6 +24,8 @@ services:
 
   redis:
     image: redis:latest
+    volumes:
+      - redis-var:/data
     networks:
       - intranet
 
@@ -165,6 +167,7 @@ networks:
 
 volumes:
   edm-var:
+  redis-var:
   pgadmin-var:
   pgdata-var:
   acm-var:

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -57,14 +57,20 @@ else:
 from invoke import Collection  # NOQA
 from invoke.executor import Executor  # NOQA
 
-from tasks import app as tasks_app  # NOQA
+namespaces = []
+try:
+    from tasks import app as tasks_app  # NOQA
+
+    namespaces.append(tasks_app)
+except ModuleNotFoundError as e:
+    logger.warning(f'Unable to load tasks.app.*\n{str(e)}')
+
 from tasks import dependencies as task_dependencies  # NOQA
 
+namespaces.append(task_dependencies)
+
 # NOTE: `namespace` or `ns` name is required!
-namespace = Collection(
-    tasks_app,
-    task_dependencies,
-)
+namespace = Collection(*namespaces)
 
 
 def invoke_execute(context, command_name, **kwargs):

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -66,8 +66,10 @@ except ModuleNotFoundError as e:
     logger.warning(f'Unable to load tasks.app.*\n{str(e)}')
 
 from tasks import dependencies as task_dependencies  # NOQA
+from tasks import docker_compose as task_docker_compose  # NOQA
 
 namespaces.append(task_dependencies)
+namespaces.append(task_docker_compose)
 
 # NOTE: `namespace` or `ns` name is required!
 namespace = Collection(*namespaces)

--- a/tasks/docker_compose.py
+++ b/tasks/docker_compose.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+"""
+docker-compose tasks for invoke
+"""
+import logging
+
+from invoke import task
+
+
+logger = logging.getLogger(__name__)
+
+
+@task
+def rebuild(context, service=[]):
+    services = service
+    with context.cd('deploy/codex'):
+        services_ = ', '.join(services)
+        logger.info(f'Stop and remove codex services {services_}')
+        if services:
+            context.run(f'docker-compose rm --stop -f {" ".join(services)}', echo=True)
+        else:
+            context.run('docker-compose down --remove-orphans', echo=True)
+        logger.info(f'Remove codex volumes {services_}')
+        name_filter = '-f name=codex_*'
+        if services:
+            name_filter = ' '.join(f'-f name=codex_{service}*' for service in services)
+        context.run(
+            f'docker volume ls -q -f dangling=true {name_filter} | xargs docker volume rm',
+            echo=True,
+            warn=True,
+        )
+        logger.info(f'Pull image updates {services_}')
+        context.run(f'docker-compose pull {" ".join(services)}', echo=True)
+        logger.info(f'Rebuild images {services_}')
+        context.run(f'docker-compose build {" ".join(services)}', echo=True)
+        command = ['docker-compose', 'up', '-d'] + services
+        logger.info(f'You can now do "{" ".join(command)}"')
+
+
+@task
+def rebuild_gitlab(context):
+    rebuild(context, service=['gitlab', 'houston'])

--- a/tests/tasks/test_docker_compose.py
+++ b/tests/tasks/test_docker_compose.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from unittest import mock
+
+from invoke import MockContext
+
+import tasks.docker_compose
+
+
+def test_rebuild_specific_services():
+    with mock.patch('tasks.docker_compose.logger') as logger:
+        context = MockContext(
+            run={
+                'docker-compose rm --stop -f db houston': True,
+                'docker volume ls -q -f dangling=true -f name=codex_db* -f name=codex_houston* | xargs docker volume rm': True,
+                'docker-compose pull db houston': True,
+                'docker-compose build db houston': True,
+            },
+        )
+        tasks.docker_compose.rebuild(context, service=['db', 'houston'])
+        assert logger.info.call_args_list == [
+            mock.call('Stop and remove codex services db, houston'),
+            mock.call('Remove codex volumes db, houston'),
+            mock.call('Pull image updates db, houston'),
+            mock.call('Rebuild images db, houston'),
+            mock.call('You can now do "docker-compose up -d db houston"'),
+        ]
+
+
+def test_rebuild():
+    with mock.patch('tasks.docker_compose.logger') as logger:
+        context = MockContext(
+            run={
+                'docker-compose down --remove-orphans': True,
+                'docker volume ls -q -f dangling=true -f name=codex_* | xargs docker volume rm': True,
+                'docker-compose pull ': True,
+                'docker-compose build ': True,
+            },
+        )
+        tasks.docker_compose.rebuild(context)
+        assert logger.info.call_args_list == [
+            mock.call('Stop and remove codex services '),
+            mock.call('Remove codex volumes '),
+            mock.call('Pull image updates '),
+            mock.call('Rebuild images '),
+            mock.call('You can now do "docker-compose up -d"'),
+        ]
+
+
+def test_rebuild_gitlab():
+    with mock.patch('tasks.docker_compose.rebuild') as rebuild:
+        context = MockContext()
+        tasks.docker_compose.rebuild_gitlab(context)
+        assert rebuild.call_args == mock.call(context, service=['gitlab', 'houston'])


### PR DESCRIPTION
- Skip loading tasks.app.* if ModuleNotFoundError

  If app dependencies are not installed, we could not run invoke:
  
  ```
  (py3) karen@yukihira:~/src/wildme/houston$ invoke --list
  Traceback (most recent call last):
    File "/home/karen/src/wildme/py3/bin/invoke", line 8, in <module>
      sys.exit(program.run())
    File "/home/karen/src/wildme/py3/lib/python3.9/site-packages/invoke/program.py", line 373, in run
      self.parse_collection()
    File "/home/karen/src/wildme/py3/lib/python3.9/site-packages/invoke/program.py", line 465, in parse_collection
      self.load_collection()
    File "/home/karen/src/wildme/py3/lib/python3.9/site-packages/invoke/program.py", line 696, in load_collection
      module, parent = loader.load(coll_name)
    File "/home/karen/src/wildme/py3/lib/python3.9/site-packages/invoke/loader.py", line 76, in load
      module = imp.load_module(name, fd, path, desc)
    File "/usr/lib/python3.9/imp.py", line 244, in load_module
      return load_package(name, filename)
    File "/usr/lib/python3.9/imp.py", line 216, in load_package
      return _load(spec)
    File "<frozen importlib._bootstrap>", line 711, in _load
    File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
    File "<frozen importlib._bootstrap_external>", line 790, in exec_module
    File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
    File "/home/karen/src/wildme/houston/tasks/__init__.py", line 60, in <module>
      from tasks import app as tasks_app  # NOQA
    File "/home/karen/src/wildme/houston/tasks/app/__init__.py", line 8, in <module>
      from tasks.app import (
    File "/home/karen/src/wildme/houston/tasks/app/consistency.py", line 9, in <module>
      import tqdm
  ModuleNotFoundError: No module named 'tqdm'
  ```
  
  With this change, we can at least use `tasks.dependencies.*` with a warning:
  
  ```
  (py3) karen@yukihira:~/src/wildme/houston$ invoke --list
  WARNING:root:Unable to load tasks.app.*
  No module named 'tqdm'
  Available tasks:
  
    dependencies.install                       Install project dependencies.
    dependencies.install-all-ui                Install project user interface dependencies.
    dependencies.install-frontend-ui           Install Front-end UI HTML/JS/CSS assets.
    dependencies.install-python-dependencies   Install Python dependencies listed in requirements.txt.
    dependencies.install-swagger-ui            Install Swagger UI HTML/JS/CSS assets.
  ```

- Add volume "redis-var" for redis in docker-compose

  We did not provide a volume for redis causing a randomly named volume to
  be created by docker and there is no way of programmatically removing
  the volume because we don't have a name.
  
  Adding the volume "redis-var" means that we can remove
  "codex_redis-var" now.

- Add docker-compose invoke tasks for rebuilding

  - Change docker-compose `db` volume to start with "db-":
  
    `pgdata-var` -> `db-pgdata-var`
  
  - Add `invoke docker-compose.rebuild` to rebuild services and remove
    volumes.  It is also possible to pass in specific services by doing,
    for example, `-s houston -s db`.
  
  - Add `invoke docker-compose.rebuild-gitlab` which should be able to fix
    gitlab authentication errors by rebuilding gitlab and houston.


**Invoke CLI Updates**

```
$ invoke docker-compose.rebuild
WARNING:root:Unable to load tasks.app.*
No module named 'tqdm'
INFO:tasks.docker_compose:Stop and remove codex services
cd deploy/codex && docker-compose down --remove-orphans
Removing network codex_intranet
Network codex_intranet not found.
Removing network codex_frontend
Network codex_frontend not found.
INFO:tasks.docker_compose:Remove codex volumes {services_}
cd deploy/codex && docker volume ls -q -f dangling=true -f name=codex_* | xargs docker volume rm
"docker volume rm" requires at least 1 argument.
See 'docker volume rm --help'.

Usage:  docker volume rm [OPTIONS] VOLUME [VOLUME...]

Remove one or more volumes
INFO:tasks.docker_compose:Pull image updates
cd deploy/codex && docker-compose pull 
Pulling db           ...
Pulling redis        ...
...
Step 29/29 : ENTRYPOINT [ "/docker-entrypoint.sh" ]
 ---> Running in 59900886ecd5
Removing intermediate container 59900886ecd5
 ---> acfd30fd0ff2
Successfully built acfd30fd0ff2
Successfully tagged codex_houston:latest
INFO:tasks.docker_compose:You can now do "docker-compose up -d"
```

```
$ invoke docker-compose.rebuild-gitlab
WARNING:root:Unable to load tasks.app.*    
No module named 'tqdm'                     
INFO:tasks.docker_compose:Stop and remove codex services gitlab, houston
cd deploy/codex && docker-compose rm --stop -f gitlab houston
No stopped containers                      
INFO:tasks.docker_compose:Remove codex volumes {services_}
cd deploy/codex && docker volume ls -q -f dangling=true -f name=codex_gitlab* -f name=codex_houston* | xargs docker volume rm
"docker volume rm" requires at least 1 argument.
See 'docker volume rm --help'.             
                                           
Usage:  docker volume rm [OPTIONS] VOLUME [VOLUME...]
                                           
Remove one or more volumes                 
INFO:tasks.docker_compose:Pull image updates gitlab, houston
cd deploy/codex && docker-compose pull gitlab houston
...
Step 27/29 : ENV HOUSTON_DOTENV ${DATA_ROOT}/.env
 ---> Using cache                          
 ---> 12dbe7815c6b                         
Step 28/29 : COPY ./.dockerfiles/docker-entrypoint.sh /docker-entrypoint.sh
 ---> Using cache                          
 ---> c2a87cd4838f                         
Step 29/29 : ENTRYPOINT [ "/docker-entrypoint.sh" ]
 ---> Using cache                          
 ---> 40560261cf65                         
Successfully built 40560261cf65            
Successfully tagged codex_houston:latest   
INFO:tasks.docker_compose:You can now do "docker-compose up -d gitlab houston"
```
