### PR TITLE
DEX-291 Give first admin user all permissions

### DIFF
--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -232,7 +232,16 @@ class AdminUserInitialized(Resource):
             admin = User.ensure_user(
                 email,
                 password,
+                is_internal=True,
                 is_admin=True,
+                is_staff=True,
+                is_researcher=True,
+                is_contributor=True,
+                is_user_manager=True,
+                is_exporter=True,
+                is_active=True,
+                in_beta=True,
+                in_alpha=True,
                 update=True,
             )
             log.info(

--- a/tests/modules/users/resources/test_admin_init.py
+++ b/tests/modules/users/resources/test_admin_init.py
@@ -29,7 +29,20 @@ def test_admin_creation(flask_app_client):
     assert response.status_code == 200
     assert response.json['initialized']  # now we True
 
-    # clean up
+    # Check user has all permissions
     user = User.find(email=valid_email)
+    assert user.is_active
+    assert user.is_admin
+    assert user.is_contributor
+    assert user.is_exporter
+    assert user.is_internal
+    assert user.is_privileged
+    assert user.is_researcher
+    assert user.is_staff
+    assert user.is_user_manager
+    assert user.in_alpha
+    assert user.in_beta
+
+    # clean up
     assert user is not None
     user.delete()


### PR DESCRIPTION
When we first start the site, it says "Codex initialized!" and has a
form to create the first admin user.  The admin user has some roles set
to true like `is_admin`.  But `is_researcher`, `is_user_manager` etc set
to false.
