### PR TITLE
made the names of a few things more intuitive

### DIFF
--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -85,11 +85,11 @@ class DetailedAssetGroupSchema(CreateAssetGroupSchema):
         exclude=Asset.asset_group_guid.key,
         many=True,
     )
-    sightings = base_fields.Nested(
+    asset_group_sightings = base_fields.Nested(
         'BaseAssetGroupSightingSchema',
         many=True,
     )
 
     class Meta(CreateAssetGroupSchema.Meta):
-        fields = CreateAssetGroupSchema.Meta.fields + ('assets', 'sightings')
+        fields = CreateAssetGroupSchema.Meta.fields + ('assets', 'asset_group_sightings')
         dump_only = CreateAssetGroupSchema.Meta.dump_only

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -58,7 +58,7 @@ class Asset(db.Model, HoustonModel):
     )
     asset_group = db.relationship('AssetGroup', backref=db.backref('assets'))
 
-    sightings = db.relationship('SightingAssets', back_populates='asset')
+    asset_sightings = db.relationship('SightingAssets', back_populates='asset')
 
     def __repr__(self):
         return (
@@ -200,7 +200,7 @@ class Asset(db.Model, HoustonModel):
         with db.session.begin(subtransactions=True):
             for annotation in self.annotations:
                 annotation.delete()
-            for sighting in self.sightings:
+            for sighting in self.asset_sightings:
                 db.session.delete(sighting)
             db.session.delete(self)
 

--- a/tests/modules/asset_groups/resources/test_commit_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_commit_asset_group.py
@@ -25,7 +25,7 @@ def test_commit_asset_group(flask_app_client, researcher_1, regular_user, test_r
             flask_app_client, regular_user, data.get()
         )
         asset_group_uuid = response.json['guid']
-        asset_group_sighting_guid = response.json['sightings'][0]['guid']
+        asset_group_sighting_guid = response.json['asset_group_sightings'][0]['guid']
         asset_uuid = response.json['assets'][0]['guid']
         asset = Asset.find(asset_uuid)
         assert asset

--- a/tests/modules/asset_groups/resources/test_create_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_create_asset_group.py
@@ -362,8 +362,8 @@ def test_create_asset_group_simulate_detection(
         assets = resp.json['assets']
         assert len(assets) == 1
         asset_guid = assets[0]['guid']
-        assert 'sightings' in resp.json
-        asset_group_sighting_uuid = resp.json['sightings'][0]['guid']
+        assert 'asset_group_sightings' in resp.json
+        asset_group_sighting_uuid = resp.json['asset_group_sightings'][0]['guid']
         job_id = str(uuid.uuid4())
         path = f'sighting/{asset_group_sighting_uuid}/sage_detected/{job_id}'
         data = {

--- a/tests/modules/asset_groups/resources/test_patch_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_patch_asset_group.py
@@ -19,7 +19,7 @@ def test_patch_asset_group(flask_app_client, researcher_1, regular_user, test_ro
             flask_app_client, regular_user, data.get()
         )
         asset_group_uuid = response.json['guid']
-        asset_group_sighting_guid = response.json['sightings'][0]['guid']
+        asset_group_sighting_guid = response.json['asset_group_sightings'][0]['guid']
 
         # Regular user can create it but not read it??????
         asset_group_utils.read_asset_group_sighting(

--- a/tests/modules/assets/resources/test_assets.py
+++ b/tests/modules/assets/resources/test_assets.py
@@ -133,7 +133,7 @@ def test_find_raw_asset(
         )
         with db.session.begin():
             db.session.add(new_sighting)
-            clone.asset_group.sightings.append(new_sighting)
+            clone.asset_group.asset_group_sightings.append(new_sighting)
 
         raw_src_response = asset_utils.read_raw_src_asset(
             flask_app_client, internal_user, asset_guid

--- a/tests/modules/job_control/test_models.py
+++ b/tests/modules/job_control/test_models.py
@@ -25,8 +25,9 @@ def test_job_control_add_remove(flask_app_client, researcher_1, test_root, db):
         )
         asset_group_uuid = resp.json['guid']
 
-        assert 'sightings' in resp.json
-        sighting_guid_str = resp.json['sightings'][0]['guid']
+        assert 'asset_group_sightings' in resp.json
+
+        sighting_guid_str = resp.json['asset_group_sightings'][0]['guid']
         sighting_guid = uuid.UUID(sighting_guid_str)
         asset_group_sighting = AssetGroupSighting.query.get(sighting_guid)
 

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -266,7 +266,7 @@ def test_create_anon_and_delete_sighting(db, flask_app_client, staff_user, test_
     sighting = Sighting.query.get(sighting_id)
     assert sighting is not None
     asset_guids.sort()
-    assert sorted([str(a.asset_guid) for a in sighting.assets]) == asset_guids
+    assert sorted([str(a.asset_guid) for a in sighting.sighting_assets]) == asset_guids
 
     # Check assets are returned in GET sighting
     with flask_app_client.login(staff_user, auth_scopes=('sightings:read',)):

--- a/tests/modules/sightings/resources/test_sighting_assets.py
+++ b/tests/modules/sightings/resources/test_sighting_assets.py
@@ -47,7 +47,7 @@ def test_asset_addition(db, flask_app_client, staff_user):
         assets = [new_asset_1, new_asset_2]
         new_sighting.add_assets(assets)
 
-        assert len(new_sighting.assets) == 2
+        assert len(new_sighting.sighting_assets) == 2
 
         add_asset = [
             utils.patch_add_op('assetId', '%s' % new_asset_3.guid),
@@ -57,7 +57,7 @@ def test_asset_addition(db, flask_app_client, staff_user):
             flask_app_client, new_researcher, '%s' % new_sighting.guid, add_asset
         )
 
-        assert len(new_sighting.assets) == 3
+        assert len(new_sighting.sighting_assets) == 3
 
     finally:
         from app.modules.asset_groups.models import AssetGroup
@@ -133,7 +133,7 @@ def test_asset_file_addition(db, flask_app_client, staff_user):
             'new_file.csv',
             '1,2,3,4,5',
         )
-        assert len(new_sighting.assets) == 1
+        assert len(new_sighting.sighting_assets) == 1
         add_file_asset_to_sighting(
             flask_app_client,
             new_researcher,
@@ -142,7 +142,7 @@ def test_asset_file_addition(db, flask_app_client, staff_user):
             'next_file.csv',
             '5,4,3,2,1',
         )
-        assert len(new_sighting.assets) == 2
+        assert len(new_sighting.sighting_assets) == 2
 
     finally:
         from app.modules.asset_groups.models import AssetGroup


### PR DESCRIPTION
## Pull Request Overview

- AssetGroup->sightings renamed to AssetGroup->asset_group_sightings
    - This also means that the AssetGroup creation response schema changes
- Sighting->assets renamed to Sightings->sighting_assets
- Assets->sighting renamed to Assets->asset_sightiings

---

**Review Notes**
- This was to resolve confusion where it appeared that the real Sighting/Asset was being deleted rather than the linkage
