### PR TITLE
Add check to all tests for clean up of AssetGroups, Sightings etc

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,15 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize('gitlab_remote_login_pat', value, scope='session')
 
 
+@pytest.fixture(autouse=True)
+def check_cleanup_objects(db):
+    count = utils.all_count(db)
+    yield
+    assert count == utils.all_count(
+        db
+    ), 'Some objects created in the test need to be cleaned up'
+
+
 @pytest.fixture(scope='session')
 def flask_app(gitlab_remote_login_pat):
     with tempfile.TemporaryDirectory() as td:

--- a/tests/modules/annotations/resources/test_annotation_keywords.py
+++ b/tests/modules/annotations/resources/test_annotation_keywords.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-
 from tests import utils
 from tests.modules.annotations.resources import utils as annot_utils
 from tests.modules.asset_groups.resources import utils as sub_utils
@@ -21,7 +20,7 @@ def test_keywords_on_annotation(
         db.session.add(keyword)
     assert keyword is not None
 
-    sub_utils.clone_asset_group(
+    clone = sub_utils.clone_asset_group(
         flask_app_client,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
@@ -115,3 +114,5 @@ def test_keywords_on_annotation(
     # the delete_annotation above should take the un-reference keyword with it [DEX-347], thus:
     res = keyword_utils.read_all_keywords(flask_app_client, researcher_1)
     assert len(res.json) == kwct - 1
+
+    clone.cleanup()

--- a/tests/modules/annotations/resources/test_patch_annotation.py
+++ b/tests/modules/annotations/resources/test_patch_annotation.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-
 import uuid
+
 from tests import utils
 from tests.modules.annotations.resources import utils as annot_utils
 from tests.modules.asset_groups.resources import utils as sub_utils
@@ -15,7 +15,7 @@ def test_patch_annotation(
     from app.modules.annotations.models import Annotation
     from app.modules.encounters.models import Encounter
 
-    sub_utils.clone_asset_group(
+    clone = sub_utils.clone_asset_group(
         flask_app_client,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
@@ -114,3 +114,9 @@ def test_patch_annotation(
 
     read_annotation = Annotation.query.get(annotation_guid)
     assert read_annotation is None
+
+    clone.cleanup()
+    first_encounter.sighting.delete()
+    first_encounter.delete()
+    second_encounter.sighting.delete()
+    second_encounter.delete()

--- a/tests/modules/asset_groups/resources/test_commit_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_commit_asset_group.py
@@ -100,7 +100,6 @@ def test_commit_asset_group_ia(
 ):
     # pylint: disable=invalid-name
     from tests.modules.asset_groups.resources.utils import TestCreationData
-    from app.modules.sightings.models import Sighting  # noqa
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     asset_group_uuid = None
@@ -135,15 +134,10 @@ def test_commit_asset_group_ia(
             flask_app_client, researcher_1, asset_group_sighting_guid, ia_config, 200
         )
 
-        asset_group_utils.commit_asset_group_sighting(
+        response = asset_group_utils.commit_asset_group_sighting(
             flask_app_client, researcher_1, asset_group_sighting_guid
         )
-
-        # sighting_uuid = response.json['guid']
-        # sighting = Sighting.query.get(sighting_uuid)
-        # assert len(sighting.get_encounters()) == 1
-        # assert len(sighting.get_assets()) == 1
-        # assert sighting.get_owner() == regular_user
+        sighting_uuid = response.json['guid']
 
     finally:
         # Restore original state

--- a/tests/modules/asset_groups/resources/test_commit_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_commit_asset_group.py
@@ -80,8 +80,12 @@ def test_commit_owner_asset_group(
         sighting = Sighting.query.get(sighting_uuid)
         encounters = sighting.get_encounters()
         assert len(encounters) == 2
-        assert encounters[0].owner == regular_user
-        assert encounters[1].owner == researcher_1
+        # It seems encounters may not be returned in order so we can't assert
+        # encounters[0].owner == regular_user
+        assert sorted([e.owner.email for e in encounters]) == [
+            researcher_1.email,
+            regular_user.email,
+        ]
 
     finally:
         # Restore original state

--- a/tests/modules/asset_groups/resources/test_ensure_submission.py
+++ b/tests/modules/asset_groups/resources/test_ensure_submission.py
@@ -1,19 +1,26 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 import uuid
-import tests.modules.asset_groups.resources.utils as utils
+
+from tests.modules.asset_groups.resources import utils
 
 
 def test_ensure_asset_group_by_uuid(
     flask_app_client, researcher_1, db, test_asset_group_uuid
 ):
-    utils.clone_asset_group(flask_app_client, researcher_1, test_asset_group_uuid)
+    clone = utils.clone_asset_group(
+        flask_app_client, researcher_1, test_asset_group_uuid
+    )
+    clone.cleanup()
 
 
 def test_ensure_empty_asset_group_by_uuid(
     flask_app_client, researcher_1, db, test_empty_asset_group_uuid
 ):
-    utils.clone_asset_group(flask_app_client, researcher_1, test_empty_asset_group_uuid)
+    clone = utils.clone_asset_group(
+        flask_app_client, researcher_1, test_empty_asset_group_uuid
+    )
+    clone.cleanup()
 
 
 def test_ensure_clone_asset_group_by_uuid(
@@ -52,3 +59,5 @@ def test_ensure_clone_asset_group_by_uuid(
         db_asset = Asset.query.get(asset.guid)
         assert asset == db_asset
         assert asset.guid == expected_guid
+
+    clone.cleanup()

--- a/tests/modules/asset_groups/resources/test_permissions.py
+++ b/tests/modules/asset_groups/resources/test_permissions.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
+import uuid
+
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.modules.assets.resources.utils as asset_utils
 import tests.extensions.tus.utils as tus_utils
 from tests import utils as test_utils
-import uuid
 
 
 def test_user_read_permissions(
@@ -17,7 +18,7 @@ def test_user_read_permissions(
     # Clone as the researcher user and then try to reread as both researcher and readonly user,
     # read by researcher user should succeed, read by readonly user should be blocked
 
-    asset_group_utils.clone_asset_group(
+    clone = asset_group_utils.clone_asset_group(
         flask_app_client,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
@@ -49,6 +50,7 @@ def test_user_read_permissions(
     asset_group_utils.read_asset_group(
         flask_app_client, None, test_clone_asset_group_data['asset_group_uuid'], 401
     )
+    clone.cleanup()
 
 
 def test_create_patch_asset_group(

--- a/tests/modules/assets/resources/test_assets.py
+++ b/tests/modules/assets/resources/test_assets.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 import hashlib
+
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.modules.assets.resources.utils as asset_utils
 
@@ -31,7 +32,7 @@ def test_find_asset(
     test_clone_asset_group_data,
 ):
     # Clone the known asset_group so that the asset data is in the database
-    asset_group_utils.clone_asset_group(
+    clone = asset_group_utils.clone_asset_group(
         flask_app_client,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
@@ -55,6 +56,7 @@ def test_find_asset(
     finally:
         # Force the server to release the file handler
         src_response.close()
+        clone.cleanup()
 
 
 def test_find_deleted_asset(
@@ -91,6 +93,7 @@ def test_find_deleted_asset(
     finally:
         # Force the server to release the file handler
         src_response.close()
+        clone.cleanup()
 
 
 def test_find_raw_asset(
@@ -141,6 +144,7 @@ def test_find_raw_asset(
     finally:
         # Force the server to release the file handler
         raw_src_response.close()
+        clone.cleanup()
 
 
 def test_user_asset_permissions(
@@ -151,7 +155,7 @@ def test_user_asset_permissions(
     test_clone_asset_group_data,
 ):
     # Clone the known asset_group so that the asset data is in the database
-    asset_group_utils.clone_asset_group(
+    clone = asset_group_utils.clone_asset_group(
         flask_app_client,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
@@ -161,6 +165,8 @@ def test_user_asset_permissions(
     asset_guid = test_clone_asset_group_data['asset_uuids'][0]
     asset_utils.read_asset(flask_app_client, readonly_user, asset_guid, 403)
 
+    clone.cleanup()
+
 
 def test_read_all_assets(
     flask_app_client,
@@ -169,7 +175,7 @@ def test_read_all_assets(
     test_clone_asset_group_data,
 ):
     # Clone the known asset_group so that the asset data is in the database
-    asset_group_utils.clone_asset_group(
+    clone = asset_group_utils.clone_asset_group(
         flask_app_client,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
@@ -182,3 +188,5 @@ def test_read_all_assets(
     # both of these lists should be lexical order
     assert admin_response.json[0]['guid'] == test_clone_asset_group_data['asset_uuids'][0]
     assert admin_response.json[1]['guid'] == test_clone_asset_group_data['asset_uuids'][1]
+
+    clone.cleanup()

--- a/tests/modules/encounters/resources/test_modify_encounter.py
+++ b/tests/modules/encounters/resources/test_modify_encounter.py
@@ -93,8 +93,13 @@ def test_modify_encounter(db, flask_app_client, researcher_1, researcher_2, admi
     assert cfd_id in enc.json['customFields']
     assert enc.json['customFields'][cfd_id] == new_cfd_test_value
 
+    new_encounter_1.sighting.delete()
+    new_encounter_1.delete()
+
 
 def test_modify_encounter_error(flask_app, flask_app_client, researcher_1):
+    from app.modules.encounters.models import Encounter
+
     response = enc_utils.create_encounter(flask_app_client, researcher_1)
     first_enc_guid = response.json['result']['encounters'][0]['id']
 
@@ -117,3 +122,6 @@ def test_modify_encounter_error(flask_app, flask_app_client, researcher_1):
             expected_status_code=500,
         )
     assert res.json['status'] == 500
+
+    Encounter.query.get(first_enc_guid).sighting.delete()
+    Encounter.query.get(first_enc_guid).delete()

--- a/tests/modules/encounters/test_models.py
+++ b/tests/modules/encounters/test_models.py
@@ -41,6 +41,7 @@ def test_encounter_add_owner(db):
 
     assert test_encounter.get_owner() is not None
     assert test_encounter.get_owner().guid == test_user.guid
+    test_encounter.delete()
 
 
 def test_encounter_set_individual(db, empty_individual, encounter_1):

--- a/tests/modules/individuals/resources/test_individual_crud.py
+++ b/tests/modules/individuals/resources/test_individual_crud.py
@@ -150,3 +150,4 @@ def test_modify_encounters(db, flask_app_client, researcher_1, empty_individual)
     with db.session.begin():
         db.session.delete(mod_enc_1)
         db.session.delete(mod_enc_2)
+        db.session.delete(empty_individual)

--- a/tests/modules/job_control/test_models.py
+++ b/tests/modules/job_control/test_models.py
@@ -36,3 +36,5 @@ def test_job_control(flask_app, researcher_1, test_root, db):
                     f'AssetGroupSighting:{ags.guid} Job:{job_id} Model:Animal UTC Start:{utc_now}'
                 ),
             ]
+
+    asset_group.delete()

--- a/tests/modules/projects/test_parameters.py
+++ b/tests/modules/projects/test_parameters.py
@@ -6,6 +6,7 @@ def test_project_remove_encounters(
     db, researcher_1, researcher_1_login, test_empty_asset_group_uuid
 ):  # pylint: disable=unused-argument
     # pylint: disable=unused-argument
+    from app.modules.asset_groups.models import AssetGroup
     from app.modules.projects.parameters import PatchProjectDetailsParameters
     from app.modules.projects.models import Project
 
@@ -30,3 +31,4 @@ def test_project_remove_encounters(
 
     with db.session.begin():
         db.session.delete(temp_proj)
+        AssetGroup.query.get(test_empty_asset_group_uuid).delete()

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -221,9 +221,6 @@ def test_create_anon_and_delete_sighting(db, flask_app_client, staff_user, test_
     from app.modules.sightings.models import Sighting
     from app.modules.users.models import User
 
-    # we should end up with these same counts (which _should be_ all zeros!)
-    orig_ct = test_utils.all_count(db)
-
     transaction_id, test_filename = sighting_utils.prep_tus_dir(test_root)
     sighting_utils.prep_tus_dir(test_root, filename='fluke.jpg')
     data_in = {
@@ -324,6 +321,3 @@ def test_create_anon_and_delete_sighting(db, flask_app_client, staff_user, test_
     sighting_utils.cleanup_tus_dir(transaction_id)
     sighting_utils.delete_sighting(flask_app_client, staff_user, sighting_id)
     new_user.delete()
-
-    post_ct = test_utils.all_count(db)
-    assert orig_ct == post_ct

--- a/tests/modules/sightings/resources/test_custom_fields.py
+++ b/tests/modules/sightings/resources/test_custom_fields.py
@@ -3,7 +3,6 @@
 
 from tests.modules.sightings.resources import utils as sighting_utils
 from tests.extensions.edm import utils as edm_utils
-from tests import utils as test_utils
 
 
 def test_custom_fields_on_sighting(
@@ -14,9 +13,6 @@ def test_custom_fields_on_sighting(
 
     cfd_id = edm_utils.custom_field_create(flask_app_client, admin_user, 'test_cfd')
     assert cfd_id is not None
-
-    # we should end up with these same counts (which _should be_ all zeros!)
-    orig_ct = test_utils.all_count(db)
 
     timestamp = datetime.datetime.now().isoformat() + 'Z'
     transaction_id, test_filename = sighting_utils.prep_tus_dir(test_root)
@@ -77,6 +73,3 @@ def test_custom_fields_on_sighting(
 
     # clean up
     sighting_utils.delete_sighting(flask_app_client, researcher_1, sighting_id)
-
-    post_ct = test_utils.all_count(db)
-    assert orig_ct == post_ct

--- a/tests/modules/sightings/test_models.py
+++ b/tests/modules/sightings/test_models.py
@@ -53,6 +53,10 @@ def test_sighting_create_and_add_encounters(db):
     logging.info(test_sighting.get_encounters())
     logging.info(test_encounter_a.get_sighting())
 
+    test_encounter_a.delete()
+    test_encounter_b.delete()
+    test_sighting.delete()
+
 
 def test_sighting_ensure_no_duplicate_encounters(db):
     from app.modules.sightings.models import Sighting, SightingStage
@@ -98,6 +102,9 @@ def test_sighting_ensure_no_duplicate_encounters(db):
 
     logging.info(test_sighting.get_encounters())
     logging.info(test_encounter.get_sighting())
+
+    test_sighting.delete()
+    test_encounter.delete()
 
 
 def test_sighting_jobs(db, request):

--- a/tests/modules/users/test_permissions.py
+++ b/tests/modules/users/test_permissions.py
@@ -296,6 +296,8 @@ def test_ObjectAccessPermission_admin_user(
     validate_cannot_write_object(owned_encounter)
     validate_cannot_delete_object(owned_encounter)
 
+    owned_encounter.delete()
+
 
 def test_ModuleAccessPermission_anonymous_user(anonymous_user_login):
     # pylint: disable=unused-argument
@@ -424,6 +426,9 @@ def test_ObjectAccessPermission_researcher_user(
     validate_can_write_object(my_encounter)
     validate_can_delete_object(my_encounter)
 
+    my_encounter.delete()
+    owned_encounter.delete()
+
 
 def test_ObjectAccessPermission_contributor_user(
     db, contributor_1_login, temp_user, public_encounter, owned_encounter
@@ -489,3 +494,6 @@ def test_ObjectAccessPermission_contributor_user(
     validate_can_read_object(my_encounter)
     validate_can_write_object(my_encounter)
     validate_can_delete_object(my_encounter)
+
+    my_encounter.delete()
+    owned_encounter.delete()


### PR DESCRIPTION
Add an autouse fixture "check_cleanup_objects" which is applied to all
the tests to make sure the number of asset groups, assets, sightings,
encounters stay the same after the tests.

Use `mock.patch('app.modules.asset_groups.tasks.delete_remote')` to stop
`asset_group.delete()` from deleting the gitlab project.  This is for
the asset group fixtures shared between tests.  Gitlab projects are not
deleted immediately and sometimes we get to a state where gitlab is in
the middle of deleting the project while we're trying to create it
again.  So let's just avoid deleting it.
