### PR TITLE
Move Sighting model import to inside the test functions

### DIFF
--- a/tests/modules/sightings/resources/test_featured_asset_guid.py
+++ b/tests/modules/sightings/resources/test_featured_asset_guid.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 import json
-from app.modules.sightings.models import Sighting
 from tests.modules.sightings.resources import utils as sighting_utils
 from tests.modules.asset_groups.resources import utils as asset_group_utils
 from tests import utils
 
 
 def test_featured_asset_guid_endpoint(db, flask_app_client, researcher_1):
+    from app.modules.sightings.models import Sighting
 
     data_in = {
         'encounters': [{}],
@@ -88,6 +88,7 @@ def test_featured_asset_guid_endpoint(db, flask_app_client, researcher_1):
 
 
 def test_patch_featured_asset_guid(db, flask_app_client, researcher_1):
+    from app.modules.sightings.models import Sighting
 
     data_in = {
         'encounters': [{}],


### PR DESCRIPTION
When doing `pytest tests/modules/sightings/resources/`:

```
>           app = create_app(flask_config_name='testing', config_override=config_override)

tests/conftest.py:54:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
app/__init__.py:159: in create_app
    extensions.init_app(app)
app/extensions/__init__.py:279: in init_app
    extension.init_app(app)
app/extensions/config/__init__.py:174: in init_app
    app.config.initialize(app)
app/extensions/config/__init__.py:50: in initialize
    self.sync(app)
app/extensions/config/__init__.py:65: in sync
    houston_configs = HoustonConfig.query.all()
/usr/local/lib/python3.9/site-packages/flask_sqlalchemy/__init__.py:550: in __get__
    mapper = orm.class_mapper(type)
/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/base.py:451: in class_mapper
    mapper = _inspect_mapped_class(class_, configure=configure)
/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/base.py:430: in _inspect_mapped_class
    mapper._configure_all()
/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/mapper.py:1352: in _configure_all
    configure_mappers()
/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/mapper.py:3299: in configure_mappers
    mapper._post_configure_properties()
/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/mapper.py:1965: in _post_configure_properties
    prop.init()
/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/interfaces.py:197: in init
    self.do_init()
/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/relationships.py:2077: in do_init
    self._process_dependent_arguments()
/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/relationships.py:2148: in _process_dependent_arguments
    self.target = self.entity.persist_selectable
/usr/local/lib/python3.9/site-packages/sqlalchemy/util/langhelpers.py:893: in __get__
    obj.__dict__[self.__name__] = result = self.fget(obj)
/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/relationships.py:2044: in entity
    argument = self.argument()
/usr/local/lib/python3.9/site-packages/sqlalchemy/ext/declarative/clsregistry.py:326: in _resolve_name
    self._raise_for_name(name, err)
/usr/local/lib/python3.9/site-packages/sqlalchemy/ext/declarative/clsregistry.py:304: in _raise_for_name
    util.raise_(
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

...

        try:
>           raise exception
E           sqlalchemy.exc.InvalidRequestError: When initializing mapper mapped class SightingAssets->sighting_assets, expression 'Asset' failed to locate a name ('Asset'). If this is a class name, consider adding this relationship() to the <class 'app.modules.sightings.models.SightingAssets'> class after both dependent classes have been defined.

/usr/local/lib/python3.9/site-packages/sqlalchemy/util/compat.py:182: InvalidRequestError
```

It appears to happen when you import a model, but I didn't look into
why...

