### PR TITLE
DEX-317: remove requirement of context in edm sighting

### DIFF
--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -35,7 +35,7 @@ class EDMManager(RestManager):
     ENDPOINT_PREFIX = 'api'
 
     # this is based on edm date of most recent commit (we must be at or greater than this)
-    MIN_VERSION = '2021-05-21 17:24:00 -0700'
+    MIN_VERSION = '2021-06-02 16:00:00 -0700'
 
     # We use // as a shorthand for prefix
     # fmt: off

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -23,12 +23,12 @@ def test_create_failures(flask_app_client, test_root, researcher_1):
     assert response.json['passed_message'] == 'Must have at least one encounter'
     assert not response.json['success']
 
-    # has encounters, zero assetReferences, but fails on bad (missing) context value
+    # has encounters, zero assetReferences, but fails on bad (missing) locationId value
     data_in = {'startTime': timestamp, 'encounters': [{}]}
     response = sighting_utils.create_sighting(
         flask_app_client, researcher_1, expected_status_code=400, data_in=data_in
     )
-    assert response.json['errorFields'][0] == 'context'
+    assert response.json['errorFields'][0] == 'locationId'
     assert not response.json['success']
 
     # has encounters, but bunk assetReferences


### PR DESCRIPTION
## Pull Request Overview

- Modifies test which expected `context` to be a required field on Sightings (it no longer is)
- :warning: This requires to be tested against the latest EDM version (which drops `context` requirement).

