### PR TITLE
DEX352 added task to print out the status of all jobs for an asset and the l…

### DIFF
--- a/tasks/app/job_control.py
+++ b/tasks/app/job_control.py
@@ -41,7 +41,7 @@ def print_last_asset_job(context, asset_guid, verbose=False):
     last_job_id = None
     last_job = {}
     for job_id in jobs.keys():
-        if not last_job_id or jobs[job_id] > last_job['start']:
+        if not last_job_id or jobs[job_id]['start'] > last_job['start']:
             last_job_id = job_id
             last_job = jobs[job_id]
 

--- a/tasks/app/job_control.py
+++ b/tasks/app/job_control.py
@@ -12,3 +12,56 @@ def print_jobs(context):
     from app.modules.job_control.models import JobControl
 
     JobControl.print_jobs()
+
+
+def get_jobs_for_asset(asset_guid, verbose):
+    from app.modules.assets.models import Asset
+    from app.modules.asset_groups.models import AssetGroup, AssetGroupSighting  # noqa
+
+    asset = Asset.query.get(asset_guid)
+    if not asset:
+        print(f'Asset {asset_guid} not found')
+        return []
+
+    asset_group_sightings = asset.asset_group.get_asset_group_sightings_for_asset(asset)
+
+    jobs = {}
+    for ags in asset_group_sightings:
+        jobs.update(ags.get_job_details(verbose))
+
+    return jobs
+
+
+@app_context_task()
+def print_last_asset_job(context, asset_guid, verbose=False):
+    """Print out the job status for the last detection job for the asset"""
+
+    jobs = get_jobs_for_asset(asset_guid, verbose)
+
+    last_job_id = None
+    last_job = {}
+    for job_id in jobs.keys():
+        if not last_job_id or jobs[job_id] > last_job['start']:
+            last_job_id = job_id
+            last_job = jobs[job_id]
+
+    print(
+        f"Last Job {last_job_id} Active:{last_job['active']}"
+        f"Started (UTC):{last_job['start']} model:{last_job['model']}"
+    )
+    if verbose:
+        print(f"\n\tRequest:{last_job['request']}\n\tResponse:{last_job['response']}")
+
+
+@app_context_task()
+def print_all_asset_jobs(context, asset_guid, verbose=False):
+    """Print out the job status for all the detection jobs for the asset"""
+    jobs = get_jobs_for_asset(asset_guid, verbose)
+
+    for job_id in jobs.keys():
+        job = jobs[job_id]
+        print(
+            f"Job {job_id} Active:{job['active']} Started (UTC):{job['start']} model:{job['model']}"
+        )
+        if verbose:
+            print(f"\n\tRequest:{job['request']}\n\tResponse:{job['response']}")

--- a/tests/tasks/app/test_job_control.py
+++ b/tests/tasks/app/test_job_control.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+import io
+from unittest import mock
+import tests.extensions.tus.utils as tus_utils
+import tests.modules.asset_groups.resources.utils as asset_group_utils
+
+from invoke import MockContext
+
+
+# Check that the task methods for the asset control job tasks print the correct output
+def test_asset_group_detection_jobs(
+    flask_app, flask_app_client, researcher_1, staff_user, test_root, db
+):
+    # pylint: disable=invalid-name
+    from tests.modules.asset_groups.resources.utils import TestCreationData
+    from tests import utils as test_utils
+
+    orig_objs = test_utils.all_count(db)
+
+    transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
+    asset_group_uuid = None
+    try:
+        data = TestCreationData(transaction_id)
+        data.add_filename(0, test_filename)
+        data.set_field('speciesDetectionModel', ['someSortOfModel'])
+
+        # Simulate a valid response from Sage but don't actually send the request to Sage
+        with mock.patch.object(
+            flask_app.acm,
+            'request_passthrough_result',
+            return_value={'success': True},
+        ):
+            resp = asset_group_utils.create_asset_group(
+                flask_app_client, None, data.get()
+            )
+            asset_group_uuid = resp.json['guid']
+
+        # Now see that the task gets what we expect
+        with mock.patch('app.create_app'):
+            with mock.patch('sys.stdout', new=io.StringIO()) as stdout:
+                from tasks.app import job_control
+
+                job_control.print_all_asset_jobs(
+                    MockContext(), resp.json['assets'][0]['guid']
+                )
+                job_output = stdout.getvalue()
+                assert 'Job ' in job_output
+                assert 'Active:True Started (UTC)' in job_output
+                assert 'model:someSortOfModel' in job_output
+
+                # Simulate a valid response from Sage but don't actually send the request to Sage
+                with mock.patch.object(
+                    flask_app.acm,
+                    'request_passthrough_result',
+                    return_value={'success': True, 'content': 'something'},
+                ):
+                    job_control.print_last_asset_job(
+                        MockContext(), resp.json['assets'][0]['guid'], verbose=True
+                    )
+                    job_output = stdout.getvalue()
+                    assert 'Job ' in job_output
+                    assert 'Active:True Started (UTC)' in job_output
+                    assert 'model:someSortOfModel' in job_output
+                    assert "Request:{'endpoint': '/api/engine/detect" in job_output
+                    assert (
+                        "Response:{'success': True, 'content': 'something'}" in job_output
+                    )
+    finally:
+        if asset_group_uuid:
+            asset_group_utils.delete_asset_group(
+                flask_app_client, staff_user, asset_group_uuid
+            )
+        tus_utils.cleanup_tus_dir(transaction_id)
+        assert orig_objs == test_utils.all_count(db)


### PR DESCRIPTION
…ast job only with verbose options

<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Allows lookup of jobs associated with the asset
- Privides task output to print all jobs or the last job associated with an asset

---


**Invoke CLI Updates **

```
$ invoke app.job-control.print_all_asset_jobs cb502276-0ac6-4f48-a104-de4d578cc441 
Job 367ba91e-f91d-4e11-bf56-199cc46e63e7 Active:TrueStarted (UTC):2021-07-02 15:18:58 model:someSortOfModel

$ invoke app.job-control.print_last_asset_jobs cb502276-0ac6-4f48-a104-de4d578cc441 verbose=True
Last Job 367ba91e-f91d-4e11-bf56-199cc46e63e7 Active:TrueStarted (UTC):2021-07-02 15:18:58 model:someSortOfModel

	Request:{'endpoint': '/api/engine/detect/cnn/lightnet/', 'function': 'start_detect_image_lightnet', 'jobid': '367ba91e-f91d-4e11-bf56-199cc46e63e7', 'callback_url': 'http://houston:5000/api/v1/asset_group/sighting/229f1adf-06ae-47d4-9150-6300a78c92c3/sage_detected/367ba91e-f91d-4e11-bf56-199cc46e63e7', 'image_uuid_list': [UUID('cb502276-0ac6-4f48-a104-de4d578cc441')], 'input': {'callback_url': 'http://houston:5000/api/v1/asset_group/sighting/229f1adf-06ae-47d4-9150-6300a78c92c3/sage_detected/367ba91e-f91d-4e11-bf56-199cc46e63e7', 'image_url': 'http://houston:5000/api/v1/asset/src-raw/', 'labeler_model_tag': 'iot_v0', 'model_tag': 'iot_v0', 'labeler_algo': 'densenet', 'sensitivity': 0.36, 'nms_aware': 'ispart', 'nms_thresh': 0.5, 'callback_detailed': True}}
	Response:{'success': True, 'content': 'something'}
```
Sage response mocked as Sage does not yet support many things we need