### PR TITLE
DEX-359 Add roles and profile image to users listing api

### DIFF
--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -37,7 +37,7 @@ class Users(Resource):
             'action': AccessOperation.READ,
         },
     )
-    @api.response(schemas.BaseUserSchema(many=True))
+    @api.response(schemas.UserListSchema(many=True))
     @api.paginate(parameters.ListUserParameters())
     def get(self, args):
         """

--- a/app/modules/users/schemas.py
+++ b/app/modules/users/schemas.py
@@ -28,6 +28,28 @@ class BaseUserSchema(ModelSchema):
         dump_only = (User.guid.key,)
 
 
+class UserListSchema(BaseUserSchema):
+    profile_fileupload = base_fields.Nested('DetailedFileUploadSchema')
+
+    class Meta(BaseUserSchema.Meta):
+        # pylint: disable=missing-docstring
+        model = User
+        fields = BaseUserSchema.Meta.fields + (
+            User.is_active.fget.__name__,
+            User.is_contributor.fget.__name__,
+            User.is_exporter.fget.__name__,
+            User.is_internal.fget.__name__,
+            User.is_staff.fget.__name__,
+            User.is_researcher.fget.__name__,
+            User.is_user_manager.fget.__name__,
+            User.is_admin.fget.__name__,
+            User.in_alpha.fget.__name__,
+            User.in_beta.fget.__name__,
+            User.profile_fileupload.key,
+        )
+        dump_only = (User.guid.key,)
+
+
 class PublicUserSchema(ModelSchema):
     """ Only fields which are safe for public display (very minimal). """
 
@@ -51,31 +73,18 @@ class DetailedUserPermissionsSchema(ModelSchema):
         dump_only = (User.guid.key,)
 
 
-class DetailedUserSchema(BaseUserSchema):
+class DetailedUserSchema(UserListSchema):
     """ Detailed user schema exposes all fields used to render a normal user profile. """
 
-    profile_fileupload = base_fields.Nested('DetailedFileUploadSchema')
-
-    class Meta(BaseUserSchema.Meta):
-        fields = BaseUserSchema.Meta.fields + (
+    class Meta(UserListSchema.Meta):
+        fields = UserListSchema.Meta.fields + (
             User.created.key,
             User.updated.key,
             User.viewed.key,
-            User.is_active.fget.__name__,
-            User.is_contributor.fget.__name__,
-            User.is_exporter.fget.__name__,
-            User.is_internal.fget.__name__,
-            User.is_staff.fget.__name__,
-            User.is_researcher.fget.__name__,
-            User.is_user_manager.fget.__name__,
-            User.is_admin.fget.__name__,
-            User.in_alpha.fget.__name__,
-            User.in_beta.fget.__name__,
             User.affiliation.key,
             User.location.key,
             User.forum_id.key,
             User.website.key,
-            User.profile_fileupload.key,
         )
 
 


### PR DESCRIPTION
The API now returns something like this:

```
[
    {
        "is_internal": true,
        "is_exporter": false,
        "is_active": true,
        "profile_fileupload": {
            "created": "2021-07-09T20:20:31.888901+00:00",
            "mime_type": "image/png",
            "guid": "ec220d3a-36c4-43a2-a062-3343eeb025bc",
            "src": "/api/v1/fileuploads/src/ec220d3a-36c4-43a2-a062-3343eeb025bc",
            "updated": "2021-07-09T20:20:31.888927+00:00"
        },
        "in_alpha": false,
        "is_admin": true,
        "is_user_manager": false,
        "is_staff": false,
        "guid": "366cb80a-e971-4576-b851-8c75177d1d6a",
        "is_researcher": false,
        "full_name": "",
        "in_beta": false,
        "is_contributor": true,
        "email": "root@example.org"
    },
    ...
```
