### PR TITLE
Fix OSError not raised in asset group tus creation test

### DIFF
--- a/tests/modules/asset_groups/test_tus_creation.py
+++ b/tests/modules/asset_groups/test_tus_creation.py
@@ -1,12 +1,14 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name,missing-docstring
 import os
+import pathlib
 import pytest
 import shutil
 
 
-def test_create_submission_from_tus(db, researcher_1, test_root):
+def test_create_submission_from_tus(flask_app, db, researcher_1, test_root):
 
+    from app.extensions.tus import tus_upload_dir
     from app.modules.asset_groups.models import AssetGroup
     from tests.modules.sightings.resources.utils import (
         prep_tus_dir,
@@ -16,6 +18,9 @@ def test_create_submission_from_tus(db, researcher_1, test_root):
     tid = get_transaction_id()  # '11111111-1111-1111-1111-111111111111'
 
     # first no such dir exists
+    transaction_dir = pathlib.Path(tus_upload_dir(flask_app, transaction_id=tid))
+    if (transaction_dir).exists():
+        shutil.rmtree(transaction_dir)
     with pytest.raises(OSError):
         sub = AssetGroup.create_from_tus('PYTEST', researcher_1, tid)
 


### PR DESCRIPTION
This only happens if the transaction directory already exists:

```
______________________________________________________ test_create_submission_from_tus[None] ______________________________________________________

flask_app = <Flask 'app'>, db = <SQLAlchemy engine=postgresql://houston:***@db/houston_test>
researcher_1 = <User(guid=9f09d9f8-55f3-4120-adb6-5c6c00c7bd61, email="researcher1@localhost", name="First Middle Last", state=Active, Alpha, roles=Contributor, Researcher)>
test_root = PosixPath('/code/tests/asset_groups/test-000')

    def test_create_submission_from_tus(flask_app, db, researcher_1, test_root):

        from app.extensions.tus import tus_upload_dir
        from app.modules.asset_groups.models import AssetGroup
        from tests.modules.sightings.resources.utils import (
            prep_tus_dir,
            get_transaction_id,
        )  # recycle

        tid = get_transaction_id()  # '11111111-1111-1111-1111-111111111111'

        # first no such dir exists
        with pytest.raises(OSError):
>           sub = AssetGroup.create_from_tus('PYTEST', researcher_1, tid)
E           Failed: DID NOT RAISE <class 'OSError'>

tests/modules/asset_groups/test_tus_creation.py:22: Failed
```

The test code even said it expects the transaction directory to not
exist:

```
    # first no such dir exists
    with pytest.raises(OSError):
        sub = AssetGroup.create_from_tus('PYTEST', researcher_1, tid)
```

We just need to add some set up code to make sure the directory doesn't
exist.

