### PR TITLE
DEX-336: asset detailed api call has width/height info

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -1096,6 +1096,7 @@ class AssetGroup(db.Model, HoustonModel):
         ):
             db.session.refresh(asset)
             asset.update_symlink(asset_asset_group_filepath)
+            asset.set_derived_meta()
             if verbose:
                 print(filepath)
                 print('\tAsset         : %s' % (asset,))

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -145,6 +145,46 @@ class Asset(db.Model, HoustonModel):
 
         return asset_symlink_filepath
 
+    def mime_type_major(self):
+        if not self.mime_type:
+            return None
+        parts = self.mime_type.split('/')
+        return parts[0]
+
+    def is_mime_type_major(self, major):
+        return self.mime_type_major() == major
+
+    # will only set .meta values that can be derived automatically from file
+    # (will not overwrite any manual/other values); silently fails if unknown type for deriving
+    #
+    #  FIXME - this now is a very basic stub -- it is operating on original file and *very* likely fails
+    #  due to exif/orientation info TODO
+    def set_derived_meta(self):
+        if not self.is_mime_type_major('image'):
+            return None
+        dmeta = {}
+        source_path = self.get_symlink()
+        assert os.path.exists(source_path)
+        with Image.open(source_path) as im:
+            size = im.size
+            dmeta['width'] = size[0]
+            dmeta['height'] = size[1]
+        meta = self.meta if self.meta else {}
+        meta['derived'] = dmeta
+        self.meta = meta
+        log.debug(f'setting meta.derived to {dmeta}')
+        return dmeta
+
+    # right now we _only_ use `derived` values, so not much logic here
+    # TODO alter when we allow ways to override derived (or have more complex logic based on orientation)
+    def get_dimensions(self):
+        if not self.meta or not self.meta['derived']:
+            return None
+        return {
+            'width': self.meta['derived'].get('width', None),
+            'height': self.meta['derived'].get('height', None),
+        }
+
     def get_or_make_format_path(self, format):
         FORMAT = {
             'master': [4096, 4096],

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -157,8 +157,8 @@ class Asset(db.Model, HoustonModel):
     # will only set .meta values that can be derived automatically from file
     # (will not overwrite any manual/other values); silently fails if unknown type for deriving
     #
-    #  FIXME - this now is a very basic stub -- it is operating on original file and *very* likely fails
-    #  due to exif/orientation info TODO
+    #  TODO - this now is a very basic stub -- it is operating on original file and *very* likely fails
+    #  due to exif/orientation info
     def set_derived_meta(self):
         if not self.is_mime_type_major('image'):
             return None
@@ -184,6 +184,10 @@ class Asset(db.Model, HoustonModel):
             'width': self.meta['derived'].get('width', None),
             'height': self.meta['derived'].get('height', None),
         }
+
+    @property
+    def dimensions(self):
+        return self.get_dimensions()
 
     def get_or_make_format_path(self, format):
         FORMAT = {

--- a/app/modules/assets/schemas.py
+++ b/app/modules/assets/schemas.py
@@ -36,6 +36,7 @@ class DetailedAssetSchema(BaseAssetSchema):
             Asset.updated.key,
             Asset.asset_group.key,
             'annotations',
+            'dimensions',
         )
         dump_only = BaseAssetSchema.Meta.dump_only + (
             Asset.created.key,

--- a/tests/modules/assets/test_models.py
+++ b/tests/modules/assets/test_models.py
@@ -63,7 +63,7 @@ def set_up_assets(flask_app, db, test_root, admin_user, request):
     return asset_group
 
 
-def test_asset_delete(flask_app, db, test_root, admin_user, request):
+def test_asset_meta_and_delete(flask_app, db, test_root, admin_user, request):
     from app.modules.annotations.models import Annotation
     from app.modules.assets.models import Asset
     from app.modules.asset_groups.models import AssetGroup
@@ -74,6 +74,9 @@ def test_asset_delete(flask_app, db, test_root, admin_user, request):
     assert len(asset_group.assets) == 3
     assert len(asset_group.assets[0].annotations) == 1
     assert len(asset_group.assets[0].asset_sightings) == 1
+    dim = asset_group.assets[0].get_dimensions()
+    assert dim['width'] > 1
+    assert dim['height'] > 1
     asset_guids = [a.guid for a in asset_group.assets]
     annotation = asset_group.assets[0].annotations[0]
     sighting = asset_group.assets[0].asset_sightings[0].sighting


### PR DESCRIPTION
## Pull Request Overview

- Basic implementation of **width / height dimension** data on Assets
- Utilizes (existing, unused) `.meta` property (json) on Asset
- `asset.set_derived_meta()` populates `meta['derived']` with information from Asset file
- `asset.get_dimensions()` uses above to deliver a dict with keys `width` and `height`
- Detailed Asset schema now includes `"dimensions": { "width": w, "height": h }`

## Future development

- Initial groundwork for more complex logic
- `asset.get_dimensions()` should be expanded to take into account **manual overrides** of values, adjustments due to **orientation issues**, etc.  (which likely will be stored in `asset.meta` alongside `asset.meta.derived`.)

