### PR TITLE
Delete app.initialize-gitlab-asset-groups task and add tests for app.asset-groups tasks

### DIFF
--- a/scripts/run_tasks_for_coverage.sh
+++ b/scripts/run_tasks_for_coverage.sh
@@ -82,16 +82,6 @@ coverage run --append `which invoke` app.consistency.all
 coverage run --append `which invoke` app.consistency.user-staff-permissions
 coverage run --append `which invoke` app.consistency.cleanup-gitlab --dryrun
 
-# test app.asset_groups.*
-coverage run --append `which invoke` app.asset-groups.create-asset-group-from-path --path=tests/asset_groups/test-000/ || echo 'Expected failure'
-coverage run --append `which invoke` app.asset-groups.create-asset-group-from-path --path=tests/does-not-exist/ --email=user@example.org || echo 'Expected failure'
-coverage run --append `which invoke` app.asset-groups.create-asset-group-from-path --path=tests/asset_groups/test-000/ --email=user@example.org
-coverage run --append `which invoke` app.asset-groups.clone-asset-group-from-gitlab --guid=00000000-0000-0000-0000-000000000003 || echo 'Expected failure'
-coverage run --append `which invoke` app.asset-groups.clone-asset-group-from-gitlab --guid=11111111-1111-1111-1111-111111111111 --email=user@example.org || echo 'Expected failure'
-coverage run --append `which invoke` app.asset-groups.clone-asset-group-from-gitlab --guid=00000000-0000-0000-0000-000000000003 --email=user@example.org
-coverage run --append `which invoke` app.asset-groups.clone-asset-group-from-gitlab --guid=00000000-0000-0000-0000-000000000003 --email=user@example.org
-coverage run --append `which invoke` app.asset-groups.list-all
-
 coverage run --append `which invoke` app.organizations.list-all
 coverage run --append `which invoke` app.assets.list-all
 coverage run --append `which invoke` app.encounters.list-all

--- a/scripts/run_tasks_for_coverage.sh
+++ b/scripts/run_tasks_for_coverage.sh
@@ -77,9 +77,6 @@ coverage run --append `which invoke` app.users.list-all
 coverage run --append `which invoke` app.users.add-role --role=Researcher --email=user@example.org
 coverage run --append `which invoke` app.users.remove-role --role=Researcher --email=user@example.org
 
-# test app.initialize.*
-coverage run --append `which invoke` app.initialize.initialize-gitlab-asset-groups --email user@example.org --dryrun
-
 # test app.consistency.*
 coverage run --append `which invoke` app.consistency.all
 coverage run --append `which invoke` app.consistency.user-staff-permissions

--- a/tests/tasks/app/test_asset_groups.py
+++ b/tests/tasks/app/test_asset_groups.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+import io
+import pathlib
+import re
+from unittest import mock
+import uuid
+
+from invoke import MockContext
+import pytest
+
+
+def test_create_asset_group_from_path(flask_app, test_root, admin_user, request):
+    with mock.patch('app.create_app'):
+        from tasks.app.asset_groups import create_asset_group_from_path
+
+        with pytest.raises(Exception) as e:
+            create_asset_group_from_path(
+                MockContext(), test_root, 'nobody@nowhere.org', 'Expected failure'
+            )
+            assert str(e) == "User with email 'nobody@nowhere.org' does not exist."
+
+        with pytest.raises(IOError) as e:
+            create_asset_group_from_path(
+                MockContext(), '/does-not-exist', admin_user.email, 'Expected failure'
+            )
+            assert str(e) == 'The path /does-not-exist does not exist.'
+
+        with mock.patch('sys.stdout', new=io.StringIO()) as stdout:
+            create_asset_group_from_path(
+                MockContext(), test_root, admin_user.email, 'AssetGroup creation test'
+            )
+            last_line = stdout.getvalue().splitlines()[-1]
+            assert last_line.startswith('Created and pushed new asset_group:')
+            guid = re.search(r'<AssetGroup\(guid=([a-f0-9-]*)', last_line).group(1)
+
+    from app.modules.asset_groups.models import AssetGroup
+
+    asset_group = AssetGroup.query.get(guid)
+    assert asset_group is not None
+    request.addfinalizer(asset_group.delete)
+
+    assert asset_group.owner == admin_user
+    dir_files = sorted(f.name for f in pathlib.Path(test_root).glob('*'))
+    asset_paths = sorted([a.path for a in asset_group.assets])
+    assert dir_files == asset_paths
+    assert asset_group.description == 'AssetGroup creation test'
+
+
+def test_clone_asset_group_from_gitlab(flask_app, db, test_asset_group_uuid, admin_user):
+    clone_root = pathlib.Path(flask_app.config['ASSET_GROUP_DATABASE_PATH'])
+    repo_path = clone_root / str(test_asset_group_uuid)
+
+    from app.modules.asset_groups.models import AssetGroup
+
+    AssetGroup.query.get(test_asset_group_uuid).delete()
+
+    with mock.patch('app.create_app'):
+        from tasks.app.asset_groups import clone_asset_group_from_gitlab
+
+        with pytest.raises(Exception) as e:
+            clone_asset_group_from_gitlab(
+                MockContext(), str(test_asset_group_uuid), 'nobody@nowhere.org'
+            )
+            assert str(e) == "User with email 'nobody@nowhere.org' does not exist."
+
+        with pytest.raises(ValueError) as e:
+            random_uuid = uuid.uuid4()
+            clone_asset_group_from_gitlab(
+                MockContext(), str(random_uuid), admin_user.email
+            )
+            assert (
+                str(e)
+                == f"Could not find asset_group in GitLab using GUID '{random_uuid}'"
+            )
+
+        with mock.patch('sys.stdout', new=io.StringIO()) as stdout:
+            assert not repo_path.exists()
+            clone_asset_group_from_gitlab(
+                MockContext(), str(test_asset_group_uuid), admin_user.email
+            )
+            assert 'Cloned asset_group from GitLab' in stdout.getvalue()
+            assert repo_path.exists()
+
+        with mock.patch('sys.stdout', new=io.StringIO()) as stdout:
+            # do it again
+            clone_asset_group_from_gitlab(
+                MockContext(), str(test_asset_group_uuid), admin_user.email
+            )
+            assert 'AssetGroup is already cloned locally' in stdout.getvalue()
+            assert repo_path.exists()
+
+
+def test_list_all(flask_app, test_asset_group_uuid, test_empty_asset_group_uuid):
+    with mock.patch('app.create_app'):
+        from tasks.app.asset_groups import list_all
+
+        with mock.patch('sys.stdout', new=io.StringIO()) as stdout:
+            list_all(MockContext())
+            asset_groups = stdout.getvalue()
+            assert f'<AssetGroup(guid={test_asset_group_uuid}' in asset_groups
+            assert f'<AssetGroup(guid={test_empty_asset_group_uuid}' in asset_groups


### PR DESCRIPTION

## Pull Request Overview

- Delete `initialize-gitlab-asset-groups` task

  This task was used to create asset groups that the tests expect but they
  are already being created by test fixtures `test_asset_group_uuid` and
  `test_empty_asset_group_uuid`.

- Add tests for app.asset-groups tasks

