### PR TITLE
Handle "name has already been taken" GitlabCreateError (attempt to fix tests in github)

### DIFF
--- a/tests/extensions/test_gitlab.py
+++ b/tests/extensions/test_gitlab.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+import tempfile
+from unittest import mock
+import uuid
+
+import gitlab.exceptions
+import pytest
+
+
+def test_ensure_project_name_taken(flask_app):
+    flask_app.git_backend._ensure_initialized()
+    projects_create = flask_app.git_backend.gl.projects.create
+
+    def raise_gitlab_exception(*args, error_message='Unknown', **kwargs):
+        raise gitlab.exceptions.GitlabCreateError(
+            response_code=400,
+            error_message=error_message,
+        )
+
+    def create_project_raise_gitlab_exception(*args, **kwargs):
+        # Create the project
+        projects_create(*args, **kwargs)
+        # But raise an error
+        raise_gitlab_exception(
+            error_message="{'name': ['has already been taken'], 'path': ['has already been taken'], 'limit_reached': []}"
+        )
+
+    with tempfile.TemporaryDirectory() as repo_path:
+        project_name = str(uuid.uuid4())
+
+        # Create the project but gitlab returns an error
+        with mock.patch.object(
+            flask_app.git_backend.gl.projects,
+            'create',
+            side_effect=create_project_raise_gitlab_exception,
+        ):
+            project = flask_app.git_backend.create_project(
+                project_name, repo_path, 'test', 'project description'
+            )
+            assert project.name == project_name
+            assert project.description == 'project description'
+
+    with tempfile.TemporaryDirectory() as repo_path:
+        project_name = str(uuid.uuid4())
+
+        # Project fails to create and gitlab returns an error
+        with mock.patch.object(
+            flask_app.git_backend.gl.projects,
+            'create',
+            side_effect=raise_gitlab_exception,
+        ):
+            with pytest.raises(gitlab.exceptions.GitlabCreateError):
+                flask_app.git_backend.create_project(
+                    project_name, repo_path, 'test', 'project description'
+                )


### PR DESCRIPTION
When running tests, we often see this failure:

```
        # test with explicit paths (should succeed)
>       sub = AssetGroup.create_from_tus('PYTEST', researcher_1, tid, paths={valid_file})

tests/modules/asset_groups/test_tus_creation.py:33:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
app/modules/asset_groups/models.py:480: in create_from_tus
    added = asset_group.import_tus_files(
app/modules/asset_groups/models.py:497: in import_tus_files
    self.ensure_remote()
app/modules/asset_groups/models.py:915: in ensure_remote
    project = current_app.git_backend.create_project(
app/extensions/gitlab.py:166: in create_project
    project = self._ensure_project(
app/extensions/gitlab.py:142: in _ensure_project
    project = self.gl.projects.create(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = (<gitlab.v4.objects.projects.ProjectManager object at 0x7f4d24eb5bb0>, {'description': 'PYTEST', 'emails_disabled': True, 'lfs_enabled': True, 'merge_method': 'rebase_merge', ...})

    @functools.wraps(f)
    def wrapped_f(*args, **kwargs):
        try:
            return f(*args, **kwargs)
        except GitlabHttpError as e:
>           raise error(e.error_message, e.response_code, e.response_body) from e
E           gitlab.exceptions.GitlabCreateError: 400: {'name': ['has already been taken'], 'path': ['has already been taken'], 'limit_reached': []}
```

It is possible to the project was created but gitlab returns and error and
because we have retry_transient_errors=True, when we hit the create project url
again, gitlab returns with an error saying "name has already been taken".

This change ignores the error if a project is found with the same name.

---

It's hard to know if this actually fixes the problem because it doesn't happen locally... :crossed_fingers: 