### PR TITLE
Adds parser and some tests. More to be done but ready for feedback.

### DIFF
--- a/app/modules/ia_config_reader.py
+++ b/app/modules/ia_config_reader.py
@@ -1,10 +1,8 @@
-from flask import Flask, current_app
+# -*- coding: utf-8 -*-
 
 import logging
 import json
 import os.path as path
-
-import utool as ut
 
 log = logging.getLogger(__name__)
 
@@ -36,8 +34,7 @@ def _link_destination(link_str):
 
 
 class IaConfig:
-
-    def __init__(self, name="zebra"):
+    def __init__(self, name='zebra'):
         self.name = name
         self.fname = short_config_name_to_full_filename(self.name)
         self.config_dict = load_config_to_dict(self.fname)
@@ -47,13 +44,12 @@ class IaConfig:
         return self.get_recursive(keys, self.config_dict)
 
     def get_recursive(self, keys, config_dict_level):
-        print(f'get_recursive called on keys {keys}')
         current_key = keys[0]
         current_value = config_dict_level[current_key]
         is_base_case = len(keys) == 1
 
         # following @-links
-        if (_is_link(current_value)):
+        if _is_link(current_value):
             # resolve the link destination. It will look like an unlinked current_value.
             current_value = self.get(_link_destination(current_value))
         # base case, no link
@@ -99,9 +95,7 @@ class IaConfig:
 
     def _resolve_links_in_value_list(self, value_list):
         resolved_list = [
-            self.get(_link_destination(value))
-            if _is_link(value)
-            else value
+            self.get(_link_destination(value)) if _is_link(value) else value
             for value in value_list
         ]
         return resolved_list
@@ -113,5 +107,3 @@ class IaConfig:
             for link in link_list
         }
         return resolved_dicts
-
-    globals().update(locals())  # just for pasting into ipython

--- a/app/modules/ia_config_reader.py
+++ b/app/modules/ia_config_reader.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, Flask, current_app
+from flask import Flask, current_app
 
 import logging
 import json
@@ -19,7 +19,7 @@ def load_config_to_dict(fname):
 
 
 def short_config_name_to_full_filename(config_name):
-    fname = f'IA.{name}.json'
+    fname = f'IA.{config_name}.json'
     return fname
 
 

--- a/app/modules/ia_config_reader.py
+++ b/app/modules/ia_config_reader.py
@@ -1,0 +1,115 @@
+from flask import Blueprint, Flask, current_app
+
+import logging
+import json
+import os.path as path
+
+import utool as ut
+
+log = logging.getLogger(__name__)
+
+
+def load_config_to_dict(fname):
+    app_home = ''
+    config_path = path.join(app_home, 'ia-configs', fname)
+    assert path.isfile(config_path), f'Could not find config at path {config_path}'
+    with open(config_path, 'r') as file:
+        config_dict = json.load(file)
+    return config_dict
+
+
+def short_config_name_to_full_filename(config_name):
+    fname = f'IA.{name}.json'
+    return fname
+
+
+class IaConfig:
+
+    def __init__(self, name="zebra"):
+        self.name = name
+        self.fname = short_config_name_to_full_filename(self.name)
+        self.config_dict = load_config_to_dict(self.fname)
+
+    def get(self, period_separated_keys):
+        keys = period_separated_keys.split('.')
+        return self.get_recursive(keys, self.config_dict)
+
+    def get_recursive(self, keys, config_dict_level):
+        print(f'get_recursive called on keys {keys}')
+        current_key = keys[0]
+        current_value = config_dict_level[current_key]
+        is_base_case = len(keys) == 1
+
+        # following @-links
+        if (_is_link(current_value)):
+            # resolve the link destination. It will look like an unlinked current_value.
+            current_value = self.get(_link_destination(current_value))
+        # base case, no link
+        if is_base_case:
+            value = current_value
+        # recursive case
+        else:
+            next_keys = keys[1:]
+            value = self.get_recursive(next_keys, current_value)
+        return value
+
+    # detects @-links in values from any level of the ia config
+    def _is_link(config_value):
+        is_link = type(config_value) is str and config_value.startswith('@')
+        return is_link
+
+    # simply takes the '@' off the beginning of a link
+    def _link_destination(link_str):
+        destination = link_str.split('@')[1]
+        return destination
+
+    def get_detectors_with_links(self, genus_species):
+        species_key = genus_species.replace(' ', '.')
+        detectors_key = f'{species_key}._detectors'
+        detectors = self.get(detectors_key)
+        return detectors
+
+    def get_detectors_list(self, genus_species):
+        detectors = self.get_detectors_with_links(genus_species)
+        detectors_list = self._resolve_links_in_value_list(detectors)
+        return detectors_list
+
+    def get_detectors_dict(self, genus_species):
+        detectors = self.get_detectors_with_links(genus_species)
+        detectors_dict = self._resolve_links_to_dict(detectors)
+        return detectors_dict
+
+    def get_identifiers_with_links(self, genus_species, ia_class):
+        species_key = genus_species.replace(' ', '.')
+        identifiers_key = f'{species_key}.{ia_class}._identifiers'
+        identifiers = self.get(identifiers_key)
+        return identifiers
+
+    def get_identifiers_list(self, genus_species, ia_class):
+        identifiers = self.get_identifiers_with_links(genus_species, ia_class)
+        identifiers_list = self._resolve_links_in_value_list(identifiers)
+        return identifiers_list
+
+    def get_identifiers_dict(self, genus_species, ia_class):
+        identifiers = self.get_identifiers_with_links(genus_species, ia_class)
+        identifiers_dict = self._resolve_links_to_dict(identifiers)
+        return identifiers_dict
+
+    def _resolve_links_in_value_list(self, value_list):
+        resolved_list = [
+            self.get(_link_destination(value))
+            if _is_link(value)
+            else value
+            for value in value_list
+        ]
+        return resolved_list
+
+    # takes a list of links, returns a dict mapping those links to their resolved values
+    def _resolve_links_to_dict(self, link_list):
+        resolved_dicts = {
+            _link_destination(link): self.get(_link_destination(link))
+            for link in link_list
+        }
+        return resolved_dicts
+
+    globals().update(locals())  # just for pasting into ipython

--- a/app/modules/ia_config_reader.py
+++ b/app/modules/ia_config_reader.py
@@ -23,6 +23,18 @@ def short_config_name_to_full_filename(config_name):
     return fname
 
 
+# detects @-links in values from any level of the ia config
+def _is_link(config_value):
+    is_link = type(config_value) is str and config_value.startswith('@')
+    return is_link
+
+
+# simply takes the '@' off the beginning of a link
+def _link_destination(link_str):
+    destination = link_str.split('@')[1]
+    return destination
+
+
 class IaConfig:
 
     def __init__(self, name="zebra"):
@@ -52,16 +64,6 @@ class IaConfig:
             next_keys = keys[1:]
             value = self.get_recursive(next_keys, current_value)
         return value
-
-    # detects @-links in values from any level of the ia config
-    def _is_link(config_value):
-        is_link = type(config_value) is str and config_value.startswith('@')
-        return is_link
-
-    # simply takes the '@' off the beginning of a link
-    def _link_destination(link_str):
-        destination = link_str.split('@')[1]
-        return destination
 
     def get_detectors_with_links(self, genus_species):
         species_key = genus_species.replace(' ', '.')

--- a/app/modules/ia_config_reader.py
+++ b/app/modules/ia_config_reader.py
@@ -7,20 +7,6 @@ import os.path as path
 log = logging.getLogger(__name__)
 
 
-def load_config_to_dict(fname):
-    app_home = ''
-    config_path = path.join(app_home, 'ia-configs', fname)
-    assert path.isfile(config_path), f'Could not find config at path {config_path}'
-    with open(config_path, 'r') as file:
-        config_dict = json.load(file)
-    return config_dict
-
-
-def short_config_name_to_full_filename(config_name):
-    fname = f'IA.{config_name}.json'
-    return fname
-
-
 # detects @-links in values from any level of the ia config
 def _is_link(config_value):
     is_link = type(config_value) is str and config_value.startswith('@')
@@ -36,8 +22,11 @@ def _link_destination(link_str):
 class IaConfig:
     def __init__(self, name='zebra'):
         self.name = name
-        self.fname = short_config_name_to_full_filename(self.name)
-        self.config_dict = load_config_to_dict(self.fname)
+        self.fname = f'IA.{name}.json'
+        config_path = path.join('ia-configs', self.fname)
+        assert path.isfile(config_path), f'Could not find config at path {config_path}'
+        with open(config_path, 'r') as file:
+            self.config_dict = json.load(file)
 
     def get(self, period_separated_keys):
         keys = period_separated_keys.split('.')

--- a/ia-configs/IA.zebra.json
+++ b/ia-configs/IA.zebra.json
@@ -1,4 +1,4 @@
-
+{
   "_README": "A value starting with '@' indicates an absolute path from the top of this config file, and parsing that @-link results in the value of that absolute path. The first half of this file (top-level _detectors and _identifiers) defines the various algorithms we use, including the configs we send to SAGE and some metadata about each config. Each algo config is under a name-key, e.g. the african_terrestrial detector.  \n The second half of the file defines the pipeline for each species by referencing the previously-defined algorithms, in the hierachy genus->species->detectors, and genus->species->iaClass->identifiers. The values of these species configurations should be @-links but literals are also supported by the parser.",
   "_detectors": {
     "african_terrestrial": {

--- a/tests/modules/test_ia_config.py
+++ b/tests/modules/test_ia_config.py
@@ -38,6 +38,7 @@ def test_detector_dict_vs_link(flask_app_client):
 
 def test_config_to_filename(flask_app_client):
     from app.modules.ia_config_reader import short_config_name_to_full_filename
+
     config_name = 'zebra'
     filename = short_config_name_to_full_filename(config_name)
     assert filename == 'IA.zebra.json'
@@ -46,6 +47,7 @@ def test_config_to_filename(flask_app_client):
 def test_loading_config_dict(flask_app_client):
     from app.modules.ia_config_reader import short_config_name_to_full_filename
     from app.modules.ia_config_reader import load_config_to_dict
+
     config_name = 'zebra'
     filename = short_config_name_to_full_filename(config_name)
     config_dict = load_config_to_dict(filename)

--- a/tests/modules/test_ia_config.py
+++ b/tests/modules/test_ia_config.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from app.modules.ia_config_reader import IaConfig
 
 # note that these tests rely on the IA.zebra.json file, which if changed, might invalidate tests.
@@ -6,15 +7,14 @@ TEST_CONFIG_NAME = 'zebra'
 
 
 def test_ia_config_creation(flask_app_client):
-
     config_name = TEST_CONFIG_NAME
-    ia_config_reader = IaConfig(config_name)
+    ia_config_reader = IaConfig(TEST_CONFIG_NAME)
     assert ia_config_reader.name is config_name
     assert ia_config_reader.fname.endswith('.json')
     assert type(ia_config_reader.config_dict) is dict
 
 
-def test_at_links(flask_app_client):
+def test_at_links_detector(flask_app_client):
     ia_config_reader = IaConfig(TEST_CONFIG_NAME)
     nolink_quagga_detectors = ia_config_reader.get_detectors_dict('Equus quagga')
     # grevy config links to quagga config
@@ -22,15 +22,40 @@ def test_at_links(flask_app_client):
     assert nolink_quagga_detectors == linked_grevy_detectors
 
 
+def test_at_links_identifier(flask_app_client):
+    ia_config_reader = IaConfig(TEST_CONFIG_NAME)
+    nolink_zebra_ia_class = ia_config_reader.get_identifiers_dict('Equus quagga', 'zebra')
+    # below species/ia_class links to config for above with two levels of linking
+    linked_grevy_ia_class = ia_config_reader.get_identifiers_dict(
+        'Equus grevyi', 'zebra_grevys'
+    )
+    assert nolink_zebra_ia_class == linked_grevy_ia_class
+
+
 def test_detector_dict_vs_link(flask_app_client):
     ia_config_reader = IaConfig(TEST_CONFIG_NAME)
     species = 'Equus quagga'
-    detectors_list = ia_config_reader.get_detectors_dict(species)
-    detectors_dict = ia_config_reader.get_detectors_list(species)
+    detectors_list = ia_config_reader.get_detectors_list(species)
+    detectors_dict = ia_config_reader.get_detectors_dict(species)
     detectors_dict_values = detectors_dict.values()
 
     dict_items_in_list = [val in detectors_list for val in detectors_dict_values]
     list_items_in_dict = [val in detectors_dict_values for val in detectors_list]
+
+    assert all(dict_items_in_list)
+    assert all(list_items_in_dict)
+
+
+def test_identifier_dict_vs_link(flask_app_client):
+    ia_config_reader = IaConfig(TEST_CONFIG_NAME)
+    species = 'Equus quagga'
+    ia_class = 'zebra'
+    identifiers_list = ia_config_reader.get_identifiers_list(species, ia_class)
+    identifiers_dict = ia_config_reader.get_identifiers_dict(species, ia_class)
+    identifiers_dict_values = identifiers_dict.values()
+
+    dict_items_in_list = [val in identifiers_list for val in identifiers_dict_values]
+    list_items_in_dict = [val in identifiers_dict_values for val in identifiers_list]
 
     assert all(dict_items_in_list)
     assert all(list_items_in_dict)
@@ -57,3 +82,42 @@ def test_loading_config_dict(flask_app_client):
     desired_keys = {'_README', '_detectors', '_identifiers', 'Equus'}
     for key in desired_keys:
         assert key in config_dict.keys()
+
+
+def test_get_identifiers_zebras(flask_app_client):
+    ia_config_reader = IaConfig(TEST_CONFIG_NAME)
+    species = 'Equus quagga'
+    ia_class = 'zebra'
+    identifiers = ia_config_reader.get_identifiers_dict(species, ia_class)
+
+    # copy/pasted from the config and pythonified (vs json)
+    # also '_identifiers.' prefix added to algo names
+    desired_identifiers = {
+        '_identifiers.hotspotter_nosv': {
+            'query_config_dict': {'sv_on': False},
+            'description': 'HotSpotter pattern-matcher',
+        }
+    }
+    assert identifiers == desired_identifiers
+
+
+def test_get_detectors_zebras(flask_app_client):
+    ia_config_reader = IaConfig(TEST_CONFIG_NAME)
+    species = 'Equus quagga'
+    detectors = ia_config_reader.get_detectors_dict(species)
+
+    desired_detectors = {
+        '_detectors.african_terrestrial': {
+            'name': 'African terrestrial mammal detector',
+            'description': 'Trained on zebras, giraffes, lions, hyenas, leopards, cheetahs, and wild dogs.',
+            'config_dict': {
+                'start_detect': '/api/engine/detect/cnn/lightnet/',
+                'labeler_algo': 'densenet',
+                'labeler_model_tag': 'zebra_v1',
+                'model_tag': 'ggr2',
+                'nms_thresh': 0.4,
+                'sensitivity': 0.4,
+            },
+        }
+    }
+    assert detectors == desired_detectors

--- a/tests/modules/test_ia_config.py
+++ b/tests/modules/test_ia_config.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from app.modules.ia_config_reader import IaConfig
+
+# note that these tests rely on the IA.zebra.json file, which if changed, might invalidate tests.
+TEST_CONFIG_NAME = 'zebra'
+
+
+def test_ia_config_creation(flask_app_client):
+
+    config_name = TEST_CONFIG_NAME
+    ia_config_reader = IaConfig(config_name)
+    assert ia_config_reader.name is config_name
+    assert ia_config_reader.fname.endswith('.json')
+    assert type(ia_config_reader.config_dict) is dict
+
+
+def test_at_links(flask_app_client):
+    ia_config_reader = IaConfig(TEST_CONFIG_NAME)
+    nolink_quagga_detectors = ia_config_reader.get_detectors_dict('Equus quagga')
+    # grevy config links to quagga config
+    linked_grevy_detectors = ia_config_reader.get_detectors_dict('Equus grevyi')
+    assert nolink_quagga_detectors == linked_grevy_detectors
+
+
+def test_detector_dict_vs_link(flask_app_client):
+    ia_config_reader = IaConfig(TEST_CONFIG_NAME)
+    species = 'Equus quagga'
+    detectors_list = ia_config_reader.get_detectors_dict(species)
+    detectors_dict = ia_config_reader.get_detectors_list(species)
+    detectors_dict_values = detectors_dict.values()
+
+    dict_items_in_list = [val in detectors_list for val in detectors_dict_values]
+    list_items_in_dict = [val in detectors_dict_values for val in detectors_list]
+
+    assert all(dict_items_in_list)
+    assert all(list_items_in_dict)
+
+
+def test_config_to_filename(flask_app_client):
+    from app.modules.ia_config_reader import short_config_name_to_full_filename
+    config_name = 'zebra'
+    filename = short_config_name_to_full_filename(config_name)
+    assert filename == 'IA.zebra.json'
+
+
+def test_loading_config_dict(flask_app_client):
+    from app.modules.ia_config_reader import short_config_name_to_full_filename
+    from app.modules.ia_config_reader import load_config_to_dict
+    config_name = 'zebra'
+    filename = short_config_name_to_full_filename(config_name)
+    config_dict = load_config_to_dict(filename)
+
+    assert type(config_dict) is dict
+
+    desired_keys = {'_README', '_detectors', '_identifiers', 'Equus'}
+    for key in desired_keys:
+        assert key in config_dict.keys()

--- a/tests/modules/test_ia_config.py
+++ b/tests/modules/test_ia_config.py
@@ -61,29 +61,6 @@ def test_identifier_dict_vs_link(flask_app_client):
     assert all(list_items_in_dict)
 
 
-def test_config_to_filename(flask_app_client):
-    from app.modules.ia_config_reader import short_config_name_to_full_filename
-
-    config_name = 'zebra'
-    filename = short_config_name_to_full_filename(config_name)
-    assert filename == 'IA.zebra.json'
-
-
-def test_loading_config_dict(flask_app_client):
-    from app.modules.ia_config_reader import short_config_name_to_full_filename
-    from app.modules.ia_config_reader import load_config_to_dict
-
-    config_name = 'zebra'
-    filename = short_config_name_to_full_filename(config_name)
-    config_dict = load_config_to_dict(filename)
-
-    assert type(config_dict) is dict
-
-    desired_keys = {'_README', '_detectors', '_identifiers', 'Equus'}
-    for key in desired_keys:
-        assert key in config_dict.keys()
-
-
 def test_get_identifiers_zebras(flask_app_client):
     ia_config_reader = IaConfig(TEST_CONFIG_NAME)
     species = 'Equus quagga'


### PR DESCRIPTION
The core functionality of the recursive, link-following parser is done here, along with methods for reading ID and detector configs given a genus, species, and (when applicable) iaClass, and tests for that functionality.

What is left to be done is integrating with the rest of the houston data model, ie sightings/encounters/annotations, as well as some more tests.

All feedback welcome, including but not limited to 1) if these files live where we want them on houston, or if I'm reading the architecture wrong and 2) naming discussions e.g. on the config class name itself, "IaConfig".