### PR TITLE
DEX-331 Users/me returns unprocessed sightings

### DIFF
--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -494,6 +494,15 @@ class User(db.Model, FeatherModel, UserEDMMixin):
             if not asset_group.is_processed()
         ]
 
+    def unprocessed_sightings(self):
+        from app.modules.sightings.models import SightingStage
+
+        return [
+            sighting.guid
+            for sighting in self.get_sightings()
+            if not sighting.stage == SightingStage.processed
+        ]
+
     def get_id(self):
         return self.guid
 

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -642,6 +642,9 @@ class User(db.Model, FeatherModel, UserEDMMixin):
     def get_sightings(self):
         sightings = []
         for encounter in self.owned_encounters:
-            sightings.append(encounter.get_sighting())
+            sighting = encounter.get_sighting()
+            if sighting:
+                sightings.append(encounter.get_sighting())
+
         sighting_set = set(sightings)
         return list(sighting_set)

--- a/app/modules/users/schemas.py
+++ b/app/modules/users/schemas.py
@@ -83,6 +83,7 @@ class PersonalUserSchema(DetailedUserSchema):
     class Meta(DetailedUserSchema.Meta):
         fields = DetailedUserSchema.Meta.fields + (
             User.unprocessed_asset_groups.__name__,
+            User.unprocessed_sightings.__name__,
             User.default_identification_catalogue.key,
             User.shares_data.key,
             User.receive_newsletter_emails.key,

--- a/tests/modules/asset_groups/resources/test_create_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_create_asset_group.py
@@ -177,10 +177,8 @@ def test_create_asset_group_no_assets(
         )
         asset_group_uuid = resp.json['guid']
 
-        # Make sure that the user has the sighting and it's in the correct state
+        # Make sure that the user has a single unprocessed sighting
         user_resp = user_utils.read_user(flask_app_client, researcher_1, 'me')
-        # if 'unprocessed_sightings' not in user_resp.json:
-        #     breakpoint()
         assert 'unprocessed_sightings' in user_resp.json
         assert len(user_resp.json['unprocessed_sightings']) == 1
         sighting_uuid = user_resp.json['unprocessed_sightings'][0]


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Users/me API now returns a list of unprocessed sightings for the user to process

---


**REST API Updates**

A new example POST API is defined with its expected parameters, if needed to be specified for a thorough review

```
[GET] /api/v1/users/ma
{
    'sightings': ['uuid', 'uuid'],
}
```