### PR TITLE
DEX-354 can now print the annotation job status from invoke task, plus tests,…

### DIFF
--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -404,6 +404,8 @@ class Sighting(db.Model, FeatherModel):
             with db.session.begin(subtransactions=True):
                 db.session.merge(self)
         else:
+            # TODO, this is correct for MVP as there is only one id per Sighting but this will need
+            # rework when there are multiple
             self.stage = SightingStage.un_reviewed
 
     # Return the contents of the last ID request sent for the annotation Id, status and any response

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -408,18 +408,6 @@ class Sighting(db.Model, FeatherModel):
             # rework when there are multiple
             self.stage = SightingStage.un_reviewed
 
-    # Return the contents of the last ID request sent for the annotation Id, status and any response
-    def get_last_identification_data(self, annotation_uuid):
-        id_data = {}
-        # TODO, DEX-354 iterate through self.jobs looking for annotation_uuid,
-        # for the last one (calculated by looking at the start time)
-        # Use the matching_set, algorithm and job_uuid from the job, to rebuild the request sent
-        # using  build_identification_request
-        # store this as id_data.request
-        # store job active in id_data.active
-        # request response for this job from Sage and store in id_data.response
-        return id_data
-
     def check_job_status(self, job_id):
         if str(job_id) not in self.jobs:
             log.warning(f'check_job_status called for invalid job {job_id}')

--- a/tests/modules/asset_groups/resources/test_commit_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_commit_asset_group.py
@@ -9,7 +9,7 @@ import tests.extensions.tus.utils as tus_utils
 def test_commit_asset_group(flask_app_client, researcher_1, regular_user, test_root, db):
     # pylint: disable=invalid-name
     from tests.modules.asset_groups.resources.utils import TestCreationData
-    from app.modules.sightings.models import Sighting
+    from app.modules.sightings.models import Sighting, SightingStage
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     asset_group_uuid = None
@@ -38,6 +38,7 @@ def test_commit_asset_group(flask_app_client, researcher_1, regular_user, test_r
 
         sighting_uuid = response.json['guid']
         sighting = Sighting.query.get(sighting_uuid)
+        assert sighting.stage == SightingStage.un_reviewed
         assert len(sighting.get_encounters()) == 1
         assert len(sighting.get_assets()) == 1
         assert sighting.get_owner() == regular_user
@@ -57,7 +58,7 @@ def test_commit_owner_asset_group(
     flask_app_client, researcher_1, regular_user, staff_user, test_root, db
 ):
     # pylint: disable=invalid-name
-    from app.modules.sightings.models import Sighting
+    from app.modules.sightings.models import Sighting, SightingStage
 
     transaction_id, test_filename = asset_group_utils.create_bulk_tus_transaction(
         test_root
@@ -80,6 +81,7 @@ def test_commit_owner_asset_group(
         sighting = Sighting.query.get(sighting_uuid)
         encounters = sighting.get_encounters()
         assert len(encounters) == 2
+        assert sighting.stage == SightingStage.un_reviewed
         # It seems encounters may not be returned in order so we can't assert
         # encounters[0].owner == regular_user
         assert sorted([e.owner.email for e in encounters]) == [
@@ -104,6 +106,7 @@ def test_commit_asset_group_ia(
 ):
     # pylint: disable=invalid-name
     from tests.modules.asset_groups.resources.utils import TestCreationData
+    from app.modules.sightings.models import Sighting, SightingStage
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     asset_group_uuid = None
@@ -142,7 +145,8 @@ def test_commit_asset_group_ia(
             flask_app_client, researcher_1, asset_group_sighting_guid
         )
         sighting_uuid = response.json['guid']
-
+        sighting = Sighting.query.get(sighting_uuid)
+        assert sighting.stage == SightingStage.un_reviewed
     finally:
         # Restore original state
         if asset_group_uuid:

--- a/tests/modules/asset_groups/resources/test_commit_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_commit_asset_group.py
@@ -67,7 +67,10 @@ def test_commit_owner_asset_group(
     sighting_uuid = None
     try:
         data = asset_group_utils.get_bulk_creation_data(transaction_id, test_filename)
+        # order of ags not deterministic so to make the test simpler, make the first encounter in all
+        # sightings owned by the regular user
         data.set_encounter_field(0, 0, 'ownerEmail', regular_user.email)
+        data.set_encounter_field(1, 0, 'ownerEmail', regular_user.email)
         resp = asset_group_utils.create_asset_group(
             flask_app_client, researcher_1, data.get()
         )

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -264,6 +264,28 @@ def commit_asset_group_sighting(
     return response
 
 
+# Many tests require a committed assetgroup with one sighting, use this helper
+def create_and_commit_asset_group(
+    flask_app_client, db, user, transaction_id, test_filename
+):
+    data = TestCreationData(transaction_id)
+    data.add_filename(0, test_filename)
+    response = create_asset_group(flask_app_client, user, data.get())
+    asset_group_uuid = response.json['guid']
+    asset_group_sighting_guid = response.json['asset_group_sightings'][0]['guid']
+    asset_uuid = response.json['assets'][0]['guid']
+    annot_uuid = patch_in_dummy_annotation(
+        flask_app_client, db, user, asset_group_sighting_guid, asset_uuid
+    )
+
+    response = commit_asset_group_sighting(
+        flask_app_client, user, asset_group_sighting_guid
+    )
+
+    sighting_uuid = response.json['guid']
+    return asset_group_uuid, sighting_uuid, annot_uuid
+
+
 def patch_asset_group(
     flask_app_client, user, asset_group_guid, data, expected_status_code=200
 ):

--- a/tests/tasks/app/test_job_control.py
+++ b/tests/tasks/app/test_job_control.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 import io
+import uuid
 from unittest import mock
 import tests.extensions.tus.utils as tus_utils
 import tests.modules.asset_groups.resources.utils as asset_group_utils
+import tests.modules.sightings.resources.utils as sighting_utils
 
 from invoke import MockContext
 
@@ -12,15 +14,11 @@ def test_asset_group_detection_jobs(
     flask_app, flask_app_client, researcher_1, staff_user, test_root, db
 ):
     # pylint: disable=invalid-name
-    from tests.modules.asset_groups.resources.utils import TestCreationData
-    from tests import utils as test_utils
-
-    orig_objs = test_utils.all_count(db)
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     asset_group_uuid = None
     try:
-        data = TestCreationData(transaction_id)
+        data = asset_group_utils.TestCreationData(transaction_id)
         data.add_filename(0, test_filename)
         data.set_field('speciesDetectionModel', ['someSortOfModel'])
 
@@ -71,4 +69,107 @@ def test_asset_group_detection_jobs(
                 flask_app_client, staff_user, asset_group_uuid
             )
         tus_utils.cleanup_tus_dir(transaction_id)
-        assert orig_objs == test_utils.all_count(db)
+
+
+# Check that the task methods for the sighting job tasks print the correct output
+def test_sighting_identification_jobs(
+    flask_app,
+    flask_app_client,
+    researcher_1,
+    test_root,
+    db,
+):
+    # pylint: disable=invalid-name
+    from app.modules.sightings.models import Sighting, SightingStage
+
+    asset_group_uuids = []
+    sighting_uuids = []
+    transactions = []
+    try:
+        # Create two sightings so that there will be a valid annotation when doing ID for the second one.
+        # Otherwise the get_matching_set_data in sightings will return an empty list
+        transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
+        (
+            asset_group_uuid,
+            sighting_uuid,
+            annot_uuid,
+        ) = asset_group_utils.create_and_commit_asset_group(
+            flask_app_client, db, researcher_1, transaction_id, test_filename
+        )
+        asset_group_uuids.append(asset_group_uuid)
+        sighting_uuids.append(sighting_uuid)
+        transactions.append(transaction_id)
+        # Fake it being all the way though to processed or it won't be valid in the matching set
+        sighting = Sighting.query.get(sighting_uuid)
+        sighting.stage = SightingStage.processed
+
+        # Second sighting, the one well use for testing
+        transaction_id, test_filename = tus_utils.prep_tus_dir(
+            test_root, str(uuid.uuid4())
+        )
+        (
+            asset_group_uuid,
+            sighting_uuid,
+            annot_uuid,
+        ) = asset_group_utils.create_and_commit_asset_group(
+            flask_app_client, db, researcher_1, transaction_id, test_filename
+        )
+        asset_group_uuids.append(asset_group_uuid)
+        sighting_uuids.append(sighting_uuid)
+        transactions.append(transaction_id)
+
+        # Here starts the test for real
+        sighting = Sighting.query.get(sighting_uuid)
+        # Push stage back to ID
+        sighting.stage = SightingStage.identification
+
+        id_configs = [
+            {
+                'algorithms': [
+                    'noddy',
+                ],
+                'matchingSetDataOwners': 'mine',
+            }
+        ]
+        with mock.patch.object(
+            flask_app.acm,
+            'request_passthrough_result',
+            return_value={'success': True},
+        ):
+            sighting.ia_pipeline(id_configs)
+
+        # Now see that the task gets what we expect
+        with mock.patch('app.create_app'):
+            with mock.patch('sys.stdout', new=io.StringIO()) as stdout:
+                from tasks.app import job_control
+
+                job_control.print_all_annotation_jobs(MockContext(), str(annot_uuid))
+                job_output = stdout.getvalue()
+                assert 'Job ' in job_output
+                assert 'Active:True Started (UTC)' in job_output
+                assert 'algorithm:noddy' in job_output
+
+                # Simulate a valid response from Sage but don't actually send the request to Sage
+                with mock.patch.object(
+                    flask_app.acm,
+                    'request_passthrough_result',
+                    return_value={'success': True, 'content': 'something'},
+                ):
+                    job_control.print_last_annotation_job(
+                        MockContext(), str(annot_uuid), verbose=True
+                    )
+                    job_output = stdout.getvalue()
+                    assert 'Job ' in job_output
+                    assert 'Active:True Started (UTC)' in job_output
+                    assert 'algorithm:noddy' in job_output
+                    assert "Request:{'jobid': " in job_output
+                    assert (
+                        "Response:{'success': True, 'content': 'something'}" in job_output
+                    )
+    finally:
+        for group in asset_group_uuids:
+            asset_group_utils.delete_asset_group(flask_app_client, researcher_1, group)
+        for sighting_uuid in sighting_uuids:
+            sighting_utils.delete_sighting(flask_app_client, researcher_1, sighting_uuid)
+        for trans in transactions:
+            tus_utils.cleanup_tus_dir(trans)


### PR DESCRIPTION
… plus test util to make this easier

<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- invoke task to print out jobs for an annotation

---

**Invoke CLI Updates [OPTIONAL]**
Here is an example invoke that shows the new functionality

$ invoke app.job_control.print_last_annotation_job {annotation_uuid} verbose=True
Last Job dae15eb6-b745-4a90-84ae-1d1773a84d29 Active:True Started (UTC):2021-07-12 16:20:05 algorithm:noddy

	Request:{'jobid': 'dae15eb6-b745-4a90-84ae-1d1773a84d29', 'callback_url': 'http://houston:5000/api/v1/asset_group/sighting/7828528f-22f4-433e-8d1c-ab148bf7dc31/sage_identified/dae15eb6-b745-4a90-84ae-1d1773a84d29', 'matching_state_list': [], 'query_annot_name_list': ['____'], 'query_annot_uuid_list': [{'__UUID__': 'b68ebc46-96f2-4847-8600-f28d867c3543'}], 'query_config_dict': {'sv_on': True}, 'database_annot_name_list': ['unknown'], 'database_annot_uuid_list': [{'__UUID__': 'd34698ba-42ad-432e-af27-c8e9f19be911'}]}
	Response:{'success': True, 'content': 'something'}

