### PR TITLE
DEX-373: allow .annotations on Encounter api data

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -468,7 +468,16 @@ class AssetGroupSighting(db.Model, HoustonModel):
         from app.modules.assets.schemas import DetailedAssetSchema
 
         asset_schema = DetailedAssetSchema(
-            many=False, only=('guid', 'filename', 'src', 'annotations')
+            many=False,
+            only=(
+                'guid',
+                'filename',
+                'src',
+                'annotations',
+                'dimensions',
+                'created',
+                'updated',
+            ),
         )
         assets = []
         for filename in self.config.get('assetReferences'):

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -465,20 +465,9 @@ class AssetGroupSighting(db.Model, HoustonModel):
 
     # Used to build the response to AssetGroupSighting GET
     def get_assets(self):
-        from app.modules.assets.schemas import DetailedAssetSchema
+        from app.modules.assets.schemas import DetailedAssetGroupAssetSchema
 
-        asset_schema = DetailedAssetSchema(
-            many=False,
-            only=(
-                'guid',
-                'filename',
-                'src',
-                'annotations',
-                'dimensions',
-                'created',
-                'updated',
-            ),
-        )
+        asset_schema = DetailedAssetGroupAssetSchema(many=False)
         assets = []
         for filename in self.config.get('assetReferences'):
             asset = self.asset_group.get_asset_for_file(filename)

--- a/app/modules/assets/schemas.py
+++ b/app/modules/assets/schemas.py
@@ -42,3 +42,12 @@ class DetailedAssetSchema(BaseAssetSchema):
             Asset.created.key,
             Asset.updated.key,
         )
+
+
+class DetailedAssetGroupAssetSchema(BaseAssetSchema):
+    fields = BaseAssetSchema.Meta.fields + (
+        Asset.created.key,
+        Asset.updated.key,
+        'annotations',
+        'dimensions',
+    )

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -286,7 +286,16 @@ class Sighting(db.Model, FeatherModel):
         from app.modules.assets.schemas import DetailedAssetSchema
 
         asset_schema = DetailedAssetSchema(
-            many=False, only=('guid', 'filename', 'src', 'annotations')
+            many=False,
+            only=(
+                'guid',
+                'filename',
+                'src',
+                'annotations',
+                'dimensions',
+                'created',
+                'updated',
+            ),
         )
         edm_json['assets'] = []
         for asset in self.get_assets():

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -374,9 +374,7 @@ class Sightings(Resource):
 
         from app.modules.assets.schemas import DetailedAssetSchema
 
-        asset_schema = DetailedAssetSchema(
-            only=('guid', 'filename', 'src', 'dimensions', 'created', 'updated')
-        )
+        asset_schema = DetailedAssetSchema(exclude=('annotations'))
         rtn = {
             'success': True,
             'result': {

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -367,7 +367,9 @@ class Sightings(Resource):
 
         from app.modules.assets.schemas import DetailedAssetSchema
 
-        asset_schema = DetailedAssetSchema(only=('guid', 'filename', 'src'))
+        asset_schema = DetailedAssetSchema(
+            only=('guid', 'filename', 'src', 'dimensions', 'created', 'updated')
+        )
         rtn = {
             'success': True,
             'result': {

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -132,7 +132,7 @@ def _validate_assets(assets, paths_wanted):
     return matches
 
 
-def _validate_annotations(enc_json):
+def _get_annotations(enc_json):
     assert enc_json is not None
     from app.modules.annotations.models import Annotation
 
@@ -276,12 +276,12 @@ class Sightings(Resource):
         enc_anns = []  # list of lists of annotations for each encounter (if applicable)
         try:
             for enc_json in request_in['encounters']:
-                anns = _validate_annotations(enc_json)
+                anns = _get_annotations(enc_json)
                 enc_anns.append(anns)
         except Exception as ex:
             cleanup.rollback_and_abort(
                 'Invalid encounter.annotations',
-                '_validate_annotations() threw %r on encounters=%r' % (ex, enc_json),
+                '_get_annotations() threw %r on encounters=%r' % (ex, enc_json),
             )
 
         asset_references = request_in.get('assetReferences')
@@ -471,13 +471,13 @@ class SightingByID(Resource):
                         and arg.get('op', None) == 'add'
                     ):
                         enc_json = arg.get('value', {})
-                        anns = _validate_annotations(enc_json)
+                        anns = _get_annotations(enc_json)
                         enc_anns.append(anns)
 
             except Exception as ex:
                 cleanup.rollback_and_abort(
                     'Invalid encounter.annotations',
-                    '_validate_annotations() threw %r on encounters=%r' % (ex, enc_json),
+                    '_get_annotations() threw %r on encounters=%r' % (ex, enc_json),
                 )
 
             result = None

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -132,6 +132,19 @@ def _validate_assets(assets, paths_wanted):
     return matches
 
 
+def _validate_annotations(enc_json):
+    assert enc_json is not None
+    from app.modules.annotations.models import Annotation
+
+    anns = []
+    anns_in = enc_json.get('annotations', [])
+    for ann_in in anns_in:
+        ann = Annotation.query.get(ann_in.get('guid', None))
+        assert ann is not None
+        anns.append(ann)
+    return anns
+
+
 @api.route('/')
 class Sightings(Resource):
     """
@@ -260,17 +273,10 @@ class Sightings(Resource):
                 % (request_in, result_data),
             )
 
-        from app.modules.annotations.models import Annotation
-
         enc_anns = []  # list of lists of annotations for each encounter (if applicable)
         try:
             for enc_json in request_in['encounters']:
-                anns = []
-                anns_in = enc_json.get('annotations', [])
-                for ann_in in anns_in:
-                    ann = Annotation.query.get(ann_in.get('guid', None))
-                    assert ann is not None
-                    anns.append(ann)
+                anns = _validate_annotations(enc_json)
                 enc_anns.append(anns)
         except Exception as ex:
             cleanup.rollback_and_abort(
@@ -336,6 +342,7 @@ class Sightings(Resource):
         from app.modules.encounters.models import Encounter
 
         if isinstance(result_data['encounters'], list):
+            assert len(result_data['encounters']) == len(enc_anns)
             i = 0
             while i < len(result_data['encounters']):
                 try:
@@ -450,7 +457,29 @@ class SightingByID(Resource):
             )
 
         if edm_count > 0:
+            cleanup = SightingCleanup()
             log.debug(f'wanting to do edm patch on args={args}')
+
+            # we pre-check any annotations we will want to attach to new encounters
+            enc_anns = (
+                []
+            )  # list of lists of annotations for each encounter (if applicable)
+            try:
+                for arg in args:
+                    if (
+                        arg.get('path', None) == '/encounters'
+                        and arg.get('op', None) == 'add'
+                    ):
+                        enc_json = arg.get('value', {})
+                        anns = _validate_annotations(enc_json)
+                        enc_anns.append(anns)
+
+            except Exception as ex:
+                cleanup.rollback_and_abort(
+                    'Invalid encounter.annotations',
+                    'loading annotations threw %r on encounters=%r' % (ex, enc_json),
+                )
+
             result = None
             try:
                 (
@@ -481,8 +510,25 @@ class SightingByID(Resource):
                 sighting.delete_cascade()  # this will get rid of our encounter(s) as well so no need to rectify_edm_encounters()
                 sighting = None
             else:
-                # TODO we must check enc.annotations here (or maybe inside rectify_edm_encounters?)
                 sighting.rectify_edm_encounters(result.get('encounters'), current_user)
+                # if we have enc_anns (len=N, N > 0), these should map to the last N encounters in this sighting
+                if len(enc_anns) > 0:
+                    enc_res = result.get('encounters', [])
+                    assert len(enc_res) == len(
+                        sighting.encounters
+                    )  # more just a sanity-check
+                    assert len(enc_anns) <= len(
+                        sighting.encounters
+                    )  # which ones were added, basically
+                    i = 0
+                    offset = len(sighting.encounters) - len(enc_anns)
+                    while i < len(enc_anns):
+                        log.debug(
+                            f'enc_len={len(sighting.encounters)},offset={offset},i={i}: onto encounters[{offset+i}] setting {enc_anns[i]}'
+                        )
+                        sighting.encounters[offset + i].annotations = enc_anns[i]
+                        i += 1
+
                 new_version = result.get('version', None)
                 if new_version is not None:
                     sighting.version = new_version

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -514,6 +514,9 @@ class SightingByID(Resource):
                 # if we have enc_anns (len=N, N > 0), these should map to the last N encounters in this sighting
                 if len(enc_anns) > 0:
                     enc_res = result.get('encounters', [])
+                    # enc_res *should* be in order added (e.g. sorted by version)
+                    # note however, i am not 100% sure if sightings.encounters is in same order!  it appears to be in all my testing.
+                    #  in the event it proves not to be, we should trust enc_res order and/or .version on each of sighting.encounters
                     assert len(enc_res) == len(
                         sighting.encounters
                     )  # more just a sanity-check

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -281,7 +281,7 @@ class Sightings(Resource):
         except Exception as ex:
             cleanup.rollback_and_abort(
                 'Invalid encounter.annotations',
-                'loading annotations threw %r on encounters=%r' % (ex, enc_json),
+                '_validate_annotations() threw %r on encounters=%r' % (ex, enc_json),
             )
 
         asset_references = request_in.get('assetReferences')
@@ -477,7 +477,7 @@ class SightingByID(Resource):
             except Exception as ex:
                 cleanup.rollback_and_abort(
                     'Invalid encounter.annotations',
-                    'loading annotations threw %r on encounters=%r' % (ex, enc_json),
+                    '_validate_annotations() threw %r on encounters=%r' % (ex, enc_json),
                 )
 
             result = None

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -245,18 +245,12 @@ def test_create_anon_and_delete_sighting(db, flask_app_client, staff_user, test_
     assert response.json['success']
     assets = sorted(response.json['result']['assets'], key=lambda a: a['filename'])
     asset_guids = [a['guid'] for a in assets]
-    assert assets == [
-        {
-            'filename': 'fluke.jpg',
-            'guid': asset_guids[0],
-            'src': f'/api/v1/assets/src/{asset_guids[0]}',
-        },
-        {
-            'filename': 'zebra.jpg',
-            'guid': asset_guids[1],
-            'src': f'/api/v1/assets/src/{asset_guids[1]}',
-        },
-    ]
+    assert assets[0]['filename'] == 'fluke.jpg'
+    assert assets[0]['guid'] == asset_guids[0]
+    assert assets[0]['src'] == f'/api/v1/assets/src/{asset_guids[0]}'
+    assert assets[1]['filename'] == 'zebra.jpg'
+    assert assets[1]['guid'] == asset_guids[1]
+    assert assets[1]['src'] == f'/api/v1/assets/src/{asset_guids[1]}'
 
     # Check sighting and assets are stored in the database
     sighting_id = response.json['result']['id']

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -321,3 +321,92 @@ def test_create_anon_and_delete_sighting(db, flask_app_client, staff_user, test_
     sighting_utils.cleanup_tus_dir(transaction_id)
     sighting_utils.delete_sighting(flask_app_client, staff_user, sighting_id)
     new_user.delete()
+
+
+def test_annotations_within_sightings(
+    db, flask_app_client, researcher_1, test_root, staff_user, test_clone_asset_group_data
+):
+    # transaction_id, test_filename = sighting_utils.prep_tus_dir(test_root)
+    # this should fail, as this it contains an invalid annotation
+    data_in = {
+        'startTime': timestamp,
+        'context': 'test',
+        'locationId': 'test',
+        'encounters': [
+            {'locationId': 'enc1'},
+            {
+                'locationId': 'enc2',
+                'annotations': [{'guid': '20000000-1000-7000-0000-000000000000'}],
+            },
+        ],
+    }
+    response = sighting_utils.create_sighting(
+        flask_app_client, researcher_1, expected_status_code=400, data_in=data_in
+    )
+    assert not response.json['success']
+    assert response.json['passed_message'] == 'Invalid encounter.annotations'
+
+    # now lets try a valid annotation
+    from tests.modules.annotations.resources import utils as annot_utils
+    from tests.modules.asset_groups.resources import utils as sub_utils
+    from app.modules.encounters.models import Encounter
+
+    sub_utils.clone_asset_group(
+        flask_app_client,
+        researcher_1,
+        test_clone_asset_group_data['asset_group_uuid'],
+    )
+
+    response = annot_utils.create_annotation_simple(
+        flask_app_client,
+        researcher_1,
+        test_clone_asset_group_data['asset_uuids'][0],
+    )
+    annot0_guid = response.json['guid']
+
+    data_in['encounters'][1]['annotations'][0]['guid'] = annot0_guid
+    response = sighting_utils.create_sighting(
+        flask_app_client, researcher_1, expected_status_code=200, data_in=data_in
+    )
+    assert response.json['success']
+    sighting_id = response.json['result']['id']
+    assert len(response.json['result']['encounters']) == 2
+    enc_guid = response.json['result']['encounters'][1]['id']
+    enc = Encounter.query.get(enc_guid)
+    assert enc is not None
+    assert len(enc.annotations) == 1
+    assert str(enc.annotations[0].guid) == annot0_guid
+
+    # now try patching in an encounter (with annotation) to this sighting
+    response = annot_utils.create_annotation_simple(
+        flask_app_client,
+        researcher_1,
+        test_clone_asset_group_data['asset_uuids'][0],
+        ia_class='test2',  # to keep this annot unique from annot0, in theory
+    )
+    annot1_guid = response.json['guid']
+
+    response = sighting_utils.patch_sighting(
+        flask_app_client,
+        researcher_1,
+        sighting_id,
+        patch_data=[
+            {
+                'op': 'add',
+                'path': '/encounters',
+                'value': {
+                    'locationId': 'encounter_patch_add_with_annotations',
+                    'annotations': [{'guid': annot1_guid}],
+                },
+            }
+        ],
+    )
+    assert len(response.json['result']['encounters']) == 3
+    enc_guid = response.json['result']['encounters'][2]['id']
+    enc = Encounter.query.get(enc_guid)
+    assert enc is not None
+    assert len(enc.annotations) == 1
+    assert str(enc.annotations[0].guid) == annot1_guid
+
+    # cleanup
+    sighting_utils.delete_sighting(flask_app_client, staff_user, sighting_id)

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -403,5 +403,7 @@ def test_annotations_within_sightings(
     assert str(enc.annotations[0].guid) == annot1_guid
 
     # cleanup
+    annot_utils.delete_annotation(flask_app_client, researcher_1, annot0_guid)
+    annot_utils.delete_annotation(flask_app_client, researcher_1, annot1_guid)
     sighting_utils.delete_sighting(flask_app_client, staff_user, sighting_id)
     clone.cleanup()

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -345,7 +345,7 @@ def test_annotations_within_sightings(
     from tests.modules.asset_groups.resources import utils as sub_utils
     from app.modules.encounters.models import Encounter
 
-    sub_utils.clone_asset_group(
+    clone = sub_utils.clone_asset_group(
         flask_app_client,
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
@@ -404,3 +404,4 @@ def test_annotations_within_sightings(
 
     # cleanup
     sighting_utils.delete_sighting(flask_app_client, staff_user, sighting_id)
+    clone.cleanup()


### PR DESCRIPTION
## Pull Request Overview

- Encounter data can now contain `annotations: [ { guid: ANN1 }, { guid: ANN2 }, ... ]`
- via POST /api/v1/sightings
- via PATCH /api/v1/sightings `op=add` `path=/encounters` `value={ enc-data }`
- contains [bonus commit](https://github.com/WildMeOrg/houston/pull/238/commits/eaafb0d17de07fb82ca6b4f064f2c860a1a8850b) to with some schema change