### PR TITLE
Fix exception patching encounter with edm error

### DIFF
--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -141,8 +141,8 @@ class EncounterByID(Resource):
             abort(
                 ex.status_code,
                 ex.message,
-                error=ex.error,
-                edm_status_code=ex.edm_status_code,
+                error=ex.get_val('error', 'Error'),
+                edm_status_code=ex.get_val('edm_status_code', None),
             )
 
         # edm patch was successful


### PR DESCRIPTION
```
        # must be edm patch
        log.debug(f'wanting to do edm patch on args={args}')
        try:
            result_data = current_app.edm.request_passthrough_result(
                'encounter.data',
                'patch',
                {'data': args},
                encounter.guid,
                request_headers=request.headers,
            )
        except HoustonException as ex:
            abort(
                ex.status_code,
                ex.message,
>               error=ex.error,
                edm_status_code=ex.edm_status_code,
            )
E           AttributeError: 'HoustonException' object has no attribute 'error'

app/modules/encounters/resources.py:144: AttributeError
```

