### PR TITLE
DEX-371 and DEX 372 Refactor patching so that it's inside the config, not the full config

### DIFF
--- a/app/modules/asset_groups/parameters.py
+++ b/app/modules/asset_groups/parameters.py
@@ -3,6 +3,8 @@
 Input arguments (Parameters) for Asset_groups resources RESTful API
 -----------------------------------------------------------
 """
+import logging
+import uuid
 
 from flask_restx_patched import Parameters, PatchJSONParameters
 from flask_login import current_user  # NOQA
@@ -10,6 +12,8 @@ from flask_login import current_user  # NOQA
 from . import schemas
 from .models import AssetGroup
 from app.modules.users.permissions import rules
+
+log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class CreateAssetGroupParameters(Parameters, schemas.CreateAssetGroupSchema):
@@ -53,16 +57,50 @@ class PatchAssetGroupDetailsParameters(PatchJSONParameters):
 class PatchAssetGroupSightingDetailsParameters(PatchJSONParameters):
     # pylint: disable=abstract-method,missing-docstring
     OPERATION_CHOICES = (PatchJSONParameters.OP_REPLACE, PatchJSONParameters.OP_ADD)
-    VALID_FIELDS = ['config']
-    PATH_CHOICES = tuple('/%s' % field for field in VALID_FIELDS)
+    # These don't exist as entities in the AssetGroupSighting, they're just config blobs
+    # but we allow patching faking them to be real
+    PATH_CHOICES = (
+        '/bearing',
+        '/behavior',
+        '/comments',
+        '/context',
+        '/customFields',
+        '/decimalLatitude',
+        '/decimalLongitude',
+        '/distance',
+        '/encounters',
+        '/endTime',
+        '/locationId',
+        '/startTime',
+        '/taxonomies',
+        '/verbatimLocality',
+        '/idConfigs',
+        '/assetReferences',
+        # TODO name not implemented, should it be?
+    )
 
     @classmethod
     def add(cls, obj, field, value, state):
         # Add and replace are the same operation so reuse the one method
         return cls.replace(obj, field, value, state)
 
+    # Asset ref patching is different enough from asset ref creation to not to be able to reuse the
+    # metadata functionality
+    @classmethod
+    def validate_asset_references(cls, obj, asset_refs):
+        from .metadata import AssetGroupMetadataError
+
+        for filename in asset_refs:
+            # asset must exist and must be part of the group
+            if not obj.asset_group.get_asset_for_file(filename):
+                raise AssetGroupMetadataError(
+                    f'{filename} not in Group for assetGroupSighting {obj.guid}'
+                )
+
     @classmethod
     def replace(cls, obj, field, value, state):
+        # Reuse metadata methods to validate ID Config
+        from .metadata import AssetGroupMetadata
 
         ret_val = False
 
@@ -71,6 +109,95 @@ class PatchAssetGroupSightingDetailsParameters(PatchJSONParameters):
             # PatchAssetGroupSightingMetadata, this assumes that the data is valid
             obj.config = value
             ret_val = True
+        elif field == 'idConfigs':
+            # Raises AssetGroupMetadataError on error which is intentionally unnhandled
+            AssetGroupMetadata.validate_id_configs(value, f'Sighting {obj.guid}')
+            obj.config[field] = value
+            ret_val = True
+        elif field == 'encounters':
+            AssetGroupMetadata.validate_encounters(value, f'Sighting {obj.guid}')
+            obj.config[field] = value
+            # All encounters in the metadata need to be allocated a pseudo ID for later patching
+            for encounter_num in range(len(obj.config['encounters'])):
+                if 'guid' not in obj.config['encounters'][encounter_num]:
+                    obj.config['encounters'][encounter_num]['guid'] = str(uuid.uuid4())
+            ret_val = True
+        elif field == 'assetReferences':
+            # Only supports patch of all refs as one operation
+            # Raises AssetGroupMetadataError on error which is intentionally unnhandled
+            cls.validate_asset_references(obj, value)
+            obj.config[field] = value
+            ret_val = True
+        else:
+            obj.config[field] = value
+            ret_val = True
+        return ret_val
+
+    @classmethod
+    def remove(cls, obj, field, value, state):
+        raise NotImplementedError()
+
+
+class PatchAssetGroupSightingEncounterDetailsParameters(PatchJSONParameters):
+    # pylint: disable=abstract-method,missing-docstring
+    OPERATION_CHOICES = (PatchJSONParameters.OP_REPLACE, PatchJSONParameters.OP_ADD)
+    # These don't exist as entities in the AssetGroupSighting, they're just config blobs
+    # but we allow patching faking them to be real
+    PATH_CHOICES = (
+        '/behavior',
+        '/comments',
+        '/customFields',
+        '/decimalLatitude',
+        '/decimalLongitude',
+        '/lifeStage',
+        '/locationId',
+        '/sex',
+        '/taxonomy',
+        '/time',
+        '/timeValues',
+        '/verbatimLocality',
+        '/ownerEmail',
+        '/annotations',
+        # TODO name and individualUuid are not here, should they be?
+    )
+
+    @classmethod
+    def add(cls, obj, field, value, state):
+        # Add and replace are the same operation so reuse the one method
+        return cls.replace(obj, field, value, state)
+
+    @classmethod
+    def replace(cls, obj, field, value, state):
+        # Reuse metadata methods to validate fields
+        from .metadata import AssetGroupMetadata, AssetGroupMetadataError
+
+        ret_val = False
+
+        assert 'encounter_uuid' in state
+        encounter_uuid = state['encounter_uuid']
+        encounter_metadata = {}
+        for encounter_num in range(len(obj.config['encounters'])):
+            if obj.config['encounters'][encounter_num]['guid'] == str(encounter_uuid):
+                encounter_metadata = obj.config['encounters'][encounter_num]
+                break
+        if not encounter_metadata:
+            raise AssetGroupMetadataError(
+                f'Encounter {encounter_uuid} not found in AssetGroupSighting {obj.guid}'
+            )
+
+        if field == 'ownerEmail':
+            AssetGroupMetadata.validate_owner_email(value, f'Encounter {encounter_uuid}')
+            encounter_metadata[field] = value
+            ret_val = True
+        elif field == 'annotations':
+            AssetGroupMetadata.validate_annotations(value, f'Encounter {encounter_uuid}')
+            encounter_metadata[field] = value
+            ret_val = True
+        else:
+            encounter_metadata[field] = value
+            ret_val = True
+        # force the write to the database
+        obj.config = obj.config
         return ret_val
 
     @classmethod

--- a/tasks/app/job_control.py
+++ b/tasks/app/job_control.py
@@ -73,9 +73,13 @@ def get_jobs_for_annotation(annotation_guid, verbose):
     annot = Annotation.query.get(annotation_guid)
     if not annot:
         print(f'Annotation {annotation_guid} not found')
-        return []
+        return {}
 
-    return annot.encounter.sighting.get_job_details(annotation_guid, verbose)
+    if annot.encounter:
+        return annot.encounter.sighting.get_job_details(annotation_guid, verbose)
+    else:
+        print(f'Annotation {annotation_guid} not connected to an encounter')
+        return {}
 
 
 @app_context_task()

--- a/tests/modules/asset_groups/resources/test_commit_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_commit_asset_group.py
@@ -3,6 +3,7 @@
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.modules.sightings.resources.utils as sighting_utils
 import tests.extensions.tus.utils as tus_utils
+from tests import utils as test_utils
 
 
 # Test a bunch of failure scenarios
@@ -127,21 +128,26 @@ def test_commit_asset_group_ia(
             flask_app_client, db, researcher_1, asset_group_sighting_guid, asset_uuid
         )
 
-        ia_config = {
-            'algorithms': [
-                'noddy',
-            ],
-        }
-        asset_group_utils.patch_in_ia_config(
-            flask_app_client, researcher_1, asset_group_sighting_guid, ia_config, 400
+        ia_configs = [
+            {
+                'algorithms': [
+                    'noddy',
+                ],
+            }
+        ]
+        patch_data = [test_utils.patch_replace_op('idConfigs', ia_configs)]
+        asset_group_utils.patch_asset_group_sighting(
+            flask_app_client, researcher_1, asset_group_sighting_guid, patch_data, 400
         )
-        ia_config['matchingSetDataOwners'] = 'someone_elses'
-        asset_group_utils.patch_in_ia_config(
-            flask_app_client, researcher_1, asset_group_sighting_guid, ia_config, 400
+        ia_configs[0]['matchingSetDataOwners'] = 'someone_elses'
+        patch_data = [test_utils.patch_replace_op('idConfigs', ia_configs)]
+        asset_group_utils.patch_asset_group_sighting(
+            flask_app_client, researcher_1, asset_group_sighting_guid, patch_data, 400
         )
-        ia_config['matchingSetDataOwners'] = 'mine'
-        asset_group_utils.patch_in_ia_config(
-            flask_app_client, researcher_1, asset_group_sighting_guid, ia_config, 200
+        ia_configs[0]['matchingSetDataOwners'] = 'mine'
+        patch_data = [test_utils.patch_replace_op('idConfigs', ia_configs)]
+        asset_group_utils.patch_asset_group_sighting(
+            flask_app_client, researcher_1, asset_group_sighting_guid, patch_data, 200
         )
 
         response = asset_group_utils.commit_asset_group_sighting(

--- a/tests/modules/asset_groups/resources/test_create_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_create_asset_group.py
@@ -100,18 +100,18 @@ def test_create_asset_group(flask_app_client, researcher_1, readonly_user, test_
             metadata_dict = json.load(asset_group_metadata_file)
         file_json = metadata_dict.get('frontend_sightings_data')
         request_json = data.get()
-        # Stored data is a superset of what was sent so ony check fields sent
+        # Stored data is a superset of what was sent so only check fields sent
         for key in request_json.keys():
             if key != 'sightings':
                 assert request_json[key] == file_json[key]
             else:
                 for sighting_num in range(len(request_json['sightings'])):
                     for sighting_key in request_json['sightings'][sighting_num].keys():
-                        assert (
-                            request_json[key][sighting_num][sighting_key]
-                            == file_json[key][sighting_num][sighting_key]
-                        )
-
+                        if sighting_key != 'encounters':
+                            assert (
+                                request_json[key][sighting_num][sighting_key]
+                                == file_json[key][sighting_num][sighting_key]
+                            )
     finally:
         if asset_group_uuid:
             asset_group_utils.delete_asset_group(

--- a/tests/modules/asset_groups/resources/test_patch_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_patch_asset_group.py
@@ -30,20 +30,22 @@ def test_patch_asset_group(flask_app_client, researcher_1, regular_user, test_ro
         group_sighting = asset_group_utils.read_asset_group_sighting(
             flask_app_client, researcher_1, asset_group_sighting_guid
         )
-        assert 'assets' in group_sighting.json
+
+        assert 'config' in group_sighting.json
+        assert 'assetReferences' in group_sighting.json['config']
         import copy
 
-        new_absent_file = copy.deepcopy(group_sighting.json['config'])
-        new_absent_file['assetReferences'].append('absent_file.jpg')
-        patch_data = [utils.patch_replace_op('config', new_absent_file)]
+        new_absent_file = copy.deepcopy(group_sighting.json['config']['assetReferences'])
+        new_absent_file.append('absent_file.jpg')
+        patch_data = [utils.patch_replace_op('assetReferences', new_absent_file)]
         asset_group_utils.patch_asset_group_sighting(
             flask_app_client, researcher_1, asset_group_sighting_guid, patch_data, 400
         )
 
         # Valid patch, adding a new encounter with an existing file
-        new_encounter = copy.deepcopy(group_sighting.json['config'])
-        new_encounter['encounters'].append({'assetReferences': ['zebra.jpg']})
-        patch_data = [utils.patch_replace_op('config', new_encounter)]
+        new_encounters = copy.deepcopy(group_sighting.json['config']['encounters'])
+        new_encounters.append({})
+        patch_data = [utils.patch_replace_op('encounters', new_encounters)]
 
         # Should not work as contributor
         asset_group_utils.patch_asset_group_sighting(

--- a/tests/modules/assets/test_models.py
+++ b/tests/modules/assets/test_models.py
@@ -8,7 +8,7 @@ import uuid
 def set_up_assets(flask_app, db, test_root, admin_user, request):
     from app.modules.annotations.models import Annotation
     from app.modules.asset_groups.models import AssetGroup
-    from app.modules.asset_groups.metadata import CreateAssetGroupMetadata
+    from app.modules.asset_groups.metadata import AssetGroupMetadata
     from app.modules.sightings.models import Sighting, SightingAssets, SightingStage
 
     from tests.modules.asset_groups.resources.utils import TestCreationData
@@ -38,7 +38,7 @@ def set_up_assets(flask_app, db, test_root, admin_user, request):
     # Create asset group from metadata
     data = TestCreationData(transaction_id)
     data.set_sighting_field(-1, 'assetReferences', [jpg.name for jpg in jpgs])
-    metadata = CreateAssetGroupMetadata(data.get())
+    metadata = AssetGroupMetadata(data.get())
     with mock.patch(
         'app.modules.asset_groups.metadata.current_user', return_value=admin_user
     ):

--- a/tests/tasks/app/test_job_control.py
+++ b/tests/tasks/app/test_job_control.py
@@ -126,7 +126,7 @@ def test_sighting_identification_jobs(
         id_configs = [
             {
                 'algorithms': [
-                    'noddy',
+                    'Pie',
                 ],
                 'matchingSetDataOwners': 'mine',
             }
@@ -147,7 +147,7 @@ def test_sighting_identification_jobs(
                 job_output = stdout.getvalue()
                 assert 'Job ' in job_output
                 assert 'Active:True Started (UTC)' in job_output
-                assert 'algorithm:noddy' in job_output
+                assert 'algorithm:Pie' in job_output
 
                 # Simulate a valid response from Sage but don't actually send the request to Sage
                 with mock.patch.object(
@@ -161,7 +161,7 @@ def test_sighting_identification_jobs(
                     job_output = stdout.getvalue()
                     assert 'Job ' in job_output
                     assert 'Active:True Started (UTC)' in job_output
-                    assert 'algorithm:noddy' in job_output
+                    assert 'algorithm:Pie' in job_output
                     assert "Request:{'jobid': " in job_output
                     assert (
                         "Response:{'success': True, 'content': 'something'}" in job_output


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Patch of full AssetGroupConfig no longer supported, now patch individual params (and lists) within the config
- Encounters have a pseudo ID which is passed to (and probably ignored by EDM)
---
Start with looking at the changes in the app/modules/asset_groups/parameters.py. That's where the guys of the patchinig is going on. Couple of TODOs in here for things I'm not sure about.
Then the resources file shows how this is used. Note the uuid of the encounter is passed to the patch code via the state dict.  
The metadata file got refactored to move validation functionality to be classmethods so that the same validation can be called from the patch code. 
That meant that the metadata functyionality needed tidying as it no longer needed the validation of the patch of full config so could be simplified quite a bit. 
As per usual, changing the tests to work with the new way took much of the time although the utils did mean that this was done once rather than multiple times.    


