### PR TITLE
DEX-218 Move AssetGroup ensure_remote, delete_remote and git_push to celery tasks

### DIFF
--- a/app/extensions/celery.py
+++ b/app/extensions/celery.py
@@ -15,3 +15,4 @@ except RuntimeError:
 
 
 # register celery tasks
+import app.modules.asset_groups.tasks  # noqa

--- a/app/extensions/gitlab.py
+++ b/app/extensions/gitlab.py
@@ -9,7 +9,6 @@ import logging
 from flask import current_app, request, session, render_template  # NOQA
 from flask_login import current_user  # NOQA
 import gitlab
-import os
 
 import keyword
 
@@ -116,7 +115,7 @@ class GitlabManager(object):
                     'GitLab remote failed to authenticate and/or initialize'
                 )
 
-    def _ensure_project(
+    def ensure_project(
         self, project_name, repo_path, project_type, description, additional_tags=[]
     ):
         self._ensure_initialized()
@@ -163,19 +162,6 @@ class GitlabManager(object):
                     project = self.get_project(project_name)
                 if not project:
                     raise
-
-        return project
-
-    def create_project(
-        self, project_name, repo_path, project_type, description, additional_tags=[]
-    ):
-        git_path = os.path.join(repo_path, '.git')
-        project = None
-
-        if not os.path.exists(git_path):
-            project = self._ensure_project(
-                project_name, repo_path, project_type, description, additional_tags
-            )
 
         return project
 

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -969,7 +969,7 @@ class AssetGroup(db.Model, HoustonModel):
     def ensure_remote(self, additional_tags=[]):
         project = current_app.git_backend.get_project(str(self.guid))
         if not project:
-            project = current_app.git_backend.create_project(
+            project = current_app.git_backend.ensure_project(
                 str(self.guid),
                 self.get_absolute_path(),
                 self.major_type.name,

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -945,13 +945,6 @@ class AssetGroup(db.Model, HoustonModel):
         log.warning('justify_existence() found ZERO assets, self-destructing %r' % self)
         self.delete()  # TODO will this also kill remote repo?
 
-    @classmethod
-    def delete_remote_repository(cls, guid):
-        return current_app.git_backend.delete_remote_project_by_name(str(guid))
-
-    def delete_remote(self):
-        return self.__class__.delete_remote_repository(self.guid)
-
     def get_repository(self):
         repo_path = pathlib.Path(self.get_absolute_path())
         if (repo_path / '.git').exists():

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -168,6 +168,8 @@ class AssetGroupsStreamlined(Resource):
                 -F files="@tests/asset_groups/test-000/fluke.jpg" \
                 https://houston.dyn.wildme.io/api/v1/asset_groups/streamlined | jq
         """
+        from .tasks import git_push
+
         context = api.commit_or_abort(
             db.session, default_error_message='Failed to create a new Asset_group'
         )
@@ -184,7 +186,9 @@ class AssetGroupsStreamlined(Resource):
 
         asset_group.git_commit('Initial commit via %s' % (request.url_rule,))
 
-        asset_group.git_push()
+        # Do git push to gitlab in the background (we won't wait for its
+        # completion here)
+        git_push.delay(str(asset_group.guid))
 
         return asset_group
 

--- a/app/modules/asset_groups/tasks.py
+++ b/app/modules/asset_groups/tasks.py
@@ -9,6 +9,26 @@ log = logging.getLogger(__name__)
 
 
 @celery.task()
+def ensure_remote(asset_group_guid, additional_tags=[]):
+    from .models import AssetGroup
+
+    asset_group = AssetGroup.query.get(asset_group_guid)
+    project = current_app.git_backend.get_project(asset_group_guid)
+    if not project:
+        project = current_app.git_backend.ensure_project(
+            asset_group_guid,
+            asset_group.get_absolute_path(),
+            asset_group.major_type.name,
+            asset_group.description,
+            additional_tags,
+        )
+
+    repo = asset_group.ensure_repository()
+    if 'origin' not in repo.remotes:
+        repo.create_remote('origin', project.web_url)
+
+
+@celery.task()
 def delete_remote(asset_group_guid):
     current_app.git_backend.delete_remote_project_by_name(asset_group_guid)
 
@@ -19,6 +39,8 @@ def git_push(asset_group_guid):
 
     asset_group = AssetGroup.query.get(asset_group_guid)
     repo = asset_group.get_repository()
+    if 'origin' not in repo.remotes:
+        ensure_remote(asset_group_guid)
     with GitLabPAT(repo):
         log.info('Pushing to authorized URL')
         repo.git.push('--set-upstream', repo.remotes.origin, repo.head.ref)

--- a/app/modules/asset_groups/tasks.py
+++ b/app/modules/asset_groups/tasks.py
@@ -1,9 +1,25 @@
 # -*- coding: utf-8 -*-
+import logging
+
 from flask import current_app
 
 from app.extensions.celery import celery
+
+log = logging.getLogger(__name__)
 
 
 @celery.task()
 def delete_remote(asset_group_guid):
     current_app.git_backend.delete_remote_project_by_name(asset_group_guid)
+
+
+@celery.task()
+def git_push(asset_group_guid):
+    from .models import AssetGroup, GitLabPAT
+
+    asset_group = AssetGroup.query.get(asset_group_guid)
+    repo = asset_group.get_repository()
+    with GitLabPAT(repo):
+        log.info('Pushing to authorized URL')
+        repo.git.push('--set-upstream', repo.remotes.origin, repo.head.ref)
+        log.info(f'...pushed to {repo.head.ref}')

--- a/app/modules/asset_groups/tasks.py
+++ b/app/modules/asset_groups/tasks.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+from flask import current_app
+
+from app.extensions.celery import celery
+
+
+@celery.task()
+def delete_remote(asset_group_guid):
+    current_app.git_backend.delete_remote_project_by_name(asset_group_guid)

--- a/tasks/app/asset_groups.py
+++ b/tasks/app/asset_groups.py
@@ -28,6 +28,7 @@ def create_asset_group_from_path(
     """
     from app.modules.users.models import User
     from app.modules.asset_groups.models import AssetGroup, AssetGroupMajorType
+    from app.modules.asset_groups.tasks import git_push
     from app.extensions import db
     import socket
 
@@ -62,7 +63,7 @@ def create_asset_group_from_path(
     hostname = socket.gethostname()
     asset_group.git_commit('Initial commit via CLI on host %r' % (hostname,))
 
-    asset_group.git_push()
+    git_push(str(asset_group.guid))
 
     print('Created and pushed new asset_group: %r' % (asset_group,))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,6 +254,8 @@ def test_root(flask_app):
 
 
 def ensure_asset_group_repo(flask_app, db, asset_group, file_data=[]):
+    from app.modules.asset_groups.tasks import git_push
+
     if pathlib.Path(asset_group.get_absolute_path()).exists():
         shutil.rmtree(asset_group.get_absolute_path())
     repo = asset_group.get_repository()
@@ -273,7 +275,8 @@ def ensure_asset_group_repo(flask_app, db, asset_group, file_data=[]):
         'Initial commit for testing',
         existing_filepath_guid_mapping=filepath_guid_mapping,
     )
-    asset_group.git_push()
+    # Call git_push without .delay in tests to do it in the foreground
+    git_push(str(asset_group.guid))
 
 
 @pytest.fixture(scope='session')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,7 +254,7 @@ def test_root(flask_app):
 
 
 def ensure_asset_group_repo(flask_app, db, asset_group, file_data=[]):
-    from app.modules.asset_groups.tasks import git_push
+    from app.modules.asset_groups.tasks import git_push, ensure_remote
 
     if pathlib.Path(asset_group.get_absolute_path()).exists():
         shutil.rmtree(asset_group.get_absolute_path())
@@ -266,7 +266,9 @@ def ensure_asset_group_repo(flask_app, db, asset_group, file_data=[]):
     with db.session.begin():
         db.session.add(asset_group)
     db.session.refresh(asset_group)
-    asset_group.ensure_remote(additional_tags=['type:pytest-required'])
+    asset_group.ensure_repository()
+    # Call ensure_remote without .delay in tests to do it in the foreground
+    ensure_remote(str(asset_group.guid), additional_tags=['type:pytest-required'])
     filepath_guid_mapping = {}
     for uuid_, path in file_data:
         repo_filepath = asset_group.git_copy_file_add(str(path))

--- a/tests/extensions/test_gitlab.py
+++ b/tests/extensions/test_gitlab.py
@@ -34,7 +34,7 @@ def test_ensure_project_name_taken(flask_app):
             'create',
             side_effect=create_project_raise_gitlab_exception,
         ):
-            project = flask_app.git_backend.create_project(
+            project = flask_app.git_backend.ensure_project(
                 project_name, repo_path, 'test', 'project description'
             )
             assert project.name == project_name
@@ -50,6 +50,6 @@ def test_ensure_project_name_taken(flask_app):
             side_effect=raise_gitlab_exception,
         ):
             with pytest.raises(gitlab.exceptions.GitlabCreateError):
-                flask_app.git_backend.create_project(
+                flask_app.git_backend.ensure_project(
                     project_name, repo_path, 'test', 'project description'
                 )

--- a/tests/modules/asset_groups/resources/test_permissions.py
+++ b/tests/modules/asset_groups/resources/test_permissions.py
@@ -57,6 +57,7 @@ def test_create_patch_asset_group(
     flask_app_client, researcher_1, readonly_user, test_root, db
 ):
     # pylint: disable=invalid-name
+    from app.modules.asset_groups.tasks import delete_remote
 
     asset_group_guid = None
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
@@ -104,7 +105,7 @@ def test_create_patch_asset_group(
         asset_group_utils.delete_asset_group(
             flask_app_client, researcher_1, asset_group_guid
         )
-        temp_asset_group.delete_remote()
+        delete_remote(str(temp_asset_group.guid))
 
         # And if the asset_group is already gone, a re attempt at deletion should get the same response
         asset_group_utils.delete_asset_group(
@@ -116,7 +117,7 @@ def test_create_patch_asset_group(
 
     finally:
         tus_utils.cleanup_tus_dir(transaction_id)
-        temp_asset_group.delete_remote()
+        delete_remote(str(temp_asset_group.guid))
         # Restore original state
         temp_asset_group = AssetGroup.query.get(asset_group_guid)
         if temp_asset_group is not None:

--- a/tests/modules/asset_groups/resources/test_upload_file.py
+++ b/tests/modules/asset_groups/resources/test_upload_file.py
@@ -35,7 +35,9 @@ def test_create_open_submission(flask_app_client, regular_user, test_root, db):
         # TODO this is what the test checked, that there was not commit, what we are now specifically not permitting
         # assert temp_submission.commit is None
     finally:
-        temp_submission.delete_remote()
+        from app.modules.asset_groups.tasks import delete_remote
+
+        delete_remote(str(temp_submission.guid))
         # Restore original state
         if temp_submission is not None:
             temp_submission.delete()
@@ -90,7 +92,9 @@ def test_submission_streamlined(flask_app_client, test_root, regular_user, db):
         assert temp_submission.commit == repo.head.object.hexsha
         assert temp_submission.major_type == test_major_type
     finally:
-        temp_submission.delete_remote()
+        from app.modules.asset_groups.tasks import delete_remote
+
+        delete_remote(str(temp_submission.guid))
 
         # Restore original state
         if temp_submission is not None:

--- a/tests/modules/sightings/resources/test_featured_asset_guid.py
+++ b/tests/modules/sightings/resources/test_featured_asset_guid.py
@@ -80,8 +80,10 @@ def test_featured_asset_guid_endpoint(db, flask_app_client, researcher_1):
     # new_asset_group.delete()
     # sighting_utils.delete_sighting(flask_app_client, researcher_1, str(sighting.guid))
 
+    from app.modules.asset_groups.tasks import delete_remote
+
     sighting_utils.delete_sighting(flask_app_client, researcher_1, str(sighting.guid))
-    new_asset_group.delete_remote()
+    delete_remote(str(new_asset_group.guid))
     asset_group_utils.delete_asset_group(
         flask_app_client, researcher_1, new_asset_group.guid
     )
@@ -134,8 +136,10 @@ def test_patch_featured_asset_guid(db, flask_app_client, researcher_1):
 
     assert new_asset_2.guid == sighting.get_featured_asset_guid()
 
+    from app.modules.asset_groups.tasks import delete_remote
+
     sighting_utils.delete_sighting(flask_app_client, researcher_1, str(sighting.guid))
-    new_asset_group.delete_remote()
+    delete_remote(str(new_asset_group.guid))
     asset_group_utils.delete_asset_group(
         flask_app_client, researcher_1, new_asset_group.guid
     )

--- a/tests/modules/sightings/resources/test_sighting_assets.py
+++ b/tests/modules/sightings/resources/test_sighting_assets.py
@@ -62,11 +62,13 @@ def test_asset_addition(db, flask_app_client, staff_user):
         assert len(new_sighting.assets) == 3
 
     finally:
+        from app.modules.asset_groups.tasks import delete_remote
+
         # staff can do this, no need to revisit encounter based ownership here
         sighting_utils.delete_sighting(
             flask_app_client, staff_user, str(new_sighting.guid)
         )
-        new_asset_group.delete_remote()
+        delete_remote(str(new_asset_group.guid))
         new_asset_1.delete()
         new_asset_2.delete()
         new_asset_3.delete()
@@ -146,9 +148,11 @@ def test_asset_file_addition(db, flask_app_client, staff_user):
         assert len(new_sighting.assets) == 2
 
     finally:
+        from app.modules.asset_groups.tasks import delete_remote
+
         sighting_utils.delete_sighting(flask_app_client, staff_user, sighting_id)
         new_researcher.delete()
         # assets are only cleaned up once the submissions are cleaned up
         for asset_group in new_researcher.asset_groups:
-            asset_group.delete_remote()
+            delete_remote(str(asset_group.guid))
             asset_group.delete()


### PR DESCRIPTION
- Return error if exception raised inside GitLabPAT

  When using the `GitLabPAT` context manager, it was eating up all the
  exceptions because we always return true in `__exit__`.
  
  In fact, `git_pull` failed:
  
  ```
  E           git.exc.GitCommandError: Cmd('git') failed due to: exit code(1)
  E             cmdline: git pull origin master
  E             stderr: 'warning: redirecting to http://08d990594836/test/e5ea9710-ce50-453f-924d-17cc7ee67a09.git/
  E           fatal: Couldn't find remote ref master'
  
  /usr/local/lib/python3.9/site-packages/git/cmd.py:931: GitCommandError
  ```
  
  so we need to catch the exception.

- Remove GitlabManager.create_project and use ensure_project instead

  `GitlabManager.create_project` only creates a gitlab project if the git
  repo doesn't exist, but we always want to create the gitlab project
  regardless, so just switch to using `GitlabManager.ensure_project`.

- Move asset group delete remote code to a celery task

  We are not actually calling the delete remote code in any application
  code, it is only currently used in tests.
  
  In tests, I think it's ok to call the code in the foreground so we can
  just do:
  
  ```
  delete_remote(str(asset_group.guid))
  ```
  
  If we ever use this in the application, we would call this in the
  background and let a celery worker execute the code by doing:
  
  ```
  delete_remote.delay(str(asset_group.guid))
  ```

- Move AssetGroup git_push into a celery task

  We can now do git_push as a background job:
  
  ```
  from app.modules.asset_groups.tasks import git_push
  
  git_push.delay(asset_group_guid)
  ```

- Move AssetGroup.ensure_remote to a celery task

  We are moving the creation of the gitlab project to a background task.
  Instead of calling `ensure_remote`, change code to do
  `ensure_repository` so the git repository exists and some time later the
  gitlab project is created.
