### PR TITLE
DEX-308: DELETE encounter cascade

### DIFF
--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -35,7 +35,7 @@ class EDMManager(RestManager):
     ENDPOINT_PREFIX = 'api'
 
     # this is based on edm date of most recent commit (we must be at or greater than this)
-    MIN_VERSION = '2021-06-02 16:48:00 -0700'
+    MIN_VERSION = '2021-06-08 22:55:00 -0700'
 
     # We use // as a shorthand for prefix
     # fmt: off

--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -174,7 +174,6 @@ class EDMManager(RestManager):
             not response.ok
             or not response_data.get('success', False)
             or response.status_code != 200
-            or result_data is None
         ):
             status_code = response.status_code
             if status_code > 600:

--- a/app/extensions/restManager/RestManager.py
+++ b/app/extensions/restManager/RestManager.py
@@ -269,7 +269,7 @@ class RestManager(RestManagerUserMixin):
         endpoint_encoded = requests.utils.quote(endpoint, safe='/?:=&')
 
         if verbose:
-            log.info(f'Sending request to {self.NAME}: {endpoint_encoded}')
+            log.info(f'Sending {method} request to {self.NAME}: {endpoint_encoded}')
             log.info(f'Contents {passthrough_kwargs}')
 
         session_ = target_session or self.sessions[target]

--- a/app/modules/encounters/models.py
+++ b/app/modules/encounters/models.py
@@ -89,14 +89,15 @@ class Encounter(db.Model, FeatherModel):
         with db.session.begin(subtransactions=True):
             db.session.delete(self)
 
-    def delete_from_edm(self, current_app):
-        response = current_app.edm.request_passthrough(
+    def delete_from_edm(self, current_app, request):
+        (response, response_data, result,) = current_app.edm.request_passthrough_parsed(
             'encounter.data',
             'delete',
             {},
             self.guid,
+            request_headers=request.headers,
         )
-        return response
+        return (response, response_data, result)
 
     def augment_edm_json(self, edm_json):
         edm_json['createdHouston'] = self.created.isoformat()

--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -191,6 +191,9 @@ class EncounterByID(Resource):
                 code=400,
             )
 
+        # we have to roll our own response here (to return) as it seems the only way we can add a header
+        #   (which we are using to denote the encounter DELETE also triggered a sighting DELETE, since
+        #   no body is returned on a 204 for DELETE
         resp = make_response()
         resp.status_code = 204
         sighting_id = None

--- a/tests/modules/encounters/resources/test_delete_encounter.py
+++ b/tests/modules/encounters/resources/test_delete_encounter.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-docstring
+
+from tests.modules.sightings.resources import utils as sighting_utils
+from tests.modules.encounters.resources import utils as enc_utils
+from tests import utils as test_utils
+import datetime
+
+timestamp = datetime.datetime.now().isoformat() + 'Z'
+
+
+def test_delete_method(db, flask_app_client, researcher_1, test_root, staff_user):
+    from app.modules.sightings.models import Sighting
+
+    # we should end up with these same counts (which _should be_ all zeros!)
+    orig_ct = test_utils.all_count(db)
+
+    transaction_id, test_filename = sighting_utils.prep_tus_dir(test_root)
+    data_in = {
+        'startTime': timestamp,
+        'locationId': 'test_delete_method',
+        'encounters': [
+            {},
+            {'locationId': 'test2'},
+        ],
+    }
+    response = sighting_utils.create_sighting(
+        flask_app_client, researcher_1, expected_status_code=200, data_in=data_in
+    )
+    assert response.json['success']
+
+    sighting_id = response.json['result']['id']
+    sighting = Sighting.query.get(sighting_id)
+    assert sighting is not None
+
+    enc0_id = response.json['result']['encounters'][0]['id']
+    enc1_id = response.json['result']['encounters'][1]['id']
+    assert enc0_id is not None
+    assert enc1_id is not None
+
+    ct = test_utils.all_count(db)
+    assert ct[0] == orig_ct[0] + 1  # one more sighting
+    assert ct[1] == orig_ct[1] + 2  # two more encounters
+
+    # this should be ok, cuz one enc remains
+    enc_utils.delete_encounter(flask_app_client, staff_user, enc0_id)
+    ct = test_utils.all_count(db)
+    assert ct[1] == orig_ct[1] + 1
+
+    # but this should then fail, cuz its the last enc and will take the sighting with it
+    enc_utils.delete_encounter(
+        flask_app_client, staff_user, enc1_id, expected_status_code=400
+    )
+    ct = test_utils.all_count(db)
+    assert ct[1] == orig_ct[1] + 1
+
+    # now this should work but take the sighting with it as well
+    headers = (('x-allow-delete-cascade-sighting', True),)
+    response = enc_utils.delete_encounter(
+        flask_app_client, staff_user, enc1_id, headers=headers
+    )
+    assert (
+        response.headers['x-deletedSighting-guid'] == sighting_id
+    )  # header tells us sighting cascade-deleted
+    ct = test_utils.all_count(db)  # back where we started
+    assert ct[0] == orig_ct[0]
+    assert ct[1] == orig_ct[1]

--- a/tests/modules/encounters/resources/utils.py
+++ b/tests/modules/encounters/resources/utils.py
@@ -53,9 +53,11 @@ def read_encounter(flask_app_client, user, enc_guid, expected_status_code=200):
     return response
 
 
-def delete_encounter(flask_app_client, user, enc_guid, expected_status_code=204):
+def delete_encounter(
+    flask_app_client, user, enc_guid, expected_status_code=204, headers=None
+):
     with flask_app_client.login(user, auth_scopes=('encounter:write',)):
-        response = flask_app_client.delete('%s%s' % (PATH, enc_guid))
+        response = flask_app_client.delete('%s%s' % (PATH, enc_guid), headers=headers)
 
     if expected_status_code == 204:
         assert response.status_code == 204
@@ -63,3 +65,4 @@ def delete_encounter(flask_app_client, user, enc_guid, expected_status_code=204)
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message'}
         )
+    return response


### PR DESCRIPTION
## Pull Request Overview

- Modifies `DELETE /api/v1/encounters/GUID` to respect cascade-related headers and remove cascade-deleted Sighting if appropriate
- Returns header value with 204 response when Sighting deleted

---

**Review Notes**
- Mostly just modifications of passthrough (for headers) and triggered Sighting-delete.  (Plus tests.)

**API request / response showing headers**
```
DELETE /api/v1/encounters/GUID HTTP/1.1
x-allow-delete-cascade-sighting: true | false
... other headers ...
```

Upon success, in the event a Sighting was deleted, response will be:

```
HTTP/1.1 204 No Content
x-deletedSighting-guid:  SIGHTING_GUID
... other headers ...
```