### PR TITLE
Set edm version api to /edm/json/git-info.json

### DIFF
--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -80,7 +80,7 @@ class EDMManager(RestManager):
             'data': '//v0/configurationDefinition/%s',
         },
         'version': {
-            'dict': '/wildbook/edm/json/git-info.json',
+            'dict': '/edm/json/git-info.json',
         }
     }
     # fmt: on


### PR DESCRIPTION
Remove `/wildbook/` from the path as it doesn't work on
nextgen.dev-wildbook.org.

