### PR TITLE
Add documentation for running docker-compose without gitlab

### DIFF
--- a/deploy/codex/README.md
+++ b/deploy/codex/README.md
@@ -31,6 +31,19 @@ Note, the composition can take several minutes to successfully come up.
 There are a number of operations setting up the services and automating the connections between them.
 All re-ups should be relatively fast.
 
+#### Running the applications without gitlab
+
+The gitlab container uses a lot of resources and can be impractical to
+run on a development machine.  It is possible to run the applications
+without gitlab by doing:
+
+    docker-compose -f docker-compose.yml -f docker-compose.no-gitlab.yml up -d
+
+This tells `docker-compose` to use both `docker-compose.yml` and
+`docker-compose.no-gitlab.yml`.  This is really only necessary for
+`docker-compose up` and `docker-compose run`.  For `docker-compose ps`
+or `docker-compose exec`, there's no need to include
+`-f docker-compose.yml -f docker-compose.no-gitlab.yml`.
 
 #### Cleaning up
 

--- a/deploy/codex/docker-compose.no-gitlab.yml
+++ b/deploy/codex/docker-compose.no-gitlab.yml
@@ -1,0 +1,16 @@
+version: "3"
+
+services:
+  gitlab:
+    deploy:
+      replicas: 0
+
+  houston:
+    environment: &houston-environment
+      GITLAB_REMOTE_URI: "-"
+
+  celery_beat:
+    environment: *houston-environment
+
+  celery_worker:
+    environment: *houston-environment


### PR DESCRIPTION
Add `docker-compose.no-gitlab.yml` that can be added to
`docker-compose.yml` making it possible to skip gitlab in houston.

Add documentation in deploy/codex/README.md for how to use
`docker-compose.no-gitlab.yml`.

