### PR TITLE
removed asset_group ownership patching. Tests massively simplified

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -208,6 +208,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
                     submitter_guid=self.asset_group.submitter_guid,
                     public=self.asset_group.anonymous,
                 )
+                log.info(f'Created encounter {new_encounter.guid} for owner {owner_guid}')
                 annotations = req_data.get('annotations', [])
                 for annot_uuid in annotations:
                     annot = Annotation.query.get(annot_uuid)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -333,7 +333,7 @@ def test_asset_group_file_data(test_root):
 
 
 @pytest.fixture
-def test_asset_group_uuid(flask_app, db, admin_user, test_asset_group_file_data):
+def test_asset_group_uuid(flask_app, db, researcher_1, test_asset_group_file_data):
     from app.extensions.gitlab import GitlabInitializationError
     from app.modules.asset_groups.models import AssetGroup, AssetGroupMajorType
 
@@ -342,14 +342,14 @@ def test_asset_group_uuid(flask_app, db, admin_user, test_asset_group_file_data)
     if asset_group is None:
         asset_group = AssetGroup(
             guid=guid,
-            owner_guid=admin_user.guid,
+            owner_guid=researcher_1.guid,
             major_type=AssetGroupMajorType.test,
             description='This is a required PyTest submission (do not delete)',
         )
         with db.session.begin():
             db.session.add(asset_group)
     else:
-        asset_group.owner_guid = admin_user.guid
+        asset_group.owner_guid = researcher_1.guid
         asset_group.major_type = AssetGroupMajorType.test
         asset_group.description = 'This is a required PyTest submission (do not delete)'
         with db.session.begin():
@@ -363,7 +363,7 @@ def test_asset_group_uuid(flask_app, db, admin_user, test_asset_group_file_data)
 
 
 @pytest.fixture
-def test_empty_asset_group_uuid(flask_app, db, admin_user):
+def test_empty_asset_group_uuid(flask_app, db, researcher_1):
     from app.modules.asset_groups.models import AssetGroup, AssetGroupMajorType
 
     guid = '00000000-0000-0000-0000-000000000001'
@@ -371,7 +371,7 @@ def test_empty_asset_group_uuid(flask_app, db, admin_user):
     if asset_group is None:
         asset_group = AssetGroup(
             guid=guid,
-            owner_guid=admin_user.guid,
+            owner_guid=researcher_1.guid,
             major_type=AssetGroupMajorType.test,
             description='',
         )

--- a/tests/modules/annotations/resources/test_annotation_keywords.py
+++ b/tests/modules/annotations/resources/test_annotation_keywords.py
@@ -8,7 +8,7 @@ from tests.modules.keywords.resources import utils as keyword_utils
 
 
 def test_keywords_on_annotation(
-    flask_app_client, admin_user, researcher_1, test_clone_asset_group_data, db
+    flask_app_client, researcher_1, test_clone_asset_group_data, db
 ):
     # pylint: disable=invalid-name
     from app.modules.annotations.models import Annotation
@@ -23,7 +23,6 @@ def test_keywords_on_annotation(
 
     sub_utils.clone_asset_group(
         flask_app_client,
-        admin_user,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
     )

--- a/tests/modules/annotations/resources/test_create_annotation.py
+++ b/tests/modules/annotations/resources/test_create_annotation.py
@@ -13,15 +13,12 @@ def test_get_annotation_not_found(flask_app_client):
     assert response.status_code == 404
 
 
-def test_create_failures(
-    flask_app_client, admin_user, researcher_1, test_clone_asset_group_data, db
-):
+def test_create_failures(flask_app_client, researcher_1, test_clone_asset_group_data, db):
     # pylint: disable=invalid-name
     # from app.modules.annotations.models import Annotation
 
     sub_utils.clone_asset_group(
         flask_app_client,
-        admin_user,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
     )
@@ -48,14 +45,13 @@ def test_create_failures(
 
 
 def test_create_and_delete_annotation(
-    flask_app_client, admin_user, researcher_1, test_clone_asset_group_data
+    flask_app_client, researcher_1, test_clone_asset_group_data
 ):
     # pylint: disable=invalid-name
     from app.modules.annotations.models import Annotation
 
     sub_utils.clone_asset_group(
         flask_app_client,
-        admin_user,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
     )
@@ -102,7 +98,6 @@ def test_annotation_permission(
     previous_annots = annot_utils.read_all_annotations(flask_app_client, staff_user)
     sub_utils.clone_asset_group(
         flask_app_client,
-        admin_user,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
     )

--- a/tests/modules/annotations/resources/test_patch_annotation.py
+++ b/tests/modules/annotations/resources/test_patch_annotation.py
@@ -17,7 +17,6 @@ def test_patch_annotation(
 
     sub_utils.clone_asset_group(
         flask_app_client,
-        admin_user,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
     )

--- a/tests/modules/asset_groups/resources/test_ensure_submission.py
+++ b/tests/modules/asset_groups/resources/test_ensure_submission.py
@@ -5,30 +5,25 @@ import tests.modules.asset_groups.resources.utils as utils
 
 
 def test_ensure_asset_group_by_uuid(
-    flask_app_client, admin_user, researcher_1, db, test_asset_group_uuid
+    flask_app_client, researcher_1, db, test_asset_group_uuid
 ):
-    utils.clone_asset_group(
-        flask_app_client, admin_user, researcher_1, test_asset_group_uuid
-    )
+    utils.clone_asset_group(flask_app_client, researcher_1, test_asset_group_uuid)
 
 
 def test_ensure_empty_asset_group_by_uuid(
-    flask_app_client, admin_user, researcher_1, db, test_empty_asset_group_uuid
+    flask_app_client, researcher_1, db, test_empty_asset_group_uuid
 ):
-    utils.clone_asset_group(
-        flask_app_client, admin_user, researcher_1, test_empty_asset_group_uuid
-    )
+    utils.clone_asset_group(flask_app_client, researcher_1, test_empty_asset_group_uuid)
 
 
 def test_ensure_clone_asset_group_by_uuid(
-    flask_app_client, admin_user, researcher_1, db, test_clone_asset_group_data
+    flask_app_client, researcher_1, db, test_clone_asset_group_data
 ):
     from app.modules.asset_groups.models import AssetGroupMajorType
     from app.modules.assets.models import Asset
 
     clone = utils.clone_asset_group(
         flask_app_client,
-        admin_user,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
     )

--- a/tests/modules/asset_groups/resources/test_permissions.py
+++ b/tests/modules/asset_groups/resources/test_permissions.py
@@ -9,7 +9,6 @@ import uuid
 
 def test_user_read_permissions(
     flask_app_client,
-    admin_user,
     researcher_1,
     readonly_user,
     db,
@@ -20,7 +19,6 @@ def test_user_read_permissions(
 
     asset_group_utils.clone_asset_group(
         flask_app_client,
-        admin_user,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
     )

--- a/tests/modules/assets/resources/test_assets.py
+++ b/tests/modules/assets/resources/test_assets.py
@@ -27,14 +27,12 @@ def test_get_asset_not_found(flask_app_client, researcher_1):
 
 def test_find_asset(
     flask_app_client,
-    admin_user,
     researcher_1,
     test_clone_asset_group_data,
 ):
     # Clone the known asset_group so that the asset data is in the database
     asset_group_utils.clone_asset_group(
         flask_app_client,
-        admin_user,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
     )
@@ -61,7 +59,6 @@ def test_find_asset(
 
 def test_find_deleted_asset(
     flask_app_client,
-    admin_user,
     researcher_1,
     db,
     test_clone_asset_group_data,
@@ -69,7 +66,6 @@ def test_find_deleted_asset(
     # Clone the known asset_group so that the asset data is in the database
     clone = asset_group_utils.clone_asset_group(
         flask_app_client,
-        admin_user,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
     )
@@ -108,7 +104,6 @@ def test_find_raw_asset(
     # Clone the known asset_group so that the asset data is in the database
     clone = asset_group_utils.clone_asset_group(
         flask_app_client,
-        admin_user,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
     )
@@ -150,7 +145,6 @@ def test_find_raw_asset(
 
 def test_user_asset_permissions(
     flask_app_client,
-    admin_user,
     researcher_1,
     readonly_user,
     db,
@@ -159,7 +153,6 @@ def test_user_asset_permissions(
     # Clone the known asset_group so that the asset data is in the database
     asset_group_utils.clone_asset_group(
         flask_app_client,
-        admin_user,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
     )
@@ -178,7 +171,6 @@ def test_read_all_assets(
     # Clone the known asset_group so that the asset data is in the database
     asset_group_utils.clone_asset_group(
         flask_app_client,
-        admin_user,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
     )

--- a/tests/tasks/app/test_asset_groups.py
+++ b/tests/tasks/app/test_asset_groups.py
@@ -56,7 +56,9 @@ def test_create_asset_group_from_path(flask_app, test_root, admin_user, request)
     assert asset_group.description == 'AssetGroup creation test'
 
 
-def test_clone_asset_group_from_gitlab(flask_app, db, test_asset_group_uuid, admin_user):
+def test_clone_asset_group_from_gitlab(
+    flask_app, db, test_asset_group_uuid, researcher_1
+):
     from app.extensions.gitlab import GitlabInitializationError
 
     try:
@@ -84,7 +86,7 @@ def test_clone_asset_group_from_gitlab(flask_app, db, test_asset_group_uuid, adm
         with pytest.raises(ValueError) as e:
             random_uuid = uuid.uuid4()
             clone_asset_group_from_gitlab(
-                MockContext(), str(random_uuid), admin_user.email
+                MockContext(), str(random_uuid), researcher_1.email
             )
             assert (
                 str(e)
@@ -94,7 +96,7 @@ def test_clone_asset_group_from_gitlab(flask_app, db, test_asset_group_uuid, adm
         with mock.patch('sys.stdout', new=io.StringIO()) as stdout:
             assert not repo_path.exists()
             clone_asset_group_from_gitlab(
-                MockContext(), str(test_asset_group_uuid), admin_user.email
+                MockContext(), str(test_asset_group_uuid), researcher_1.email
             )
             assert 'Cloned asset_group from GitLab' in stdout.getvalue()
             assert repo_path.exists()
@@ -102,7 +104,7 @@ def test_clone_asset_group_from_gitlab(flask_app, db, test_asset_group_uuid, adm
         with mock.patch('sys.stdout', new=io.StringIO()) as stdout:
             # do it again
             clone_asset_group_from_gitlab(
-                MockContext(), str(test_asset_group_uuid), admin_user.email
+                MockContext(), str(test_asset_group_uuid), researcher_1.email
             )
             assert 'AssetGroup is already cloned locally' in stdout.getvalue()
             assert repo_path.exists()


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Removed Asset group Ownership patching
- Asset group can now be cloned from Gitlab by Researcher
- Tests significantly simplified as a consequence

---
This will need tweaking when PR 209 goes in but PR209 should go in first, moved to draft until it does.