### PR TITLE
DEX-347:  if a keyword ends up un-referenced (by annotation), it gets deleted

### DIFF
--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -114,8 +114,10 @@ class Annotation(db.Model, HoustonModel):
     def delete(self):
         with db.session.begin(subtransactions=True):
             while self.keyword_refs:
+                ref = self.keyword_refs.pop()
                 # this is actually removing the AnnotationKeywords refs (not actual Keywords)
-                db.session.delete(self.keyword_refs.pop())
+                db.session.delete(ref)
+                ref.keyword.delete_if_unreferenced()  # but this *may* remove keyword itself
             db.session.delete(self)
 
     def check_job_status(self, job_id):

--- a/app/modules/annotations/parameters.py
+++ b/app/modules/annotations/parameters.py
@@ -13,6 +13,10 @@ from .models import Annotation
 from app.extensions.api import abort
 from flask_restx_patched._http import HTTPStatus
 
+import logging
+
+log = logging.getLogger(__name__)  # pylint: disable=invalid-name
+
 
 class CreateAnnotationParameters(Parameters, schemas.BaseAnnotationSchema):
     asset_guid = base_fields.UUID(description='The GUID of the asset', required=True)
@@ -115,5 +119,10 @@ class PatchAnnotationDetailsParameters(PatchJSONParameters):
             if keyword is None:
                 return False
             obj.remove_keyword(keyword)
+            if keyword.number_annotations() < 1:
+                log.warn(
+                    f'{keyword} is no longer referenced by any Annotation, deleting.'
+                )
+                keyword.delete()
             return True
         return False

--- a/app/modules/annotations/parameters.py
+++ b/app/modules/annotations/parameters.py
@@ -13,10 +13,6 @@ from .models import Annotation
 from app.extensions.api import abort
 from flask_restx_patched._http import HTTPStatus
 
-import logging
-
-log = logging.getLogger(__name__)  # pylint: disable=invalid-name
-
 
 class CreateAnnotationParameters(Parameters, schemas.BaseAnnotationSchema):
     asset_guid = base_fields.UUID(description='The GUID of the asset', required=True)
@@ -119,10 +115,6 @@ class PatchAnnotationDetailsParameters(PatchJSONParameters):
             if keyword is None:
                 return False
             obj.remove_keyword(keyword)
-            if keyword.number_annotations() < 1:
-                log.warn(
-                    f'{keyword} is no longer referenced by any Annotation, deleting.'
-                )
-                keyword.delete()
+            keyword.delete_if_unreferenced()
             return True
         return False

--- a/app/modules/keywords/models.py
+++ b/app/modules/keywords/models.py
@@ -46,3 +46,9 @@ class Keyword(db.Model, HoustonModel):
     def delete(self):
         with db.session.begin(subtransactions=True):
             db.session.delete(self)
+
+    def number_annotations(self):
+        from app.modules.annotations.models import AnnotationKeywords
+
+        refs = AnnotationKeywords.query.filter_by(keyword_guid=self.guid).all()
+        return len(refs)

--- a/app/modules/keywords/models.py
+++ b/app/modules/keywords/models.py
@@ -8,6 +8,9 @@ from app.extensions import db, HoustonModel
 
 import uuid
 import enum
+import logging
+
+log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class KeywordSource(str, enum.Enum):
@@ -46,6 +49,11 @@ class Keyword(db.Model, HoustonModel):
     def delete(self):
         with db.session.begin(subtransactions=True):
             db.session.delete(self)
+
+    def delete_if_unreferenced(self):
+        if self.number_annotations() < 1:
+            log.warn(f'{self} is no longer referenced by any Annotation, deleting.')
+            self.delete()
 
     def number_annotations(self):
         from app.modules.annotations.models import AnnotationKeywords

--- a/app/modules/keywords/resources.py
+++ b/app/modules/keywords/resources.py
@@ -40,7 +40,7 @@ class Keywords(Resource):
         Returns a list of Keyword starting from ``offset`` limited by ``limit``
         parameter.
         """
-        return Keyword.query.offset(args['offset']).limit(args['limit'])
+        return Keyword.query.all()
 
     @api.permission_required(
         permissions.ModuleAccessPermission,


### PR DESCRIPTION
## Pull Request Overview

- Functionality request by @brmscheiner 
- Triggered by `DELETE annotation` as well as `PATCH annotation, op=remove, path=/keywords`
- _Bonus_ tweak (also requested by ben) [allows](https://github.com/WildMeOrg/houston/pull/225/commits/e16cc7d74be6615a65e4eaba9f81ee5682c51b70) `GET /api/v1/keywords` to get _entire_ list (disable pagination)

Possibly later if we want to "protect" certain keywords from deletion (e.g. if they are non-user-sourced) we can modify behavior of `keyword.delete_if_unreferenced()`.
