### PR TITLE
Mock .delay() in tests if redis unavailable (fix nightly failure)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,7 @@
 name: Nightly
 on:
   schedule:
-    - cron: '0 0 * * *' # Every day at midnight
+    - cron: '0 16 * * *' # Every day at 16:00 UTC (~09:00 PT)
   push:
     paths:
       - '.github/workflows/nightly.yml'

--- a/tests/test_tus.py
+++ b/tests/test_tus.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 import base64
-import os
 import pathlib
 import shutil
 import urllib.parse
 
 import pytest
-import redis
+
+from tests.utils import redis_unavailable
 
 
 @pytest.fixture
@@ -26,15 +26,6 @@ def file_upload_path(flask_app, file_upload_asset_group_id, file_upload_filename
     yield path
     if path.parent.exists():
         shutil.rmtree(path.parent)
-
-
-def redis_unavailable(*args):
-    try:
-        host = os.getenv('REDIS_HOST') or 'localhost'
-        redis.Redis(host=host).get('test')
-        return False
-    except redis.exceptions.ConnectionError:
-        return True
 
 
 def test_tus_options(flask_app_client):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,6 +13,7 @@ from flask import Response
 from flask.testing import FlaskClient
 from werkzeug.utils import cached_property
 from app.extensions.auth import security
+import redis
 
 import uuid
 import os
@@ -270,3 +271,14 @@ def all_count(db):
 
 def row_count(db, cls):
     return db.session.query(cls).count()
+
+
+def redis_unavailable(cached_value=[]):
+    if len(cached_value) == 0:
+        try:
+            host = os.getenv('REDIS_HOST') or 'localhost'
+            redis.Redis(host=host).get('test')
+            cached_value.append(False)
+        except redis.exceptions.ConnectionError:
+            cached_value.append(True)
+    return cached_value[0]


### PR DESCRIPTION
- Mock .delay() in tests if redis unavailable

  We are running tests in macos in github without redis so mock `.delay()`
  to not use redis.

- Change nightly workflow to run at 9am PST or 10am PDT
