### PR TITLE
Upgrade invoke requirement to >=1.5.0

### DIFF
--- a/tasks/requirements.txt
+++ b/tasks/requirements.txt
@@ -1,4 +1,4 @@
 colorlog
-invoke
+invoke>=1.5.0
 lockfile
 requests


### PR DESCRIPTION
With invoke 1.4.1, the docker-compose task tests fail:

```
__________________________________________________________________ test_rebuild ___________________________________________________________________

    def test_rebuild():
        with mock.patch('tasks.docker_compose.logger') as logger:
            context = MockContext(
                run={
                    'docker-compose down --remove-orphans': True,
                    'docker volume ls -q -f dangling=true -f name=codex_* | xargs docker volume rm': True,
                    'docker-compose pull ': True,
                    'docker-compose build ': True,
                },
            )
>           tasks.docker_compose.rebuild(context)

tests/tasks/test_docker_compose.py:39:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
/usr/local/lib/python3.9/site-packages/invoke/tasks.py:127: in __call__
    result = self.body(*args, **kwargs)
tasks/docker_compose.py:22: in rebuild
    context.run('docker-compose down --remove-orphans', echo=True)
/usr/local/lib/python3.9/site-packages/invoke/context.py:464: in run
    return self._yield_result("__run", command)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <MockContext: <Config: {'run': {'asynchronous': False, 'disown': False, 'dry': False, 'echo': False, 'echo_stdin': Non...llection_name': 'tasks', 'dedupe': True, 'executor_class': None, 'search_root': None}, 'timeouts': {'command': None}}>>
attname = '__run', command = 'docker-compose down --remove-orphans'

    def _yield_result(self, attname, command):
        # NOTE: originally had this with a bunch of explicit
        # NotImplementedErrors, but it doubled method size, and chance of
        # unexpected index/etc errors seems low here.
        try:
            value = getattr(self, attname)
            # TODO: thought there's a 'better' 2x3 DictType or w/e, but can't
            # find one offhand
            if isinstance(value, dict):
                if hasattr(value[command], "__iter__"):
                    result = value[command].pop(0)
                elif isinstance(value[command], Result):
                    result = value.pop(command)
            elif hasattr(value, "__iter__"):
                result = value.pop(0)
            elif isinstance(value, Result):
                result = value
                delattr(self, attname)
>           return result
E           UnboundLocalError: local variable 'result' referenced before assignment

/usr/local/lib/python3.9/site-packages/invoke/context.py:455: UnboundLocalError
```

This is fixed in invoke 1.5.0.

