### PR TITLE
DEX-189 Delete gitlab project when asset_group.delete()

### DIFF
--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -347,10 +347,15 @@ class AssetGroupByID(Resource):
         """
         Delete an Asset_group by ID.
         """
+        _, asset_group_id = asset_group
         asset_group = self._get_asset_group_with_428(asset_group)
 
         if asset_group is not None:
             asset_group.delete()
+        else:
+            from .tasks import delete_remote
+
+            delete_remote.delay(str(asset_group_id))
 
         return None
 

--- a/tests/modules/asset_groups/resources/test_permissions.py
+++ b/tests/modules/asset_groups/resources/test_permissions.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-from app.extensions.gitlab import GitlabInitializationError
-
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.modules.assets.resources.utils as asset_utils
 import tests.extensions.tus.utils as tus_utils
@@ -59,8 +57,6 @@ def test_create_patch_asset_group(
     flask_app_client, researcher_1, readonly_user, test_root, db
 ):
     # pylint: disable=invalid-name
-    from app.modules.asset_groups.tasks import delete_remote
-
     asset_group_guid = None
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     try:
@@ -107,10 +103,8 @@ def test_create_patch_asset_group(
         asset_group_utils.delete_asset_group(
             flask_app_client, researcher_1, asset_group_guid
         )
-        try:
-            delete_remote(str(temp_asset_group.guid))
-        except GitlabInitializationError:
-            pass
+        # temp_asset_group should be already deleted on gitlab
+        assert not AssetGroup.is_on_remote(str(temp_asset_group.guid))
 
         # And if the asset_group is already gone, a re attempt at deletion should get the same response
         asset_group_utils.delete_asset_group(
@@ -122,10 +116,6 @@ def test_create_patch_asset_group(
 
     finally:
         tus_utils.cleanup_tus_dir(transaction_id)
-        try:
-            delete_remote(str(temp_asset_group.guid))
-        except GitlabInitializationError:
-            pass
         # Restore original state
         temp_asset_group = AssetGroup.query.get(asset_group_guid)
         if temp_asset_group is not None:

--- a/tests/modules/asset_groups/resources/test_upload_file.py
+++ b/tests/modules/asset_groups/resources/test_upload_file.py
@@ -3,8 +3,6 @@
 import filecmp
 from os.path import join, basename
 
-from app.extensions.gitlab import GitlabInitializationError
-
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.extensions.tus.utils as tus_utils
 
@@ -37,12 +35,6 @@ def test_create_open_submission(flask_app_client, regular_user, test_root, db):
         # TODO this is what the test checked, that there was not commit, what we are now specifically not permitting
         # assert temp_submission.commit is None
     finally:
-        from app.modules.asset_groups.tasks import delete_remote
-
-        try:
-            delete_remote(str(temp_submission.guid))
-        except GitlabInitializationError:
-            pass
         # Restore original state
         if temp_submission is not None:
             temp_submission.delete()
@@ -97,13 +89,6 @@ def test_submission_streamlined(flask_app_client, test_root, regular_user, db):
         assert temp_submission.commit == repo.head.object.hexsha
         assert temp_submission.major_type == test_major_type
     finally:
-        from app.modules.asset_groups.tasks import delete_remote
-
-        try:
-            delete_remote(str(temp_submission.guid))
-        except GitlabInitializationError:
-            pass
-
         # Restore original state
         if temp_submission is not None:
             temp_submission.delete()


### PR DESCRIPTION
We already have `DELETE /api/v1/asset_groups/<id>` to delete the asset
group from the database.  This change adds code to delete it from gitlab
as well.

