### PR TITLE
DEX-292 Allow any users created in POST /api/v1/users/ to login

### DIFF
--- a/app/modules/auth/resources.py
+++ b/app/modules/auth/resources.py
@@ -59,16 +59,13 @@ class OAuth2Sessions(Resource):
 
         failure = None
         if user is not None:
-            if True not in [user.in_alpha, user.in_beta, user.is_staff, user.is_admin]:
-                failure = 'Account Not Authorized'
-            else:
-                status = login_user(user, remember=False)
+            status = login_user(user, remember=False)
 
-                if status:
-                    log.info('Logged in User via API: %r' % (user,))
-                    create_session_oauth2_token()
-                else:
-                    failure = 'Account Disabled'
+            if status:
+                log.info('Logged in User via API: %r' % (user,))
+                create_session_oauth2_token()
+            else:
+                failure = 'Account Disabled'
         else:
             failure = 'Account Not Found'
 

--- a/app/modules/users/parameters.py
+++ b/app/modules/users/parameters.py
@@ -179,7 +179,7 @@ class PatchUserDetailsParameters(PatchJSONParameters):
         """
         log.debug('Updating replace field %s' % (field,))
         log.debug('sensitive %s' % (cls.SENSITIVE_FIELDS,))
-        log.debug('sensitive %s' % (cls.PRIVILEGED_FIELDS,))
+        log.debug('privileged %s' % (cls.PRIVILEGED_FIELDS,))
         if field in cls.SENSITIVE_FIELDS or field in cls.PRIVILEGED_FIELDS:
             log.debug('Updating sensitive field %s' % (field,))
             if 'current_password' not in state:

--- a/tests/modules/auth/resources/test_general_access.py
+++ b/tests/modules/auth/resources/test_general_access.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
+import json
+
 import pytest
 
 
@@ -14,3 +16,60 @@ def test_unauthorized_access(http_method, http_path, flask_app_client):
     response = flask_app_client.open(method=http_method, path=http_path)
     print(response)
     assert response.status_code == 401
+
+
+def test_created_user_login(flask_app_client, admin_user, request):
+    from app.modules.users.models import User
+
+    with flask_app_client.login(admin_user, auth_scopes=('users:write',)):
+        response = flask_app_client.post(
+            '/api/v1/users/',
+            content_type='application/json',
+            data=json.dumps({'email': 'test.user@example.org', 'password': 'password'}),
+        )
+        assert response.status_code == 200
+        assert response.json['email'] == 'test.user@example.org'
+        assert response.json['is_active'] is True
+        user_guid = response.json['guid']
+
+    request.addfinalizer(lambda: User.query.get(user_guid).delete())
+
+    response = flask_app_client.post(
+        '/api/v1/auth/sessions',
+        content_type='application/json',
+        data=json.dumps({'email': 'test.user@example.org', 'password': 'password'}),
+    )
+    request.addfinalizer(lambda: flask_app_client.cookie_jar.clear())
+    assert response.status_code == 200, response.json
+    flask_app_client.cookie_jar.clear()
+
+    # Check users can't login if is_active is False
+    with flask_app_client.login(admin_user, auth_scopes=('users:write',)):
+        response = flask_app_client.patch(
+            f'/api/v1/users/{user_guid}',
+            content_type='application/json',
+            data=json.dumps(
+                [
+                    {
+                        'op': 'test',
+                        'path': '/current_password',
+                        'value': admin_user.password_secret,
+                    },
+                    {
+                        'op': 'replace',
+                        'path': '/is_active',
+                        'value': False,
+                    },
+                ],
+            ),
+        )
+        assert response.status_code == 200
+        assert response.json['is_active'] is False
+
+    response = flask_app_client.post(
+        '/api/v1/auth/sessions',
+        content_type='application/json',
+        data=json.dumps({'email': 'test.user@example.org', 'password': 'password'}),
+    )
+    assert response.status_code == 401, response.json
+    assert response.json['message'] == 'Account Disabled'


### PR DESCRIPTION
After creating users in frontend using `POST /api/v1/users/`, it was not
possible to login using the email and password.  The reason is because
in `POST /api/v1/auth/sessions` does not allow logins unless user is
`in_alpha`, `in_beta`, `is_staff` or `is_admin`.

