### PR TITLE
DEX-279 Make Gitlab optional

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -108,6 +108,10 @@ jobs:
           docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e TEST_DATABASE_URI=$TEST_DATABASE_URI houston pytest -s -v
           docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e TEST_DATABASE_URI=$TEST_DATABASE_URI houston pytest -s -v
 
+      - name: Run tests without gitlab
+        run: |
+          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e TEST_DATABASE_URI=$TEST_DATABASE_URI -e GITLAB_REMOTE_URI=http://connection-error/ houston pytest -s -v
+
       - name: Check DB migrations (sqlite)
         if: matrix.db-uri == 'sqlite://'
         run: |

--- a/app/extensions/gitlab.py
+++ b/app/extensions/gitlab.py
@@ -22,6 +22,10 @@ GITLAB_TIMESTAMP_FORMAT_STR = '%Y-%m-%dT%H:%M:%S.%fZ'  # Ex: '2020-10-23T16:57:5
 log = logging.getLogger(__name__)
 
 
+class GitlabInitializationError(RuntimeError):
+    pass
+
+
 class GitlabManager(object):
     def __init__(self, pre_initialize=False, *args, **kwargs):
         super(GitlabManager, self).__init__(*args, **kwargs)
@@ -111,7 +115,7 @@ class GitlabManager(object):
                 if current_app.debug:
                     log.exception('problem initializing GitLab integration')
 
-                raise RuntimeError(
+                raise GitlabInitializationError(
                     'GitLab remote failed to authenticate and/or initialize'
                 )
 

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -373,15 +373,15 @@ class AssetGroup(db.Model, HoustonModel):
             os.mkdir(assets_path)
         pathlib.Path(os.path.join(assets_path, '.touch')).touch()
 
-        metatdata_path = os.path.join(group_path, 'metadata.json')
-        if not os.path.exists(metatdata_path):
-            with open(metatdata_path, 'w') as metatdata_file:
+        metadata_path = os.path.join(group_path, 'metadata.json')
+        if not os.path.exists(metadata_path):
+            with open(metadata_path, 'w') as metatdata_file:
                 json.dump({}, metatdata_file)
 
-        with open(metatdata_path, 'r') as metatdata_file:
+        with open(metadata_path, 'r') as metatdata_file:
             group_metadata = json.load(metatdata_file)
 
-        with open(metatdata_path, 'w') as metatdata_file:
+        with open(metadata_path, 'w') as metatdata_file:
             json.dump(group_metadata, metatdata_file)
 
         log.info('LOCAL  REPO: %r' % (repo.working_tree_dir,))

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -63,6 +63,7 @@ class Asset(db.Model, HoustonModel):
             'filesystem_guid={self.filesystem_guid}, '
             'semantic_guid={self.semantic_guid}, '
             'mime="{self.mime_type}", '
+            'asset_group_guid="{self.asset_group_guid}", '
             ')>'.format(class_name=self.__class__.__name__, self=self)
         )
 

--- a/tests/extensions/test_gitlab.py
+++ b/tests/extensions/test_gitlab.py
@@ -6,9 +6,14 @@ import uuid
 import gitlab.exceptions
 import pytest
 
+from app.extensions.gitlab import GitlabInitializationError
+
 
 def test_ensure_project_name_taken(flask_app):
-    flask_app.git_backend._ensure_initialized()
+    try:
+        flask_app.git_backend._ensure_initialized()
+    except GitlabInitializationError:
+        pytest.skip('Gitlab unavailable')
     projects_create = flask_app.git_backend.gl.projects.create
 
     def raise_gitlab_exception(*args, error_message='Unknown', **kwargs):

--- a/tests/modules/asset_groups/resources/test_permissions.py
+++ b/tests/modules/asset_groups/resources/test_permissions.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
+from app.extensions.gitlab import GitlabInitializationError
+
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.modules.assets.resources.utils as asset_utils
 import tests.extensions.tus.utils as tus_utils
@@ -105,7 +107,10 @@ def test_create_patch_asset_group(
         asset_group_utils.delete_asset_group(
             flask_app_client, researcher_1, asset_group_guid
         )
-        delete_remote(str(temp_asset_group.guid))
+        try:
+            delete_remote(str(temp_asset_group.guid))
+        except GitlabInitializationError:
+            pass
 
         # And if the asset_group is already gone, a re attempt at deletion should get the same response
         asset_group_utils.delete_asset_group(
@@ -117,7 +122,10 @@ def test_create_patch_asset_group(
 
     finally:
         tus_utils.cleanup_tus_dir(transaction_id)
-        delete_remote(str(temp_asset_group.guid))
+        try:
+            delete_remote(str(temp_asset_group.guid))
+        except GitlabInitializationError:
+            pass
         # Restore original state
         temp_asset_group = AssetGroup.query.get(asset_group_guid)
         if temp_asset_group is not None:

--- a/tests/modules/asset_groups/resources/test_upload_file.py
+++ b/tests/modules/asset_groups/resources/test_upload_file.py
@@ -3,6 +3,8 @@
 import filecmp
 from os.path import join, basename
 
+from app.extensions.gitlab import GitlabInitializationError
+
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.extensions.tus.utils as tus_utils
 
@@ -37,7 +39,10 @@ def test_create_open_submission(flask_app_client, regular_user, test_root, db):
     finally:
         from app.modules.asset_groups.tasks import delete_remote
 
-        delete_remote(str(temp_submission.guid))
+        try:
+            delete_remote(str(temp_submission.guid))
+        except GitlabInitializationError:
+            pass
         # Restore original state
         if temp_submission is not None:
             temp_submission.delete()
@@ -94,7 +99,10 @@ def test_submission_streamlined(flask_app_client, test_root, regular_user, db):
     finally:
         from app.modules.asset_groups.tasks import delete_remote
 
-        delete_remote(str(temp_submission.guid))
+        try:
+            delete_remote(str(temp_submission.guid))
+        except GitlabInitializationError:
+            pass
 
         # Restore original state
         if temp_submission is not None:

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -272,6 +272,10 @@ class CloneAssetGroup(object):
             # and read it back as the real user
             with client.login(owner, auth_scopes=('asset_groups:read',)):
                 self.response = client.get(url)
+        else:
+            assert (
+                False
+            ), f'url={url} status_code={self.response.status_code} data={self.response.data}'
 
     def remove_files(self):
         database_path = config.TestingConfig.ASSET_GROUP_DATABASE_PATH
@@ -299,5 +303,5 @@ def clone_asset_group(
     clone = CloneAssetGroup(client, admin_user, owner, guid, force_clone)
 
     if not expect_failure:
-        assert clone.response.status_code == 200
+        assert clone.response.status_code == 200, clone.response.data
     return clone

--- a/tests/modules/sightings/resources/test_sighting_assets.py
+++ b/tests/modules/sightings/resources/test_sighting_assets.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
+from app.extensions.gitlab import GitlabInitializationError
 import sqlalchemy
 
 from tests import utils
@@ -68,7 +69,10 @@ def test_asset_addition(db, flask_app_client, staff_user):
         sighting_utils.delete_sighting(
             flask_app_client, staff_user, str(new_sighting.guid)
         )
-        delete_remote(str(new_asset_group.guid))
+        try:
+            delete_remote(str(new_asset_group.guid))
+        except GitlabInitializationError:
+            pass
         new_asset_1.delete()
         new_asset_2.delete()
         new_asset_3.delete()
@@ -154,5 +158,8 @@ def test_asset_file_addition(db, flask_app_client, staff_user):
         new_researcher.delete()
         # assets are only cleaned up once the submissions are cleaned up
         for asset_group in new_researcher.asset_groups:
-            delete_remote(str(asset_group.guid))
+            try:
+                delete_remote(str(asset_group.guid))
+            except GitlabInitializationError:
+                pass
             asset_group.delete()


### PR DESCRIPTION
- Add code to handle gitlab not available

  Raise GitlabInitializationError instead of RuntimeError in GitlabManager
  if unable to initialize gitlab.
  
  Skip tests that require gitlab if GitlabInitializationError is raised.

- Fix metadata_path typo in asset_groups/models.py

  Replace "metatdata_path" with "metadata_path" in asset_groups/models.py

- Run tests without gitlab in testing workflow

  Set GITLAB_REMOTE_URI to a non existent url to run tests without gitlab
