### PR TITLE
DEX-383 remove support for bulkUpload field

### DIFF
--- a/app/modules/asset_groups/metadata.py
+++ b/app/modules/asset_groups/metadata.py
@@ -248,9 +248,7 @@ class AssetGroupMetadata(object):
     @property
     def bulk_upload(self):
         assert self.data_processed >= AssetGroupMetadata.DataProcessed.first_level
-        return ('bulkUpload' in self.request and self.request['bulkUpload']) or (
-            'uploadType' in self.request and self.request['uploadType'] == 'bulk'
-        )
+        return 'uploadType' in self.request and self.request['uploadType'] == 'bulk'
 
     @property
     def location_id(self):
@@ -302,8 +300,7 @@ class AssetGroupMetadata(object):
 
         # Parse according to docs.google.com/document/d/11TMq1qzaQxva97M3XYwaEYYUawJ5VsrRXnJvTQR_nG0/edit?pli=1#
         top_level_fields = [
-            ('bulkUpload', bool, False),  # Temporary, to be removed
-            ('uploadType', str, False),  # Will become mandatory
+            ('uploadType', str, True),
             ('speciesDetectionModel', list, True),
             ('transactionId', str, False),
             ('sightings', list, True),
@@ -351,7 +348,7 @@ class AssetGroupMetadata(object):
         # Message was valid, is the user allowed to do so
         from app.modules.users.models import User
 
-        if 'bulkUpload' not in self.request and 'uploadType' not in self.request:
+        if 'uploadType' not in self.request:
             raise AssetGroupMetadataError(
                 "Use uploadType to define type 'bulk' or 'form'"
             )

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -539,10 +539,7 @@ class AssetGroup(db.Model, HoustonModel):
 
     @property
     def bulk_upload(self):
-        ret_val = False
-        if self.config and 'bulkUpload' in self.config:
-            ret_val = self.config['bulkUpload']
-        return ret_val
+        return 'uploadType' in self.request and self.request['uploadType'] == 'bulk'
 
     @property
     def anonymous(self):

--- a/tests/modules/asset_groups/resources/test_create_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_create_asset_group.py
@@ -16,6 +16,7 @@ def test_create_asset_group(flask_app_client, researcher_1, readonly_user, test_
 
     try:
         data = TestCreationData(transaction_id, False)
+        data.set_field('uploadType', 'form')
         data.set_field('description', 'This is a test asset_group, please ignore')
 
         resp_msg = 'speciesDetectionModel field missing from request'
@@ -75,7 +76,8 @@ def test_create_asset_group(flask_app_client, researcher_1, readonly_user, test_
         )
 
         data.set_sighting_field(0, 'assetReferences', [test_filename])
-        resp_msg = "Use uploadType to define type 'bulk' or 'form'"
+        data.remove_field('uploadType')
+        resp_msg = 'uploadType field missing from request'
         asset_group_utils.create_asset_group(
             flask_app_client, researcher_1, data.get(), 400, resp_msg
         )
@@ -212,12 +214,12 @@ def test_create_asset_group_anonymous(
         )
         data.remove_field('submitterEmail')
 
-        data.set_field('bulkUpload', True)
+        data.set_field('uploadType', 'bulk')
         resp_msg = 'anonymous users not permitted to do bulk upload'
         asset_group_utils.create_asset_group(
             flask_app_client, None, data.get(), 400, resp_msg
         )
-        data.set_field('bulkUpload', False)
+        data.set_field('uploadType', 'form')
 
         data.set_encounter_field(0, 0, 'ownerEmail', researcher_1.email)
         resp_msg = 'anonymous users not permitted to assign owners'

--- a/tests/modules/asset_groups/test_models.py
+++ b/tests/modules/asset_groups/test_models.py
@@ -73,7 +73,7 @@ def test_asset_group_sightings_jobs(flask_app, db, admin_user, test_root, reques
 def test_asset_group_sightings_bulk(
     flask_app, flask_app_client, db, admin_user, researcher_1, test_root, request
 ):
-    from app.modules.asset_groups.models import AssetGroup, AssetGroupSighting
+    from app.modules.asset_groups.models import AssetGroupSighting
 
     transaction_id, test_filename = asset_group_utils.create_bulk_tus_transaction(
         test_root
@@ -85,7 +85,6 @@ def test_asset_group_sightings_bulk(
             flask_app_client, researcher_1, data.get()
         )
         asset_group_uuid = resp.json['guid']
-        asset_group = AssetGroup.query.get(asset_group_uuid)
 
         # Make sure that both AGS' are created and have the correct locations
         ags1 = AssetGroupSighting.query.get(resp.json['asset_group_sightings'][0]['guid'])
@@ -96,12 +95,6 @@ def test_asset_group_sightings_bulk(
         # Due to DB interactions, cannot rely on the order
         assert sorted(ags.config['locationId'] for ags in (ags1, ags2)) == sorted(
             cnf['locationId'] for cnf in data.content['sightings']
-        )
-        asset_group = AssetGroup.query.get(asset_group_uuid)
-
-        assert (
-            asset_group.asset_group_sightings[0].config['locationId']
-            == data.content['sightings'][0]['locationId']
         )
 
     finally:


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- bulkUpload field now replaced with uploadType as agreed with Ben
- tests updated to reflect this

---


