### PR TITLE
Raise exception if app.db.upgrade fails

### DIFF
--- a/tasks/app/db.py
+++ b/tasks/app/db.py
@@ -240,7 +240,8 @@ def upgrade(
             log.error('Rolling back Sqlite3 database to backup')
             shutil.copy2(_db_filepath_backup, _db_filepath)
             log.error('...restored')
-        log.critical('Database upgrade failed', exc_info=True)
+        log.critical('Database upgrade failed')
+        raise
     finally:
         if sqlite and os.path.exists(_db_filepath_backup):
             log.info('Deleting database backup %r' % (_db_filepath_backup,))


### PR DESCRIPTION
When `invoke app.db.upgrade` fails, an error is displayed but the exit
code was 0 causing the github testing workflow to ignore the error.

Change it so we raise the exception when app.db.upgrade fails.

---

Here's what happens when upgrade fails now:

https://github.com/WildMeOrg/houston/runs/2530807171?check_suite_focus=true#step:11:34

The workflow fails correctly.