### PR TITLE
DEX-260 Fix GITLAB_REMOTE_LOGIN_PAT not loaded in app config

### DIFF
--- a/.dockerfiles/docker-entrypoint.sh
+++ b/.dockerfiles/docker-entrypoint.sh
@@ -22,7 +22,9 @@ file_env() {
 	elif [ "${!fileVar:-}" ]; then
 		val="$(< "${!fileVar}")"
 	fi
-	export "$var"="$val"
+	if [ "$val" != "" ]; then
+		export "$var"="$val"
+	fi
 	unset "$fileVar"
 }
 

--- a/app/extensions/asset_group/__init__.py
+++ b/app/extensions/asset_group/__init__.py
@@ -93,6 +93,8 @@ class AssetGroupManager(object):
             log.info('Logging into Asset Group GitLab...')
             log.info('\t URI: %r' % (remote_uri,))
             log.info('\t NS : %r' % (remote_namespace,))
+            if current_app.config.get('DEBUG', False):
+                log.info(f'\t GITLAB_REMOTE_LOGIN_PAT: {remote_personal_access_token}')
 
             try:
                 self.gl = git_remote.GitRemote(


### PR DESCRIPTION
When using docker-compose, in the houston entrypoint
`.dockerfiles/docker-entrypoint.sh`, we try to load
`GITLAB_REMOTE_LOGIN_PAT`:

```
file_env 'GITLAB_REMOTE_LOGIN_PAT'
```

Since there is nothing set up, we end up with `GITLAB_REMOTE_LOGIN_PAT`
set to an empty string.

In `config.py`:

```
load_dotenv(_dotenv, override=False)
```

Which is supposed to load `GITLAB_REMOTE_LOGIN_PAT` in `/data/var/.env`,
but since it is already in `os.environ` and `override=False`,
`GITLAB_REMOTE_LOGIN_PAT` ends up not getting loaded.

The fix is in the entrypoint, to not set `GITLAB_REMOTE_LOGIN_PAT` if it
is an empty string.

