### PR TITLE
DEX-281 implement detection callback from Sage

### DIFF
--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -6,6 +6,7 @@ Annotations database models
 
 from app.extensions import db, HoustonModel
 from app.modules.keywords.models import Keyword, KeywordSource
+from app.utils import HoustonException
 
 import uuid
 import logging
@@ -132,3 +133,20 @@ class Annotation(db.Model, HoustonModel):
         assert 'rect' in bounds
         assert isinstance(bounds['rect'], list)
         assert len(bounds['rect']) == 4
+
+    @classmethod
+    def create_bounds(cls, input_data):
+        xtl = input_data.get('xtl')
+        ytl = input_data.get('ytl')
+        width = input_data.get('width')
+        height = input_data.get('height')
+        theta = input_data.get('theta')
+
+        if xtl is None or ytl is None or width is None or height is None or theta is None:
+            raise HoustonException(
+                log_message=f'{input_data} missing fields',
+                message='input Data needs xtl, ytl, width, height and theta',
+            )
+        resp = {'rect': [xtl, ytl, width, height], 'theta': theta}
+
+        return resp

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -140,12 +140,12 @@ class Annotation(db.Model, HoustonModel):
         ytl = input_data.get('ytl')
         width = input_data.get('width')
         height = input_data.get('height')
-        theta = input_data.get('theta')
+        theta = input_data.get('theta', 0)
 
-        if xtl is None or ytl is None or width is None or height is None or theta is None:
+        if xtl is None or ytl is None or width is None or height is None:
             raise HoustonException(
                 log_message=f'{input_data} missing fields',
-                message='input Data needs xtl, ytl, width, height and theta',
+                message='input Data needs xtl, ytl, width and height',
             )
         resp = {'rect': [xtl, ytl, width, height], 'theta': theta}
 

--- a/app/modules/asset_groups/parameters.py
+++ b/app/modules/asset_groups/parameters.py
@@ -69,7 +69,7 @@ class PatchAssetGroupSightingDetailsParameters(PatchJSONParameters):
         if field == 'config':
             # The permissions check of what is allowed to be updated is done in the
             # PatchAssetGroupSightingMetadata, this assumes that the data is valid
-            obj.meta = value
+            obj.config = value
             ret_val = True
         return ret_val
 

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -443,6 +443,32 @@ class AssetGroupSightingCommit(Resource):
         return sighting
 
 
+@api.route('/sighting/<uuid:asset_group_sighting_guid>/sage_detected/<uuid:job_guid>')
+@api.login_required(oauth_scopes=['asset_group_sightings:write'])
+@api.response(
+    code=HTTPStatus.NOT_FOUND,
+    description='Asset_group_sighting not found.',
+)
+@api.resolve_object_by_model(AssetGroupSighting, 'asset_group_sighting')
+class AssetGroupSightingDetected(Resource):
+    """
+    Detection of Asset Group Sighting complete
+    """
+
+    @api.permission_required(
+        permissions.ObjectAccessPermission,
+        kwargs_on_request=lambda kwargs: {
+            'obj': kwargs['asset_group_sighting'],
+            'action': AccessOperation.WRITE_PRIVILEGED,
+        },
+    )
+    def post(self, asset_group_sighting, job_guid):
+        try:
+            asset_group_sighting.detected(job_guid, json.loads(request.data))
+        except HoustonException as ex:
+            abort(ex.status_code, ex.message, errorFields=ex.get_val('error', 'Error'))
+
+
 @api.route('/tus/collect/<uuid:asset_group_guid>')
 @api.login_required(oauth_scopes=['asset_groups:read'])
 @api.response(

--- a/app/modules/encounters/models.py
+++ b/app/modules/encounters/models.py
@@ -81,6 +81,11 @@ class Encounter(db.Model, FeatherModel):
     def is_public(self):
         return self.public
 
+    def add_annotation(self, annotation):
+        if annotation not in self.annotations:
+            with db.session.begin(subtransactions=True):
+                self.annotations.append(annotation)
+
     def delete(self):
         with db.session.begin():
             db.session.delete(self)

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -92,8 +92,9 @@ class Sighting(db.Model, FeatherModel):
         return [ref.asset for ref in self.assets]
 
     def add_asset(self, asset):
-        with db.session.begin(subtransactions=True):
-            self.add_asset_in_context(asset)
+        if asset not in self.get_assets():
+            with db.session.begin(subtransactions=True):
+                self.add_asset_in_context(asset)
 
     def add_assets(self, asset_list):
         with db.session.begin():

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -32,6 +32,7 @@ ANY_ROLE_MAP = {
         'is_admin',
         'is_researcher',
     ],
+    ('AssetGroupSighting', AccessOperation.WRITE_PRIVILEGED, 'Object'): ['is_internal'],
 }
 ANY_OBJECT_METHOD_MAP = {
     ('SiteSetting', AccessOperation.READ, 'Object'): ['is_public'],

--- a/app/modules/users/permissions/types.py
+++ b/app/modules/users/permissions/types.py
@@ -14,4 +14,5 @@ class AccessOperation(enum.Enum):
     # Some information needs to be much more secure
     READ_PRIVILEGED = 2
     WRITE = 3
-    DELETE = 4
+    WRITE_PRIVILEGED = 4
+    DELETE = 5

--- a/app/utils.py
+++ b/app/utils.py
@@ -12,8 +12,7 @@ log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class HoustonException(Exception):
-    def __init__(self, **kwargs):
-        log_message = kwargs.get('log_message', '')
+    def __init__(self, log_message, **kwargs):
         self.message = kwargs.get('message', log_message)
         self.status_code = kwargs.get('status_code', 400)
 

--- a/tests/modules/asset_groups/resources/test_commit_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_commit_asset_group.py
@@ -1,16 +1,23 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 import tests.modules.asset_groups.resources.utils as asset_group_utils
+import tests.modules.sightings.resources.utils as sighting_utils
 import tests.extensions.tus.utils as tus_utils
+from tests import utils as test_utils
+import uuid
 
 
 # Test a bunch of failure scenarios
 def test_commit_asset_group(flask_app_client, researcher_1, regular_user, test_root, db):
     # pylint: disable=invalid-name
     from tests.modules.asset_groups.resources.utils import TestCreationData
+    from app.modules.sightings.models import Sighting
+    from app.modules.assets.models import Asset
+    from app.modules.annotations.models import Annotation
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     asset_group_uuid = None
+    sighting_uuid = None
     try:
         data = TestCreationData(transaction_id)
         data.add_filename(0, test_filename)
@@ -19,6 +26,33 @@ def test_commit_asset_group(flask_app_client, researcher_1, regular_user, test_r
         )
         asset_group_uuid = response.json['guid']
         asset_group_sighting_guid = response.json['sightings'][0]['guid']
+        asset_uuid = response.json['assets'][0]['guid']
+        asset = Asset.find(asset_uuid)
+        assert asset
+
+        # Create a dummy annotation for this Sighting
+        new_annot = Annotation(
+            guid=uuid.uuid4(),
+            asset=asset,
+            ia_class='none',
+            bounds={'rect': [45, 5, 78, 3], 'theta': 4.8},
+        )
+        with db.session.begin(subtransactions=True):
+            db.session.add(new_annot)
+
+        # Patch it in
+        group_sighting = asset_group_utils.read_asset_group_sighting(
+            flask_app_client, researcher_1, asset_group_sighting_guid
+        )
+
+        import copy
+
+        new_annot_data = copy.deepcopy(group_sighting.json['config'])
+        new_annot_data['encounters'][0]['annotations'] = [str(new_annot.guid)]
+        patch_data = [test_utils.patch_replace_op('config', new_annot_data)]
+        asset_group_utils.patch_asset_group_sighting(
+            flask_app_client, researcher_1, asset_group_sighting_guid, patch_data
+        )
 
         # Should not be able to commit as contributor
         asset_group_utils.commit_asset_group_sighting(
@@ -28,12 +62,11 @@ def test_commit_asset_group(flask_app_client, researcher_1, regular_user, test_r
         response = asset_group_utils.commit_asset_group_sighting(
             flask_app_client, researcher_1, asset_group_sighting_guid
         )
-        from app.modules.sightings.models import Sighting
 
-        sighting = Sighting.query.get(response.json['guid'])
+        sighting_uuid = response.json['guid']
+        sighting = Sighting.query.get(sighting_uuid)
         assert len(sighting.get_encounters()) == 1
-        # TODO restore once sightings have assets again
-        # assert len(sighting.get_assets()) == 1
+        assert len(sighting.get_assets()) == 1
         assert sighting.get_owner() == regular_user
 
     finally:
@@ -42,5 +75,6 @@ def test_commit_asset_group(flask_app_client, researcher_1, regular_user, test_r
             asset_group_utils.delete_asset_group(
                 flask_app_client, regular_user, asset_group_uuid
             )
-
+        if sighting_uuid:
+            sighting_utils.delete_sighting(flask_app_client, regular_user, sighting_uuid)
         tus_utils.cleanup_tus_dir(transaction_id)

--- a/tests/modules/asset_groups/resources/test_create_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_create_asset_group.py
@@ -349,24 +349,30 @@ def test_create_asset_group_simulate_detection(
     import uuid
     from tests.modules.asset_groups.resources.utils import TestCreationData
 
+    transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
+    asset_group_uuid = None
     try:
-        data = TestCreationData(None)
-        data.remove_field('transactionId')
-
+        data = TestCreationData(transaction_id)
+        data.add_filename(0, test_filename)
         resp = asset_group_utils.create_asset_group(
             flask_app_client, researcher_1, data.get()
         )
         asset_group_uuid = resp.json['guid']
+        assert 'assets' in resp.json
+        assets = resp.json['assets']
+        assert len(assets) == 1
+        asset_guid = assets[0]['guid']
         assert 'sightings' in resp.json
         asset_group_sighting_uuid = resp.json['sightings'][0]['guid']
-        path = f'sighting/{asset_group_sighting_uuid}/sage_detected/{str(uuid.uuid4())}'
+        job_id = str(uuid.uuid4())
+        path = f'sighting/{asset_group_sighting_uuid}/sage_detected/{job_id}'
         data = {
             'response': {
-                'jobid': 'f3155b31-3170-45de-a6d9-874716cc7e65',
+                'jobid': job_id,
                 'json_result': {
                     'has_assignments': False,
                     'image_uuid_list': [
-                        '57d21f3c-69d8-4f1d-7716-9923dcf4b5d8',
+                        asset_guid,
                     ],
                     'results_list': [
                         [

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -227,6 +227,25 @@ def read_asset_group_sighting(
     return response
 
 
+def simulate_detection_response(
+    flask_app_client, user, path, data, expected_status_code=200
+):
+    with flask_app_client.login(user, auth_scopes=('asset_group_sightings:write',)):
+        response = flask_app_client.post(
+            f'{PATH}{path}',
+            content_type='application/json',
+            data=json.dumps(data),
+        )
+
+    if expected_status_code == 200:
+        test_utils.validate_dict_response(response, 200, {})
+    else:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+    return response
+
+
 # multiple tests clone a asset_group, do something with it and clean it up. Make sure this always happens using a
 # class with a cleanup method to be called if any assertions fail
 class CloneAssetGroup(object):

--- a/tests/modules/sightings/resources/utils.py
+++ b/tests/modules/sightings/resources/utils.py
@@ -103,7 +103,7 @@ def delete_sighting(flask_app_client, user, sight_guid, expected_status_code=204
         response = flask_app_client.delete('%s%s' % (PATH, sight_guid))
 
     if expected_status_code == 204:
-        assert response.status_code == 204
+        assert response.status_code == 204, response.json
     else:
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message'}


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Annotation creation from detection response.
- As yet we cannot test this properly but by removing some checks (now restored) this has been tested to the point where annotations are created and insterted into the DB.


---

**REST API Updates**

A new example POST API is defined with its expected parameters, if needed to be specified for a thorough review

```
[POST] /api/v1/asset_group/sighting/{sighting_guid}/sage_detected/{job_uuid}
{
    See : https://kaiju.dyn.wildme.io:5005/api/engine/job/result/?jobid=f3155b31-3170-45de-a6d9-874716cc7e65&__format__=true
}
```
