### PR TITLE
Fix test_create_and_modify_and_delete_sighting

### DIFF
--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -153,7 +153,7 @@ def test_create_and_modify_and_delete_sighting(
     ct = test_utils.all_count(db)
     assert ct['Encounter'] == orig_ct['Encounter'] + 3  # previously was + 2
     assert len(sighting.encounters) == 3
-    enc2_id = str(sighting.encounters[2].guid)
+    enc0_id, enc1_id, enc2_id = [str(e.guid) for e in sighting.encounters]
 
     # patch op=remove the one we just added to get us back to where we started
     response = sighting_utils.patch_sighting(
@@ -193,7 +193,7 @@ def test_create_and_modify_and_delete_sighting(
         ],
         expected_status_code=400,
     )
-    assert response.json['edm_status_code'] == 602
+    assert response.json['edm_status_code'] == 602, response.json
     # should still have same number encounters as above here
     ct = test_utils.all_count(db)
     assert ct['Encounter'] == orig_ct['Encounter'] + 1


### PR DESCRIPTION
When deleting an encounter from edm, the status code is 601 instead of
602, the difference is in the "details":

```
org.ecocean.api.ApiValueException: invalid encounter id=ee51557d-3307-4066-bfe1-0911b637bf7e
```

vs

```
org.ecocean.api.ApiDeleteCascadeException: org.ecocean.Occurrence@30793197[id=31ed46a3-3d30-41ac-b087-7fe00caa4785,fieldStudySite=<null>,fieldSurveyCode=<null>,sightingPlatform=<null>,decimalLatitude=<null>,decimalLongitude=<null>,individualCount=<null>,numEncounters=1] will be removed via cascade; aborting
```

What is happening in the test is that it tries to delete an encounter
that has already been deleted.  The reason for this is the test stores
`enc0_id` and `enc1_id` when there are 2 encounters and when another one
is added, the test does `enc2_id = str(sighting.encounters[2].guid)`
assuming that the newest encounter is at the end of
`sighting.encounters`.  That assumption isn't correct and so `enc2_id`
ends up being the same as `enc0_id` sometimes causing edm to return an
error.

