### PR TITLE
Set FLASK_CONFIG to testing in tests/conftest.py

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -104,23 +104,23 @@ jobs:
       # Install and test - Test order is randomized, run three times to ensure correctness
       - name: Run tests (random x3)
         run: |
-          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e TEST_DATABASE_URI=$TEST_DATABASE_URI houston pytest -s -v
-          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e TEST_DATABASE_URI=$TEST_DATABASE_URI houston pytest -s -v
-          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e TEST_DATABASE_URI=$TEST_DATABASE_URI houston pytest -s -v
+          docker-compose exec -T -e TEST_DATABASE_URI=$TEST_DATABASE_URI houston pytest -s -v
+          docker-compose exec -T -e TEST_DATABASE_URI=$TEST_DATABASE_URI houston pytest -s -v
+          docker-compose exec -T -e TEST_DATABASE_URI=$TEST_DATABASE_URI houston pytest -s -v
 
       - name: Run tests without gitlab
         run: |
-          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e TEST_DATABASE_URI=$TEST_DATABASE_URI -e GITLAB_REMOTE_URI=http://connection-error/ houston pytest -s -v
+          docker-compose exec -T -e TEST_DATABASE_URI=$TEST_DATABASE_URI -e GITLAB_REMOTE_URI=http://connection-error/ houston pytest -s -v
 
       - name: Check DB migrations (sqlite)
         if: matrix.db-uri == 'sqlite://'
         run: |
           # initialize the database
-          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e SQLALCHEMY_DATABASE_URI=$SQLALCHEMY_DATABASE_URI houston invoke app.db.upgrade --no-backup
+          docker-compose exec -T -e SQLALCHEMY_DATABASE_URI=$SQLALCHEMY_DATABASE_URI houston invoke app.db.upgrade --no-backup
           # downgrade to the previous migration step
-          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e SQLALCHEMY_DATABASE_URI=$SQLALCHEMY_DATABASE_URI houston invoke app.db.downgrade
+          docker-compose exec -T -e SQLALCHEMY_DATABASE_URI=$SQLALCHEMY_DATABASE_URI houston invoke app.db.downgrade
           # upgrade to the latest version
-          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e SQLALCHEMY_DATABASE_URI=$SQLALCHEMY_DATABASE_URI houston invoke app.db.upgrade
+          docker-compose exec -T -e SQLALCHEMY_DATABASE_URI=$SQLALCHEMY_DATABASE_URI houston invoke app.db.upgrade
         env:
           # Don't use in memory sqlite database for database migration
           SQLALCHEMY_DATABASE_URI: ''
@@ -129,21 +129,21 @@ jobs:
         if: matrix.db-uri != 'sqlite://'
         run: |
           set -ex
-          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e SQLALCHEMY_DATABASE_URI=$TEST_DATABASE_URI houston coverage run /usr/local/bin/invoke app.db.upgrade --no-backup
-          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e SQLALCHEMY_DATABASE_URI=$TEST_DATABASE_URI houston coverage run --append /usr/local/bin/invoke app.db.downgrade
-          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e SQLALCHEMY_DATABASE_URI=$TEST_DATABASE_URI houston coverage run --append /usr/local/bin/invoke app.db.upgrade --no-backup
-          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e SQLALCHEMY_DATABASE_URI=$TEST_DATABASE_URI houston /bin/bash -c 'if [ -n "$(coverage run --append /usr/local/bin/invoke app.db.migrate)" ]; then echo Missing database migration; exit 1; fi'
+          docker-compose exec -T -e SQLALCHEMY_DATABASE_URI=$TEST_DATABASE_URI houston coverage run /usr/local/bin/invoke app.db.upgrade --no-backup
+          docker-compose exec -T -e SQLALCHEMY_DATABASE_URI=$TEST_DATABASE_URI houston coverage run --append /usr/local/bin/invoke app.db.downgrade
+          docker-compose exec -T -e SQLALCHEMY_DATABASE_URI=$TEST_DATABASE_URI houston coverage run --append /usr/local/bin/invoke app.db.upgrade --no-backup
+          docker-compose exec -T -e SQLALCHEMY_DATABASE_URI=$TEST_DATABASE_URI houston /bin/bash -c 'if [ -n "$(coverage run --append /usr/local/bin/invoke app.db.migrate)" ]; then echo Missing database migration; exit 1; fi'
 
       - name: Run tests after DB checks
         run: |
-          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e TEST_DATABASE_URI=$TEST_DATABASE_URI houston pytest --no-cov -s -v
+          docker-compose exec -T -e TEST_DATABASE_URI=$TEST_DATABASE_URI houston pytest --no-cov -s -v
 
       - name: Run Codecov
         continue-on-error: true
         run: |
-          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e TEST_DATABASE_URI=$TEST_DATABASE_URI houston pytest -s -v --cov=./ --cov-append
-          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e TEST_DATABASE_URI=$TEST_DATABASE_URI houston pytest -s -v -m separate tests/test_transactions.py::test_transactions[None-request_transaction] --cov-append
-          docker-compose exec -T -e FLASK_CONFIG=$FLASK_CONFIG -e TEST_DATABASE_URI=$TEST_DATABASE_URI houston pytest -s -v -m separate tests/test_transactions.py::test_transactions[None-commit_or_abort] --cov-append
+          docker-compose exec -T -e TEST_DATABASE_URI=$TEST_DATABASE_URI houston pytest -s -v --cov=./ --cov-append
+          docker-compose exec -T -e TEST_DATABASE_URI=$TEST_DATABASE_URI houston pytest -s -v -m separate tests/test_transactions.py::test_transactions[None-request_transaction] --cov-append
+          docker-compose exec -T -e TEST_DATABASE_URI=$TEST_DATABASE_URI houston pytest -s -v -m separate tests/test_transactions.py::test_transactions[None-commit_or_abort] --cov-append
 
       - name: Run other invoke tasks for coverage and errors
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,14 +194,14 @@ The EDM is a compiled Java application, and no volume mapping solution to a runn
 New Houston code must be tested with `pytest`. If dependencies are set up correctly an initial testing run can be done outside the docker container
 with the `pytest` command at the root level of the repository.
 
-To fully test you can `docker-compose exec houston /bin/bash` and set `FLASK_CONFIG= pytest` or
-test files inside the container from outside the container in one line using `docker-compose exec -e FLASK_CONFIG= houston pytest`.
+To fully test you can `docker-compose exec houston /bin/bash` and run `pytest` or
+test files inside the container from outside the container in one line using `docker-compose exec houston pytest`.
 
 They can also be run locally with simply `pytest`.
 
 These methods can target a specific app module by altering the command to something like this:
 
-    pytest tests/modules/[MODULE NAME]` or `FLASK_CONFIG= pytest tests/modules/[MODULE NAME]
+    pytest tests/modules/[MODULE NAME]`
 
 And may also the flags `-s` to print all additional logging or `-x` to stop on the first failed test.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import os
 import pathlib
 import tempfile
 import uuid
@@ -10,6 +11,10 @@ from flask_login import current_user, login_user, logout_user
 from tests import utils
 
 from app import create_app
+
+
+# Force FLASK_CONFIG to be testing instead of using what's defined in the environment
+os.environ['FLASK_CONFIG'] = 'testing'
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
This stops the need to change `FLASK_CONFIG` defined in the houston
docker container when running tests.

```
>           app = create_app(flask_config_name='testing', config_override=config_override)

tests/conftest.py:67:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
app/__init__.py:132: in create_app
    configure_from_config_file(app, flask_config_name)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

app = <Flask 'app'>, flask_config_name = 'testing'

    def configure_from_config_file(app, flask_config_name=None):
        env_flask_config_name = os.getenv('FLASK_CONFIG')
        if not env_flask_config_name and flask_config_name is None:
            flask_config_name = 'local'
        elif flask_config_name is None:
            flask_config_name = env_flask_config_name
        else:
            if env_flask_config_name:
>               assert env_flask_config_name == flask_config_name, (
                    'FLASK_CONFIG environment variable ("%s") and flask_config_name argument '
                    '("%s") are both set and are not the same.'
                    % (env_flask_config_name, flask_config_name)
                )
E               AssertionError: FLASK_CONFIG environment variable ("local") and flask_config_name argument ("testing") are both set and are not the same.

app/__init__.py:67: AssertionError
```

