### PR TITLE
DEX-357 Asset can only be in one sighting

### DIFF
--- a/app/modules/asset_groups/metadata.py
+++ b/app/modules/asset_groups/metadata.py
@@ -88,6 +88,11 @@ class BaseAssetGroupMetadata(object):
                     )
                 if file_size < 1:
                     raise AssetGroupMetadataError(f'found zero-size file for {filename}')
+                if filename in self.files:
+                    raise AssetGroupMetadataError(
+                        f'found {filename} in multiple sightings'
+                    )
+
                 # Set ensures no duplicates
                 self.files.add(filename)
 

--- a/tests/modules/asset_groups/resources/test_create_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_create_asset_group.py
@@ -291,6 +291,29 @@ def test_create_asset_group_detection(
         assert orig_objs == test_utils.all_count(db)
 
 
+def test_create_bulk_asset_group_dup_asset(flask_app_client, researcher_1, test_root, db):
+    # pylint: disable=invalid-name
+
+    transaction_id, test_filename = asset_group_utils.create_bulk_tus_transaction(
+        test_root
+    )
+    asset_group_uuid = None
+    try:
+        data = asset_group_utils.get_bulk_creation_data(transaction_id, test_filename)
+        data.add_filename(0, 'fluke.jpg')
+        expected_err = 'found fluke.jpg in multiple sightings'
+        asset_group_utils.create_asset_group(
+            flask_app_client, researcher_1, data.get(), 400, expected_err
+        )
+
+    finally:
+        if asset_group_uuid:
+            asset_group_utils.delete_asset_group(
+                flask_app_client, researcher_1, asset_group_uuid
+            )
+        tus_utils.cleanup_tus_dir(transaction_id)
+
+
 def test_create_bulk_asset_group(flask_app_client, researcher_1, test_root, db):
     # pylint: disable=invalid-name
     import uuid

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -127,7 +127,6 @@ def get_bulk_creation_data(transaction_id, test_filename):
     data.add_encounter(1)
     data.add_filename(1, 'coelacanth.png')
     data.add_encounter(1)
-    data.add_filename(1, 'fluke.jpg')
     data.add_filename(1, 'phoenix.jpg')
     data.set_field('uploadType', 'bulk')
     return data


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Trivial tweak to the metadata checking to ensure that an asset can only be in one sighting
- Tests modified to not trigger it accidentally, new test added to check it
---

