### PR TITLE
Store AssetGroupSighting.jobs correctly in the database

### DIFF
--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -142,6 +142,25 @@ class JSON(db.TypeDecorator):
 
         return process(value)
 
+    def compare_values(self, x, y):
+        # This method is used to determine whether a field has changed.
+        #
+        # This is a problem for lists and dicts because if the user edits the
+        # list or dict in place, "x" and "y" are going to be the same and we
+        # can't determine whether the field has changed.
+        #
+        # For example, if self.jobs was {}, then we do:
+        # self.jobs['job_id'] = {'some': 'stuff'}
+        #
+        # compare_values is going to get {'job_id': {'some': 'stuff'}} twice
+        # because sqlalchemy is unable to get back the previous value of
+        # self.jobs which was {}
+        #
+        # So we can't determine whether the field has actually changed.  If we
+        # return True here, the object does not get saved, so we're going to
+        # just always return False
+        return False
+
 
 class GUID(db.TypeDecorator):
     """Platform-independent GUID type.

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -46,7 +46,7 @@ class Sighting(db.Model, FeatherModel):
 
     # May have multiple jobs outstanding, store as Json obj dictionary, uuid_str is key,
     # Content = {'algorithm': model, 'active': Bool}
-    jobs = db.Column(db.JSON, default={}, nullable=True)
+    jobs = db.Column(db.JSON, default=lambda: {}, nullable=True)
 
     # A sighting may have multiple IaConfigs used for IA on Sage, each with multiple algorithms,
     # even if only one is supported for MVP, Store as Json obj List
@@ -376,6 +376,12 @@ class Sighting(db.Model, FeatherModel):
                 'active': True,
                 'start': datetime.utcnow(),
             }
+            # This is necessary because we can only mark self as modified if
+            # we assign to one of the database attributes
+
+            self.jobs = self.jobs
+            with db.session.begin(subtransactions=True):
+                db.session.merge(self)
         # TODO what stage is the Sighting in if no jobs are created?
 
     # Return the contents of the last ID request sent for the annotation Id, status and any response

--- a/tests/modules/asset_groups/test_models.py
+++ b/tests/modules/asset_groups/test_models.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+import datetime
+import pathlib
+from unittest import mock
+import uuid
+
+
+def test_asset_group_sightings_jobs(flask_app, db, admin_user, test_root, request):
+    from app.modules.asset_groups.models import AssetGroup, AssetGroupSighting
+
+    transaction_id = str(uuid.uuid4())
+    trans_dir = (
+        pathlib.Path(flask_app.config['UPLOADS_DATABASE_PATH'])
+        / f'trans-{transaction_id}'
+    )
+    trans_dir.mkdir(parents=True)
+    with (trans_dir / 'zebra.jpg').open('wb') as f:
+        with (test_root / 'zebra.jpg').open('rb') as g:
+            f.write(g.read())
+    asset_group = AssetGroup.create_from_tus(
+        'test asset group description', admin_user, transaction_id
+    )
+    with db.session.begin():
+        db.session.add(asset_group)
+    request.addfinalizer(asset_group.delete)
+
+    ags1 = AssetGroupSighting(
+        config={'assetReferences': ['zebra.jpg']}, asset_group_guid=asset_group.guid
+    )
+    ags2 = AssetGroupSighting(
+        config={'assetReferences': []}, asset_group_guid=asset_group.guid
+    )
+    with db.session.begin():
+        db.session.add(ags1)
+        db.session.add(ags2)
+    request.addfinalizer(ags1.delete)
+    request.addfinalizer(ags2.delete)
+
+    now = datetime.datetime(2021, 7, 7, 17, 55, 34)
+    job_id1 = uuid.UUID('53ea04e0-1e87-412d-aa17-0ff5e05db78d')
+    job_id2 = uuid.UUID('fca55971-f014-4a8d-9e94-2c88b72d2d8c')
+
+    uuids = [job_id2, job_id1]
+
+    # Don't send anything to acm
+    with mock.patch('app.modules.asset_groups.models.current_app'):
+        with mock.patch('datetime.datetime') as mock_datetime:
+            with mock.patch(
+                'app.modules.asset_groups.models.uuid.uuid4', side_effect=uuids.pop
+            ):
+                mock_datetime.utcnow.return_value = now
+                ags1.run_sage_detection('ags1-model')
+                ags2.run_sage_detection('ags2-model')
+
+    assert AssetGroupSighting.query.get(ags1.guid).jobs == {
+        str(job_id1): {
+            'model': 'ags1-model',
+            'active': True,
+            'start': now,
+        },
+    }
+    assert AssetGroupSighting.query.get(ags2.guid).jobs == {
+        str(job_id2): {
+            'model': 'ags2-model',
+            'active': True,
+            'start': now,
+        },
+    }


### PR DESCRIPTION
The first problem is in the jobs column definition, we had `default={}`
and then we modify `self.jobs` by doing:

```
self.jobs[str(job_id)] = {...}
```

The default `{}` is only initialized once, so we are basically editing
the same dict in different AssetGroupSighting instances.

We fix this by doing `default=lambda: {}` so we are creating a new
instance of dict for every AssetGroupSighting.

Next, the AssetGroupSighting isn't saved after we modified `self.jobs`.
The problem here is modifying `self.jobs[str(job_id)]` doesn't trigger
the sqlalchemy code to detect something has actually changed.
`self.jobs` needs to be assigned to in order for this mechanism to work:

```
self.jobs = self.jobs
```

Finally, sqlalchemy would compare the old value of `self.jobs` with the
new value of `self.jobs` before the assignment and of course `self.jobs`
was modified, so the comparison would come back "the same".  So the fix
here is done in the `JSON` type definition in
`app/extensions/__init__.py`:

```
def compare_values(self, x, y):
    return False
```

This tells sqlalchemy that the values are not the same and so it should
write to the database.

---

I fixed a similar problem in sightings, added to this PR.