### PR TITLE
DEX-303: handle cascade-delete of individual

### DIFF
--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -35,7 +35,7 @@ class EDMManager(RestManager):
     ENDPOINT_PREFIX = 'api'
 
     # this is based on edm date of most recent commit (we must be at or greater than this)
-    MIN_VERSION = '2021-06-08 22:55:00 -0700'
+    MIN_VERSION = '2021-06-16 16:00:00 -0700'
 
     # We use // as a shorthand for prefix
     # fmt: off

--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -197,8 +197,10 @@ class EncounterByID(Resource):
         resp = make_response()
         resp.status_code = 204
         sighting_id = None
+        deleted_individuals = None
         if result is not None:
             sighting_id = result.get('deletedSighting', None)
+            deleted_individuals = result.get('deletedIndividuals', None)
         if sighting_id is not None:
             from app.modules.sightings.models import Sighting
 
@@ -221,5 +223,20 @@ class EncounterByID(Resource):
         else:
             encounter.delete()
         # TODO handle failure of feather deletion (when edm successful!)  out-of-sync == bad
+        log.warning(
+            f'HEY !!!!!!!!!!!!!!!!!!!!!!!!!!!! got deleted_individual={deleted_individuals}'
+        )
+        if deleted_individuals:
+            from app.modules.individuals.models import Individual
+
+            for indiv_guid in deleted_individuals:
+                goner = Individual.query.get(indiv_guid)
+                if goner is None:
+                    log.error(
+                        f'EDM requested cascade-delete of individual id={indiv_guid}; but was not found in houston!'
+                    )
+                else:
+                    log.info(f'EDM requested cascade-delete of {goner}; deleting')
+                    goner.delete()
 
         return resp

--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -223,9 +223,6 @@ class EncounterByID(Resource):
         else:
             encounter.delete()
         # TODO handle failure of feather deletion (when edm successful!)  out-of-sync == bad
-        log.warning(
-            f'HEY !!!!!!!!!!!!!!!!!!!!!!!!!!!! got deleted_individual={deleted_individuals}'
-        )
         if deleted_individuals:
             from app.modules.individuals.models import Individual
 

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -450,6 +450,7 @@ class SightingByID(Resource):
                 log.warning(  # TODO future audit log here
                     f'EDM triggered self-deletion of {sighting} result={result}'
                 )
+                response_data['threatened_sighting_id'] = str(sighting.guid)
                 sighting.delete_cascade()  # this will get rid of our encounter(s) as well so no need to rectify_edm_encounters()
                 sighting = None
             else:

--- a/tests/modules/encounters/resources/test_delete_encounter.py
+++ b/tests/modules/encounters/resources/test_delete_encounter.py
@@ -49,22 +49,24 @@ def test_delete_method(db, flask_app_client, researcher_1, test_root, staff_user
     assert individual_guid is not None
 
     ct = test_utils.all_count(db)
-    assert ct[0] == orig_ct[0] + 1  # one more sighting
-    assert ct[1] == orig_ct[1] + 2  # two more encounters
-    assert ct[4] == orig_ct[4] + 1  # one more individual
+    assert ct['Sighting'] == orig_ct['Sighting'] + 1  # one more sighting
+    assert ct['Encounter'] == orig_ct['Encounter'] + 2  # two more encounters
+    assert ct['Individual'] == orig_ct['Individual'] + 1  # one more individual
 
     # this should be ok, cuz one enc remains (no cascade effects)
     enc_utils.delete_encounter(flask_app_client, staff_user, enc0_id)
     ct = test_utils.all_count(db)
-    assert ct[1] == orig_ct[1] + 1
-    assert ct[4] == orig_ct[4] + 1  # just to confirm indiv is still there
+    assert ct['Encounter'] == orig_ct['Encounter'] + 1
+    assert (
+        ct['Individual'] == orig_ct['Individual'] + 1
+    )  # just to confirm indiv is still there
 
     # but this should then fail, cuz its the last enc and will take the sighting with it
     response = enc_utils.delete_encounter(
         flask_app_client, staff_user, enc1_id, expected_status_code=400
     )
     ct = test_utils.all_count(db)
-    assert ct[1] == orig_ct[1] + 1
+    assert ct['Encounter'] == orig_ct['Encounter'] + 1
     assert response.json['edm_status_code'] == 604
 
     # this will fail cuz it *only* allows sighting-cascade and we need individual also
@@ -86,6 +88,6 @@ def test_delete_method(db, flask_app_client, researcher_1, test_root, staff_user
         response.headers['x-deletedSighting-guid'] == sighting_id
     )  # header tells us sighting cascade-deleted
     ct = test_utils.all_count(db)  # back where we started
-    assert ct[0] == orig_ct[0]
-    assert ct[1] == orig_ct[1]
-    assert ct[4] == orig_ct[4]
+    assert ct['Sighting'] == orig_ct['Sighting']
+    assert ct['Encounter'] == orig_ct['Encounter']
+    assert ct['Individual'] == orig_ct['Individual']

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -104,8 +104,8 @@ def test_create_and_modify_and_delete_sighting(
 
     # test to see if we grew by 1 sighting and 2 encounters
     ct = test_utils.all_count(db)
-    assert ct[0] == orig_ct[0] + 1
-    assert ct[1] == orig_ct[1] + 2
+    assert ct['Sighting'] == orig_ct['Sighting'] + 1
+    assert ct['Encounter'] == orig_ct['Encounter'] + 2
 
     # test some simple modification (should succeed)
     new_loc_id = 'test_2'
@@ -151,7 +151,7 @@ def test_create_and_modify_and_delete_sighting(
     )
     # test to see if we now are +1 encounter
     ct = test_utils.all_count(db)
-    assert ct[1] == orig_ct[1] + 3  # previously was + 2
+    assert ct['Encounter'] == orig_ct['Encounter'] + 3  # previously was + 2
     assert len(sighting.encounters) == 3
     enc2_id = str(sighting.encounters[2].guid)
 
@@ -167,7 +167,7 @@ def test_create_and_modify_and_delete_sighting(
     assert len(sighting.encounters) == 2
     # test to see if we now are back to where we started
     ct = test_utils.all_count(db)
-    assert ct[1] == orig_ct[1] + 2
+    assert ct['Encounter'] == orig_ct['Encounter'] + 2
 
     # patch op=remove the first encounter; should succeed no problem cuz there is one enc remaining
     response = sighting_utils.patch_sighting(
@@ -180,7 +180,7 @@ def test_create_and_modify_and_delete_sighting(
     )
     # test to see if we now are -1 encounter
     ct = test_utils.all_count(db)
-    assert ct[1] == orig_ct[1] + 1  # previously was + 2
+    assert ct['Encounter'] == orig_ct['Encounter'] + 1  # previously was + 2
 
     # similar to above, but this should fail as this is our final encounter, and thus cascade-deletes the occurrence -- and this
     #   requires confirmation
@@ -196,7 +196,7 @@ def test_create_and_modify_and_delete_sighting(
     assert response.json['edm_status_code'] == 602
     # should still have same number encounters as above here
     ct = test_utils.all_count(db)
-    assert ct[1] == orig_ct[1] + 1
+    assert ct['Encounter'] == orig_ct['Encounter'] + 1
 
     # now we try again, but this time with header to allow for cascade deletion of sighting
     response = sighting_utils.patch_sighting(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -254,9 +254,9 @@ def patch_replace_op(path, value):
 
 # for counts of _specific_ classes.  see: all_count() for handy shortcut
 def multi_count(db, cls_list):
-    cts = []
+    cts = {}
     for cls in cls_list:
-        cts.append(row_count(db, cls))
+        cts[cls.__name__] = row_count(db, cls)
     return cts
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -265,8 +265,9 @@ def all_count(db):
     from app.modules.encounters.models import Encounter
     from app.modules.assets.models import Asset
     from app.modules.asset_groups.models import AssetGroup
+    from app.modules.individuals.models import Individual
 
-    return multi_count(db, (Sighting, Encounter, Asset, AssetGroup))
+    return multi_count(db, (Sighting, Encounter, Asset, AssetGroup, Individual))
 
 
 def row_count(db, cls):


### PR DESCRIPTION
## Pull Request Overview

- Modification of Sighting (and/or Encounter) can trigger a cascade-delete for Individual -- this PR addresses this behavior
- Requires special force-header `x-allow-delete-cascade-individual: true` for process to complete
---

**Review Notes**
- Needs latest/corresponding EDM update

