### PR TITLE
DEX-317 (part 2) - remove requirement of context from sighting

### DIFF
--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -35,7 +35,7 @@ class EDMManager(RestManager):
     ENDPOINT_PREFIX = 'api'
 
     # this is based on edm date of most recent commit (we must be at or greater than this)
-    MIN_VERSION = '2021-06-02 16:00:00 -0700'
+    MIN_VERSION = '2021-06-02 16:48:00 -0700'
 
     # We use // as a shorthand for prefix
     # fmt: off

--- a/app/modules/asset_groups/metadata.py
+++ b/app/modules/asset_groups/metadata.py
@@ -68,7 +68,6 @@ class BaseAssetGroupMetadata(object):
         sighting_fields = [
             ('locationId', str, False),
             ('startTime', str, True),
-            ('context', str, True),
             ('encounters', list, True),
             ('name', str, False),
             ('assetReferences', list, False),

--- a/tests/modules/asset_groups/resources/test_create_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_create_asset_group.py
@@ -62,11 +62,6 @@ def test_create_asset_group(flask_app_client, researcher_1, readonly_user, test_
         )
 
         data.set_sighting_field(0, 'startTime', 'never')
-        resp_msg = 'context field missing from Sighting 1'
-        asset_group_utils.create_asset_group(
-            flask_app_client, researcher_1, data.get(), 400, resp_msg
-        )
-        data.set_sighting_field(0, 'context', 'nothing')
 
         resp_msg = 'encounters field missing from Sighting 1'
         asset_group_utils.create_asset_group(

--- a/tests/modules/asset_groups/resources/test_patch_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_patch_asset_group.py
@@ -33,14 +33,6 @@ def test_patch_asset_group(flask_app_client, researcher_1, regular_user, test_ro
 
         import copy
 
-        no_context_config = copy.deepcopy(group_sighting.json['config'])
-        del no_context_config['context']
-        patch_data = [utils.patch_replace_op('config', no_context_config)]
-
-        asset_group_utils.patch_asset_group_sighting(
-            flask_app_client, researcher_1, asset_group_sighting_guid, patch_data, 400
-        )
-
         new_absent_file = copy.deepcopy(group_sighting.json['config'])
         new_absent_file['assetReferences'].append('absent_file.jpg')
         patch_data = [utils.patch_replace_op('config', new_absent_file)]

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -27,8 +27,7 @@ class TestCreationData(object):
                 'transactionId': transaction_id,
                 'sightings': [
                     {
-                        'startTime': 'sometime or other',
-                        'context': 'something',
+                        'startTime': '2000-01-01T01:01:01Z',
                         # Yes, that really is a location, it's a village in Wiltshire https://en.wikipedia.org/wiki/Tiddleywink
                         'locationId': 'Tiddleywink',
                         'encounters': [{}],
@@ -45,8 +44,7 @@ class TestCreationData(object):
         self.content['sightings'].append(
             {
                 'locationId': location,
-                'startTime': 'now',
-                'context': 'none',
+                'startTime': '2000-01-01T01:01:01Z',
                 'assetReferences': [],
                 'encounters': [],
             }

--- a/tests/modules/encounters/resources/utils.py
+++ b/tests/modules/encounters/resources/utils.py
@@ -15,7 +15,7 @@ def create_encounter(flask_app_client, user, expected_status_code=200):
 
     data_in = {
         'locationId': 'PYTEST-SIGHTING',
-        'context': 'TEXT',
+        'startTime': '2000-01-01T01:01:01Z',
         'encounters': [{'locationId': 'PYTEST-ENCOUNTER'}],
     }
     response = sighting_utils.create_sighting(flask_app_client, user, data_in)

--- a/tests/modules/sightings/resources/test_custom_fields.py
+++ b/tests/modules/sightings/resources/test_custom_fields.py
@@ -23,7 +23,6 @@ def test_custom_fields_on_sighting(
     cfd_test_value = 'CFD_TEST_VALUE'
     data_in = {
         'startTime': timestamp,
-        'context': 'test',
         'locationId': 'test',
         'customFields': {
             cfd_id: cfd_test_value,

--- a/tests/modules/sightings/resources/test_custom_fields.py
+++ b/tests/modules/sightings/resources/test_custom_fields.py
@@ -18,7 +18,7 @@ def test_custom_fields_on_sighting(
     # we should end up with these same counts (which _should be_ all zeros!)
     orig_ct = test_utils.all_count(db)
 
-    timestamp = datetime.datetime.now().isoformat()
+    timestamp = datetime.datetime.now().isoformat() + 'Z'
     transaction_id, test_filename = sighting_utils.prep_tus_dir(test_root)
     cfd_test_value = 'CFD_TEST_VALUE'
     data_in = {

--- a/tests/modules/sightings/resources/test_featured_asset_guid.py
+++ b/tests/modules/sightings/resources/test_featured_asset_guid.py
@@ -11,7 +11,7 @@ def test_featured_asset_guid_endpoint(db, flask_app_client, researcher_1):
 
     data_in = {
         'encounters': [{}],
-        'context': 'test',
+        'startTime': '2000-01-01T01:01:01Z',
         'locationId': 'test',
     }
 
@@ -94,7 +94,7 @@ def test_patch_featured_asset_guid(db, flask_app_client, researcher_1):
 
     data_in = {
         'encounters': [{}],
-        'context': 'test',
+        'startTime': '2000-01-01T01:01:01Z',
         'locationId': 'test',
     }
 

--- a/tests/modules/sightings/resources/utils.py
+++ b/tests/modules/sightings/resources/utils.py
@@ -44,7 +44,7 @@ def cleanup_tus_dir(tid):
 def create_sighting(
     flask_app_client,
     user,
-    data_in={'locationId': 'PYTEST', 'context': 'test'},
+    data_in={'locationId': 'PYTEST', 'startTime': '2000-01-01T01:01:01Z'},
     expected_status_code=200,
 ):
     if user is not None:

--- a/tests/modules/users/resources/test_getting_users_info.py
+++ b/tests/modules/users/resources/test_getting_users_info.py
@@ -125,7 +125,7 @@ def test_getting_sightings_for_user(flask_app_client, db, staff_user):
 
     data_in = {
         'encounters': [{}],
-        'context': 'test',
+        'startTime': '2000-01-01T01:01:01Z',
         'locationId': 'test',
     }
 


### PR DESCRIPTION

## Pull Request Overview

- Further cleanup of no longer requiring `context` on sightings
- Also handles fact `startTime` on sightings is now required (and must be valid value)

---

**Review Notes**
- Mostly modifications / drops to tests
- :warning: requires latest EDM version
