### PR TITLE
DEX-386 remove unused AssetGroupStreamlined API as it's not needed

### DIFF
--- a/tests/modules/asset_groups/resources/test_upload_file.py
+++ b/tests/modules/asset_groups/resources/test_upload_file.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import filecmp
-from os.path import join, basename
+from os.path import basename
 
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.extensions.tus.utils as tus_utils
@@ -34,60 +33,6 @@ def test_create_open_submission(flask_app_client, regular_user, test_root, db):
         }
         # TODO this is what the test checked, that there was not commit, what we are now specifically not permitting
         # assert temp_submission.commit is None
-    finally:
-        # Restore original state
-        if temp_submission is not None:
-            temp_submission.delete()
-
-
-def test_submission_streamlined(flask_app_client, test_root, regular_user, db):
-    # pylint: disable=invalid-name
-    temp_submission = None
-
-    try:
-        from app.modules.asset_groups.models import AssetGroup, AssetGroupMajorType
-
-        test_major_type = AssetGroupMajorType.test
-
-        test_image_list = ['zebra.jpg', 'fluke.jpg']
-        files = [
-            _upload_content(join(test_root, filename)) for filename in test_image_list
-        ]
-
-        with flask_app_client.login(regular_user, auth_scopes=('asset_groups:write',)):
-            response = flask_app_client.post(
-                '/api/v1/asset_groups/streamlined',
-                data=dict(
-                    major_type=test_major_type,
-                    description='Test AssetGroup (streamlined)',
-                    files=files,
-                ),
-            )
-        # since we passed file descriptors to files we need to close them now
-        [f[0].close() for f in files]
-
-        temp_submission = AssetGroup.query.get(response.json['guid'])
-
-        assert response.status_code == 200
-        assert response.content_type == 'application/json'
-        assert isinstance(response.json, dict)
-        assert set(response.json.keys()) >= {
-            'guid',
-            'commit',
-            'major_type',
-            'owner_guid',
-        }
-
-        repo = temp_submission.get_repository()
-
-        # compares file in local repo
-        for filename in test_image_list:
-            local_filepath = join(test_root, filename)
-            repo_filepath = join(repo.working_tree_dir, '_asset_group', filename)
-            assert filecmp.cmp(local_filepath, repo_filepath)
-
-        assert temp_submission.commit == repo.head.object.hexsha
-        assert temp_submission.major_type == test_major_type
     finally:
         # Restore original state
         if temp_submission is not None:


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- AssetGroupStreamlined started off as an idea last year, it has since been suceeded by design decisions so should go 

---

