### PR TITLE
Add celery_worker and celery_beat services to docker-compose

### DIFF
--- a/deploy/codex/docker-compose.yml
+++ b/deploy/codex/docker-compose.yml
@@ -101,7 +101,7 @@ services:
   houston:
     # https://github.com/WildMeOrg/houston
     # image: wildme/houston:latest
-    build:
+    build: &houston-build
       context: ../../
     command: [ "wait-for", "db:5432", "--", "wait-for", "edm:8080", "--", "invoke", "app.run", "--host", "0.0.0.0" ]
     networks:
@@ -110,7 +110,7 @@ services:
     ports:
       # FIXME: exposed for developer verification
       - "83:5000"
-    environment:
+    environment: &houston-environment
       FLASK_CONFIG: local
       FLASK_CONFIG_IMPORT: "docker_local_config.LocalConfig"
       SQLALCHEMY_DATABASE_URI: "${SQLALCHEMY_DATABASE_URI}"
@@ -129,7 +129,7 @@ services:
       GIT_PUBLIC_NAME: "${GIT_PUBLIC_NAME}"
       GIT_EMAIL: "${GIT_EMAIL}"
       GITLAB_NAMESPACE: "${GITLAB_NAMESPACE}"
-    volumes:
+    volumes: &houston-volumes
       - houston-var:/data
       - ./houston/docker-entrypoint-init.d:/docker-entrypoint-init.d
       - ./houston/docker-entrypoint-always-init.d:/docker-entrypoint-always-init.d
@@ -137,6 +137,22 @@ services:
       - ../../:/code
       # FIXME: Can we define a better mountpoint for this file? Maybe /config.py?
       - ./houston/local_config.py:/code/docker_local_config.py
+
+  celery_beat:
+    build: *houston-build
+    command: [ "wait-for", "db:5432", "--", "wait-for", "edm:8080", "--", "celery", "-A", "app.extensions.celery.celery", "beat", "-s", "/data/var/celerybeat-schedule", "-l", "DEBUG"]
+    networks:
+      - intranet
+    environment: *houston-environment
+    volumes: *houston-volumes
+
+  celery_worker:
+    build: *houston-build
+    command: [ "wait-for", "db:5432", "--", "wait-for", "edm:8080", "--", "celery", "-A", "app.extensions.celery.celery", "worker", "-l", "DEBUG"]
+    networks:
+      - intranet
+    environment: *houston-environment
+    volumes: *houston-volumes
 
   dev-frontend:
     # this component is intended to only be used in development


### PR DESCRIPTION
- Change gitlab set up script to work with existing user

  In case "houston" already exists, the docker entrypoint script can still
  create a personal access token.
  
  Also skip creating the group "test" if the group already exists.

- Add celery_worker and celery_beat services to docker-compose

  Both celery_worker and celery_beat are clones of the houston service.
  The only difference is they don't run the web application, instead
  celery_beat runs celery beat which is necessary for triggering periodic
  tasks and celery_worker is necessary for running background and periodic
  tasks.

---

@hwindsor `docker-compose up -d celery_worker celery_beat` should run separate services so there's no need to do `docker-compose exec houston celery ...` etc anymore.