### PR TITLE
DEX-261 Add reauthentication for edm when response is 401

### DIFF
--- a/app/extensions/restManager/RestManager.py
+++ b/app/extensions/restManager/RestManager.py
@@ -332,11 +332,6 @@ class RestManager(RestManagerUserMixin):
         self, tag, method, passthrough_kwargs, args=None, target='default'
     ):
         self._ensure_initialized()
-        try:
-            # Try to convert string integers to integers
-            target = int(target)
-        except ValueError:
-            pass
 
         # Check target
         targets = list(self.targets)

--- a/tests/extensions/edm/test_edm.py
+++ b/tests/extensions/edm/test_edm.py
@@ -2,6 +2,7 @@
 # pylint: disable=invalid-name,missing-docstring
 
 import uuid
+from unittest import mock
 
 # this tests edm hostname & credentials configs
 
@@ -28,3 +29,27 @@ def test_initialize_admin_user(flask_app):
 def test_edm_version(flask_app):
     version_ok = flask_app.edm.version_check()
     assert version_ok
+
+
+def test_reauthentication(flask_app):
+    flask_app.edm._ensure_initialized()
+    original_get = flask_app.edm.sessions['default'].get
+    mock_401 = mock.Mock(status_code=401, ok=False, content=b'')
+    edm_uri = flask_app.config['EDM_URIS']['default']
+
+    def mock_get(url, *args, call_count=[], **kwargs):
+        if call_count == []:
+            call_count.append(1)
+            return mock_401
+        return original_get(url, *args, **kwargs)
+
+    with mock.patch.object(
+        flask_app.edm.sessions['default'], 'get', side_effect=mock_get
+    ) as edm_get:
+        random_id = uuid.uuid4()
+        result = flask_app.edm.get_dict('encounter.data', random_id)
+        assert result.status_code == 404
+        urls = [i[0][0] for i in edm_get.call_args_list]
+        assert len(urls) == 3
+        assert urls[0] == urls[2] == f'{edm_uri}api/v0/org.ecocean.Encounter/{random_id}'
+        assert urls[1].startswith(f'{edm_uri}api/v0/login?')


### PR DESCRIPTION
- Remove code to cast target to int in RestManager

  We don't use integer as targets anymore in RestManager so there is no
  need to do `target = int(target)`.

- Add reauthentication for edm when response is 401

  EDM authentication appears to log out after some time so change
  RestManager to reauthenticate before sending the request again.
