### PR TITLE
Dex 152 - patching encounters on individual

### DIFF
--- a/app/modules/individuals/parameters.py
+++ b/app/modules/individuals/parameters.py
@@ -51,7 +51,7 @@ class PatchIndividualDetailsParameters(PatchJSONParameters):
                         encounter = Encounter.query.filter(
                             Encounter.guid == encounter_guid
                         ).first()
-                        if encounter is not None and encounter not in obj.encounters:
+                        if encounter is not None and encounter in obj.encounters:
                             obj.remove_encounter(encounter)
                             ret_val = True
         return ret_val

--- a/app/modules/individuals/parameters.py
+++ b/app/modules/individuals/parameters.py
@@ -5,10 +5,7 @@ Input arguments (Parameters) for Individuals resources RESTful API
 """
 from flask_restx_patched import Parameters, PatchJSONParameters
 from . import schemas
-from app.modules.users.permissions import rules
-from app.modules.users.permissions.types import AccessOperation
 import logging
-import uuid
 
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name

--- a/app/modules/individuals/parameters.py
+++ b/app/modules/individuals/parameters.py
@@ -35,14 +35,9 @@ class PatchIndividualDetailsParameters(PatchJSONParameters):
         PatchJSONParameters.OP_REMOVE,
     )
 
-    # Is this weird? I need to modify EDM and Houston records
-    PATH_CHOICES_HOUSTON = ['encounters']
+    PATH_CHOICES_EDM = ('/encounters',)
 
-    PATH_CHOICES_EDM = ['encounters']
-
-    PATH_CHOICES = tuple(
-        '/%s' % field for field in (PATH_CHOICES_EDM + PATH_CHOICES_HOUSTON)
-    )
+    PATH_CHOICES = PATH_CHOICES_EDM
 
     @classmethod
     def remove(cls, obj, field, value, state):

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -269,10 +269,6 @@ class IndividualByID(Resource):
 
         db.session.merge(individual)
 
-        import utool
-
-        utool.embed()
-
         return individual
 
     @api.permission_required(

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -228,7 +228,7 @@ class IndividualByID(Resource):
         for arg in args:
             if (
                 'path' in arg
-                and arg['path'][1:]
+                and arg['path']
                 in parameters.PatchIndividualDetailsParameters.PATH_CHOICES_EDM
             ):
                 edm_count += 1

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -223,16 +223,13 @@ class IndividualByID(Resource):
                 args, obj=individual
             )
 
-        # copycat the pattern established in sightings module
-        edm_count = 0
-        for arg in args:
-            if (
-                'path' in arg
-                and arg['path']
-                in parameters.PatchIndividualDetailsParameters.PATH_CHOICES_EDM
-            ):
-                edm_count += 1
-        if edm_count > 0 and edm_count != len(args):
+        edm_args = [
+            arg
+            for arg in args
+            if arg['path'] in parameters.PatchIndividualDetailsParameters.PATH_CHOICES_EDM
+        ]
+
+        if len(edm_args) > 0 and len(edm_args) != len(args):
             log.error(f'Mixed edm/houston patch called with args {args}')
             abort(
                 success=False,
@@ -241,7 +238,7 @@ class IndividualByID(Resource):
                 code=400,
             )
 
-        if edm_count > 0:
+        if len(edm_args) > 0:
             log.debug(f'wanting to do edm patch on args={args}')
             result = None
             try:
@@ -252,7 +249,7 @@ class IndividualByID(Resource):
                 ) = current_app.edm.request_passthrough_parsed(
                     'individual.data',
                     'patch',
-                    {'data': args},
+                    {'data': edm_args},
                     individual.guid,
                     request_headers=request.headers,
                 )

--- a/tests/modules/individuals/resources/test_individual_crud.py
+++ b/tests/modules/individuals/resources/test_individual_crud.py
@@ -171,13 +171,11 @@ def test_add_remove_encounters(db, flask_app_client, researcher_1):
         utils.patch_add_op('encounters', [str(enc_2.guid)]),
     ]
 
-    import json
-
     individual_utils.patch_individual(
         flask_app_client,
         researcher_1,
         '%s' % individual_1.guid,
-        patch_data=json.dumps(add_encounters),
+        patch_data=add_encounters,
         headers=None,
         expected_status_code=200,
     )
@@ -195,7 +193,7 @@ def test_add_remove_encounters(db, flask_app_client, researcher_1):
         flask_app_client,
         researcher_1,
         '%s' % individual_1.guid,
-        json.dumps(remove_encounters),
+        remove_encounters,
         None,
         200,
     )
@@ -213,7 +211,7 @@ def test_add_remove_encounters(db, flask_app_client, researcher_1):
         flask_app_client,
         researcher_1,
         '%s' % individual_1.guid,
-        json.dumps(add_encounters),
+        add_encounters,
         None,
         200,
     )

--- a/tests/modules/individuals/resources/test_individual_crud.py
+++ b/tests/modules/individuals/resources/test_individual_crud.py
@@ -4,9 +4,11 @@ import logging
 
 # import json
 import uuid
+import datetime
 from app.modules.individuals.models import Individual
 
 from tests.modules.individuals.resources import utils as individual_utils
+from tests.modules.sightings.resources import utils as sighting_utils
 
 from tests import utils
 
@@ -91,65 +93,148 @@ def test_read_encounter_from_edm(db, flask_app_client):
         db.session.delete(temp_enc)
 
 
-def test_add_remove_encounters(db, flask_app_client, researcher_1, empty_individual):
+def test_add_remove_encounters(db, flask_app_client, researcher_1):
 
-    mod_enc_1 = utils.generate_encounter_instance(
+    enc_1 = utils.generate_encounter_instance(
         user_email='mod1@user', user_password='mod1user', user_full_name='Test User'
     )
-    mod_enc_2 = utils.generate_encounter_instance(
+    enc_2 = utils.generate_encounter_instance(
         user_email='mod2@user', user_password='mod2user', user_full_name='Test User'
     )
+    enc_3 = utils.generate_encounter_instance(
+        user_email='mod3@user', user_password='mod3user', user_full_name='Test User'
+    )
+
+    owner_1 = utils.generate_user_instance(
+        email='owner@localhost',
+        is_researcher=True,
+    )
+
+    data_in = {
+        'startTime': datetime.datetime.now().isoformat() + 'Z',
+        'context': 'test',
+        'locationId': 'test',
+        'encounters': [
+            {},
+            {},
+            {},
+            {'locationId': 'Monster Island'},
+        ],
+    }
+    response = sighting_utils.create_sighting(
+        flask_app_client, researcher_1, expected_status_code=200, data_in=data_in
+    )
+
+    log.warning(
+        '********** test_add_remove_encounters TEST RESPONSE: ' + str(response.json)
+    )
+
+    from app.modules.sightings.models import Sighting
+
+    sighting_id = response.json['result']['id']
+    sighting = Sighting.query.get(sighting_id)
+
+    assert response.json['success']
+    result_data = response.json['result']
+
+    from app.modules.encounters.models import Encounter
+
+    enc_1.guid = result_data['encounters'][0]['id']
+    enc_1.guid = result_data['encounters'][1]['id']
+    enc_1.guid = result_data['encounters'][2]['id']
+    # enc_1 = Encounter(
+    #     guid=result_data['encounters'][0]['id'],
+    #     version=result_data['encounters'][1].get('version', 2),
+    #     owner_guid=researcher_1.guid,
+    # )
+    # enc_2 = Encounter(
+    #     guid=result_data['encounters'][0]['id'],
+    #     version=result_data['encounters'][1].get('version', 2),
+    #     owner_guid=researcher_1.guid,
+    # )
+    # enc_3 = Encounter(
+    #     guid=result_data['encounters'][0]['id'],
+    #     version=result_data['encounters'][1].get('version', 2),
+    #     owner_guid=researcher_1.guid,
+    # )
+    with db.session.begin():
+        # db.session.add(individual_1)
+        db.session.add(owner_1)
+        # db.session.add(enc_1)
+        # db.session.add(enc_2)
+        # db.session.add(enc_3)
+
+    sighting.add_encounter(enc_1)
+    sighting.add_encounter(enc_2)
+    sighting.add_encounter(enc_3)
 
     # You need to own an individual to modify it, and ownership is determined from it's encounters
-    mod_enc_1.owner = researcher_1
-    mod_enc_2.owner = researcher_1
+    enc_1.owner = owner_1
+    enc_2.owner = owner_1
+    enc_3.owner = owner_1
 
-    # let's start with one
-    empty_individual.add_encounter(mod_enc_1)
+    db.session.refresh(owner_1)
 
-    with db.session.begin():
-        db.session.add(empty_individual)
-        db.session.add(mod_enc_1)
-        db.session.add(mod_enc_2)
+    response = individual_utils.create_individual(
+        flask_app_client, owner_1, 200, {'encounters': [{'id': str(enc_1.guid)}]}
+    )
+    individual_1 = Individual.query.get(response.json['result']['id'])
 
-    assert str(mod_enc_1.guid) in [
-        str(encounter.guid) for encounter in empty_individual.get_encounters()
+    # # let's start with one
+    # individual_1.add_encounter(enc_1)
+
+    assert str(enc_1.guid) in [
+        str(encounter.guid) for encounter in individual_1.get_encounters()
     ]
 
     add_encounters = [
-        utils.patch_add_op('encounters', [str(mod_enc_2.guid)]),
+        utils.patch_add_op('encounters', [str(enc_2.guid)]),
     ]
 
     individual_utils.patch_individual(
         flask_app_client,
-        '%s' % empty_individual.guid,
+        '%s' % individual_1.guid,
         researcher_1,
         add_encounters,
         200,
     )
 
-    assert str(mod_enc_2.guid) in [
-        str(encounter.guid) for encounter in empty_individual.get_encounters()
+    assert str(enc_2.guid) in [
+        str(encounter.guid) for encounter in individual_1.get_encounters()
     ]
 
     # remove the one we just verified was there
     remove_encounters = [
-        utils.patch_remove_op('encounters', [str(mod_enc_1.guid)]),
+        utils.patch_remove_op('encounters', [str(enc_1.guid)]),
     ]
 
     individual_utils.patch_individual(
         flask_app_client,
-        '%s' % empty_individual.guid,
+        '%s' % individual_1.guid,
         researcher_1,
         remove_encounters,
         200,
     )
 
-    assert str(mod_enc_1.guid) not in [
-        str(encounter.guid) for encounter in empty_individual.get_encounters()
+    assert str(enc_1.guid) not in [
+        str(encounter.guid) for encounter in individual_1.get_encounters()
     ]
 
-    with db.session.begin():
-        db.session.delete(mod_enc_1)
-        db.session.delete(mod_enc_2)
-        db.session.delete(empty_individual)
+    # okay, now with multiple
+    add_encounters = [
+        utils.patch_add_op('encounters', [str(enc_1.guid), str(enc_3.guid)]),
+    ]
+
+    individual_utils.patch_individual(
+        flask_app_client,
+        '%s' % individual_1.guid,
+        researcher_1,
+        add_encounters,
+        200,
+    )
+
+    assert str(enc_1.guid), str(enc_3.guid) in [
+        str(encounter.guid) for encounter in individual_1.get_encounters()
+    ]
+
+    sighting.delete_cascade()

--- a/tests/modules/individuals/resources/utils.py
+++ b/tests/modules/individuals/resources/utils.py
@@ -54,18 +54,21 @@ def delete_individual(flask_app_client, user, guid, expected_status_code=204):
 
 
 def patch_individual(
-    flask_app_client, individual_guid, user, data, expected_status_code=200
+    flask_app_client,
+    user,
+    individual_guid,
+    patch_data=[],
+    headers=None,
+    expected_status_code=200,
 ):
     with flask_app_client.login(user, auth_scopes=('individuals:write',)):
         response = flask_app_client.patch(
             '%s%s' % (PATH, individual_guid),
+            data=json.dumps(patch_data),
             content_type='application/json',
-            data=json.dumps(data),
+            headers=headers,
         )
-    if expected_status_code == 200:
-        test_utils.validate_dict_response(response, 200, {'guid'})
-    else:
-        test_utils.validate_dict_response(
-            response, expected_status_code, {'status', 'message'}
-        )
+
+    assert isinstance(response.json, dict)
+    assert response.status_code == expected_status_code
     return response


### PR DESCRIPTION
This enables patching encounters and includes the passthrough work in EDM to modify more fields. 

Patching the encounters on a Individual can accept a list: 

`           
 patch_data=[
                {'op': 'remove', 'path': '/encounters', 'value': [str(GUID), str(GUID)] },
],
`
