### PR TITLE
DEX-387 ordering of entries by the guid in the DB to ensure that is the order used in the UI

### DIFF
--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -14,6 +14,22 @@ import logging
 def init_app(app, **kwargs):
     from importlib import import_module
 
+    # Import all models first for db.relationship to avoid model look up
+    # error:
+    #
+    # sqlalchemy.exc.InvalidRequestError: When initializing mapper
+    # mapped class AssetGroupSighting->asset_group_sighting, expression
+    # 'Sighting' failed to locate a name ('Sighting'). If this is a
+    # class name, consider adding this relationship() to the <class
+    # 'app.modules.asset_groups.models.AssetGroupSighting'> class after
+    # both dependent classes have been defined.
+    for module_name in app.config['ENABLED_MODULES']:
+        try:
+            import_module(f'.{module_name}.models', package=__name__)
+        except ModuleNotFoundError:
+            # Some modules don't have models and that's ok
+            pass
+
     for module_name in app.config['ENABLED_MODULES']:
         logging.debug('Init module %r' % (module_name,))
         import_module('.%s' % module_name, package=__name__).init_app(app, **kwargs)

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -40,7 +40,7 @@ class Annotation(db.Model, HoustonModel):
         index=True,
         nullable=False,
     )
-    asset = db.relationship('Asset', backref=db.backref('annotations'))
+    asset = db.relationship('Asset', back_populates='annotations')
 
     encounter_guid = db.Column(
         db.GUID,
@@ -48,7 +48,7 @@ class Annotation(db.Model, HoustonModel):
         index=True,
         nullable=True,
     )
-    encounter = db.relationship('Encounter', backref=db.backref('annotations'))
+    encounter = db.relationship('Encounter', back_populates='annotations')
     keyword_refs = db.relationship('AnnotationKeywords')
     ia_class = db.Column(db.String(length=255), nullable=False)
     bounds = db.Column(db.JSON, nullable=False)

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -464,7 +464,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
         self.job_complete(str(job_id))
 
     # Used to build the response to AssetGroupSighting GET
-    def assets(self):
+    def get_assets(self):
         from app.modules.assets.schemas import DetailedAssetSchema
 
         asset_schema = DetailedAssetSchema(

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -470,10 +470,13 @@ class AssetGroupSighting(db.Model, HoustonModel):
         asset_schema = DetailedAssetSchema(
             many=False, only=('guid', 'filename', 'src', 'annotations')
         )
-        resp = []
+        assets = []
         for filename in self.config.get('assetReferences'):
             asset = self.asset_group.get_asset_for_file(filename)
             assert asset
+            assets.append(asset)
+        resp = []
+        for asset in sorted(assets, key=lambda ast: ast.guid):
             json_msg, err = asset_schema.dump(asset)
             resp.append(json_msg)
         return resp
@@ -570,10 +573,12 @@ class AssetGroup(db.Model, HoustonModel):
     )
 
     asset_group_sightings = db.relationship(
-        'AssetGroupSighting', back_populates='asset_group'
+        'AssetGroupSighting',
+        back_populates='asset_group',
+        order_by='AssetGroupSighting.guid',
     )
 
-    assets = db.relationship('Asset', back_populates='asset_group')
+    assets = db.relationship('Asset', back_populates='asset_group', order_by='Asset.guid')
 
     def __repr__(self):
         return (

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -11,10 +11,15 @@ from flask_login import current_user  # NOQA
 import requests.exceptions
 import utool as ut
 
-from app.extensions import db, HoustonModel, parallel
 from app.extensions.gitlab import GitlabInitializationError
-from app.version import version
+from app.extensions import db, HoustonModel, parallel
+from app.modules.annotations.models import Annotation
+from app.modules.assets.models import Asset
+from app.modules.encounters.models import Encounter
+from app.modules.sightings.models import Sighting, SightingStage
+from app.modules.users.models import User
 from app.utils import HoustonException
+from app.version import version
 
 import logging
 import tqdm
@@ -112,9 +117,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
         index=True,
         nullable=False,
     )
-    asset_group = db.relationship(
-        'AssetGroup', backref=db.backref('asset_group_sightings')
-    )
+    asset_group = db.relationship('AssetGroup', back_populates='asset_group_sightings')
 
     # configuration metadata from the create request
     config = db.Column(db.JSON, nullable=True)
@@ -126,9 +129,6 @@ class AssetGroupSighting(db.Model, HoustonModel):
 
     def commit(self):
         from app.modules.utils import Cleanup
-        from app.modules.sightings.models import Sighting, SightingStage
-        from app.modules.encounters.models import Encounter
-        from app.modules.annotations.models import Annotation
 
         if self.stage != AssetGroupSightingStage.curation:
             raise HoustonException(
@@ -198,8 +198,6 @@ class AssetGroupSighting(db.Model, HoustonModel):
             try:
                 owner_guid = self.asset_group.owner_guid
                 if 'ownerEmail' in req_data:
-                    from app.modules.users.models import User
-
                     owner_email = req_data['ownerEmail']
                     encounter_owner = User.find(email=owner_email)
                     # Validated in the metadata code so must be correct
@@ -389,8 +387,6 @@ class AssetGroupSighting(db.Model, HoustonModel):
         return True
 
     def detected(self, job_id, data):
-        from app.modules.assets.models import Asset
-        from app.modules.annotations.models import Annotation
         import uuid
 
         if self.stage != AssetGroupSightingStage.detection:
@@ -561,7 +557,7 @@ class AssetGroup(db.Model, HoustonModel):
         db.GUID, db.ForeignKey('user.guid'), index=True, nullable=False
     )
     owner = db.relationship(
-        'User', backref=db.backref('asset_groups'), foreign_keys=[owner_guid]
+        'User', back_populates='asset_groups', foreign_keys=[owner_guid]
     )
 
     submitter_guid = db.Column(
@@ -569,9 +565,15 @@ class AssetGroup(db.Model, HoustonModel):
     )
     submitter = db.relationship(
         'User',
-        backref=db.backref('submitted_asset_groups'),
+        back_populates='submitted_asset_groups',
         foreign_keys=[submitter_guid],
     )
+
+    asset_group_sightings = db.relationship(
+        'AssetGroupSighting', back_populates='asset_group'
+    )
+
+    assets = db.relationship('Asset', back_populates='asset_group')
 
     def __repr__(self):
         return (
@@ -586,8 +588,6 @@ class AssetGroup(db.Model, HoustonModel):
 
     @property
     def anonymous(self):
-        from app.modules.users.models import User
-
         return self.owner is User.get_public_user()
 
     @property
@@ -842,8 +842,6 @@ class AssetGroup(db.Model, HoustonModel):
         if metadata.owner is not None and not metadata.owner.is_anonymous:
             group_owner = metadata.owner
         else:
-            from app.modules.users.models import User
-
             group_owner = User.get_public_user()
 
         if metadata.tus_transaction_id and not metadata.files:
@@ -892,8 +890,6 @@ class AssetGroup(db.Model, HoustonModel):
         if owner is not None and not owner.is_anonymous:
             group_owner = owner
         else:
-            from app.modules.users.models import User
-
             group_owner = User.get_public_user()
         asset_group = AssetGroup(
             major_type=AssetGroupMajorType.filesystem,
@@ -988,7 +984,6 @@ class AssetGroup(db.Model, HoustonModel):
             https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
             http://www.iana.org/assignments/media-types/media-types.xhtml
         """
-        from app.modules.assets.models import Asset
         import utool as ut
         import magic
 

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -27,6 +27,8 @@ class DetailedAssetGroupSightingSchema(BaseAssetGroupSightingSchema):
     Detailed Asset_group_sighting schema exposes all useful fields.
     """
 
+    assets = base_fields.Function(AssetGroupSighting.get_assets)
+
     completion = base_fields.Function(AssetGroupSighting.get_completion)
 
     class Meta(BaseAssetGroupSightingSchema.Meta):
@@ -34,7 +36,7 @@ class DetailedAssetGroupSightingSchema(BaseAssetGroupSightingSchema):
         fields = BaseAssetGroupSightingSchema.Meta.fields + (
             AssetGroupSighting.stage.key,
             AssetGroupSighting.config.key,
-            AssetGroupSighting.assets.__name__,
+            'assets',
             'completion',
         )
         dump_only = BaseAssetGroupSightingSchema.Meta.dump_only

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -56,9 +56,13 @@ class Asset(db.Model, HoustonModel):
     )
     asset_group = db.relationship('AssetGroup', back_populates='assets')
 
-    asset_sightings = db.relationship('SightingAssets', back_populates='asset')
+    asset_sightings = db.relationship(
+        'SightingAssets', back_populates='asset', order_by='SightingAssets.sighting_guid'
+    )
 
-    annotations = db.relationship('Annotation', back_populates='asset')
+    annotations = db.relationship(
+        'Annotation', back_populates='asset', order_by='Annotation.guid'
+    )
 
     def __repr__(self):
         return (

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -14,8 +14,6 @@ from PIL import Image
 import uuid
 import logging
 
-# In order to support sightings backref we must import the model definitions for sightings here
-from app.modules.sightings import models as sightings_models  # NOQA
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -56,9 +54,11 @@ class Asset(db.Model, HoustonModel):
         index=True,
         nullable=False,
     )
-    asset_group = db.relationship('AssetGroup', backref=db.backref('assets'))
+    asset_group = db.relationship('AssetGroup', back_populates='assets')
 
     asset_sightings = db.relationship('SightingAssets', back_populates='asset')
+
+    annotations = db.relationship('Annotation', back_populates='asset')
 
     def __repr__(self):
         return (

--- a/app/modules/collaborations/models.py
+++ b/app/modules/collaborations/models.py
@@ -5,7 +5,10 @@ Collaborations database models
 """
 import uuid
 import logging
+
 from app.extensions import db, HoustonModel
+from app.modules.users.models import User
+
 
 log = logging.getLogger(__name__)
 
@@ -78,8 +81,6 @@ class Collaboration(db.Model, HoustonModel):
             )
 
         for guid_index in range(len(user_guids)):
-            from app.modules.users.models import User
-
             user_tup = User.ensure_edm_obj(user_guids[guid_index])
 
             if user_tup is None or user_tup[0] is None:

--- a/app/modules/encounters/models.py
+++ b/app/modules/encounters/models.py
@@ -3,15 +3,10 @@
 Encounters database models
 --------------------
 """
+import uuid
 
 from app.extensions import db, FeatherModel
 from app.modules.individuals.models import Individual
-
-from app.modules.asset_groups import models as asset_groups_models  # NOQA
-from app.modules.assets import models as assets_models  # NOQA
-
-
-import uuid
 
 
 class Encounter(db.Model, FeatherModel):
@@ -24,32 +19,28 @@ class Encounter(db.Model, FeatherModel):
     )  # pylint: disable=invalid-name
     version = db.Column(db.BigInteger, default=None, nullable=True)
 
-    from app.modules.sightings.models import Sighting
-
     sighting_guid = db.Column(
         db.GUID, db.ForeignKey('sighting.guid'), index=True, nullable=True
     )
-    sighting = db.relationship('Sighting', backref=db.backref('encounters'))
-
-    from app.modules.individuals.models import Individual
+    sighting = db.relationship('Sighting', back_populates='encounters')
 
     individual_guid = db.Column(
         db.GUID, db.ForeignKey('individual.guid'), index=True, nullable=True
     )
-    individual = db.relationship('Individual', backref=db.backref('encounters'))
+    individual = db.relationship('Individual', back_populates='encounters')
 
     owner_guid = db.Column(
         db.GUID, db.ForeignKey('user.guid'), index=True, nullable=False
     )
     owner = db.relationship(
-        'User', backref=db.backref('owned_encounters'), foreign_keys=[owner_guid]
+        'User', back_populates='owned_encounters', foreign_keys=[owner_guid]
     )
 
     submitter_guid = db.Column(
         db.GUID, db.ForeignKey('user.guid'), index=True, nullable=True
     )
     submitter = db.relationship(
-        'User', backref=db.backref('submitted_encounters'), foreign_keys=[submitter_guid]
+        'User', back_populates='submitted_encounters', foreign_keys=[submitter_guid]
     )
 
     # Asset group sighting stores the configuration for this encounter,
@@ -61,6 +52,8 @@ class Encounter(db.Model, FeatherModel):
     public = db.Column(db.Boolean, default=False, nullable=False)
 
     projects = db.relationship('ProjectEncounter', back_populates='encounter')
+
+    annotations = db.relationship('Annotation', back_populates='encounter')
 
     def __repr__(self):
         return (

--- a/app/modules/encounters/models.py
+++ b/app/modules/encounters/models.py
@@ -51,9 +51,15 @@ class Encounter(db.Model, FeatherModel):
 
     public = db.Column(db.Boolean, default=False, nullable=False)
 
-    projects = db.relationship('ProjectEncounter', back_populates='encounter')
+    projects = db.relationship(
+        'ProjectEncounter',
+        back_populates='encounter',
+        order_by='ProjectEncounter.project_guid',
+    )
 
-    annotations = db.relationship('Annotation', back_populates='encounter')
+    annotations = db.relationship(
+        'Annotation', back_populates='encounter', order_by='Annotation.guid'
+    )
 
     def __repr__(self):
         return (

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -18,14 +18,16 @@ class Individual(db.Model, FeatherModel):
         db.GUID, default=uuid.uuid4, primary_key=True
     )  # pylint: disable=invalid-name
 
+    version = db.Column(db.BigInteger, default=None, nullable=True)
+
+    encounters = db.relationship('Encounter', back_populates='individual')
+
     def __repr__(self):
         return (
             '<{class_name}('
             'guid={self.guid}, '
             ')>'.format(class_name=self.__class__.__name__, self=self)
         )
-
-    version = db.Column(db.BigInteger, default=None, nullable=True)
 
     def get_encounters(self):
         return self.encounters

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -20,7 +20,9 @@ class Individual(db.Model, FeatherModel):
 
     version = db.Column(db.BigInteger, default=None, nullable=True)
 
-    encounters = db.relationship('Encounter', back_populates='individual')
+    encounters = db.relationship(
+        'Encounter', back_populates='individual', order_by='Encounter.guid'
+    )
 
     def __repr__(self):
         return (

--- a/app/modules/job_control/models.py
+++ b/app/modules/job_control/models.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 """Provides UI space served directly from this application"""
-
 import logging
+
+from app.modules.asset_groups.models import AssetGroupSighting
+from app.modules.sightings.models import Sighting
+
 
 log = logging.getLogger(__name__)
 
@@ -12,17 +15,11 @@ class JobControl(object):
     # Called by a periodic background task,
     @classmethod
     def check_jobs(cls):
-        from app.modules.asset_groups.models import AssetGroupSighting
-        from app.modules.sightings.models import Sighting
-
         AssetGroupSighting.check_jobs()
         Sighting.check_jobs()
 
     # Central point for all "job" related things to be accessed.
     @classmethod
     def print_jobs(cls):
-        from app.modules.asset_groups.models import AssetGroupSighting
-        from app.modules.sightings.models import Sighting
-
         AssetGroupSighting.print_jobs()
         Sighting.print_jobs()

--- a/app/modules/keywords/models.py
+++ b/app/modules/keywords/models.py
@@ -3,12 +3,11 @@
 Keywords database models
 --------------------
 """
-
-from app.extensions import db, HoustonModel
-
-import uuid
 import enum
 import logging
+import uuid
+
+from app.extensions import db, HoustonModel
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/app/modules/organizations/models.py
+++ b/app/modules/organizations/models.py
@@ -3,15 +3,16 @@
 Organizations database models
 --------------------
 """
-
-from flask import current_app
-from app.extensions import db, HoustonModel
-from app.extensions.edm import EDMObjectMixin
-
+import datetime
 import logging
 import uuid
-import datetime
+
+from flask import current_app
 import pytz
+
+from app.extensions.edm import EDMObjectMixin
+from app.extensions import db, HoustonModel
+from app.modules.users.models import User
 
 log = logging.getLogger(__name__)
 
@@ -54,7 +55,6 @@ class OrganizationEDMMixin(EDMObjectMixin):
     def ensure_edm_obj(cls, guid, owner=None):
 
         if owner is None:
-            from app.modules.users.models import User
             from flask_login import current_user
 
             candidates = [
@@ -89,8 +89,6 @@ class OrganizationEDMMixin(EDMObjectMixin):
         return utc_time.astimezone(current_app.config.get('TIMEZONE'))
 
     def _process_members(self, members):
-        from app.modules.users.models import User
-
         for member in members:
             log.info('Adding Member ID %s' % (member.id,))
             user, is_new = User.ensure_edm_obj(member.id)
@@ -167,7 +165,7 @@ class Organization(db.Model, HoustonModel, OrganizationEDMMixin):
     )
 
     owner_guid = db.Column(db.GUID, db.ForeignKey('user.guid'), index=True, nullable=True)
-    owner = db.relationship('User', backref=db.backref('owned_organizations'))
+    owner = db.relationship('User', back_populates='owned_organizations')
 
     def __repr__(self):
         return (

--- a/app/modules/projects/models.py
+++ b/app/modules/projects/models.py
@@ -3,11 +3,11 @@
 Projects database models
 --------------------
 """
+import uuid
 
 from sqlalchemy_utils import Timestamp
+
 from app.extensions import db, HoustonModel
-from app.modules.encounters import models as encounters_models  # NOQA
-import uuid
 
 
 # All many:many associations handled as Houston model classes to give control and history
@@ -52,7 +52,7 @@ class Project(db.Model, HoustonModel, Timestamp):
     owner_guid = db.Column(
         db.GUID, db.ForeignKey('user.guid'), index=True, nullable=False
     )
-    owner = db.relationship('User', backref=db.backref('owned_projects'))
+    owner = db.relationship('User', back_populates='owned_projects')
 
     def __repr__(self):
         return (

--- a/app/modules/projects/models.py
+++ b/app/modules/projects/models.py
@@ -47,7 +47,11 @@ class Project(db.Model, HoustonModel, Timestamp):
         'ProjectUserMembershipEnrollment', back_populates='project'
     )
 
-    encounter_members = db.relationship('ProjectEncounter', back_populates='project')
+    encounter_members = db.relationship(
+        'ProjectEncounter',
+        back_populates='project',
+        order_by='ProjectEncounter.encounter_guid',
+    )
 
     owner_guid = db.Column(
         db.GUID, db.ForeignKey('user.guid'), index=True, nullable=False

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -65,7 +65,9 @@ class Sighting(db.Model, FeatherModel):
 
     name = db.Column(db.String(length=120), nullable=True)
 
-    encounters = db.relationship('Encounter', back_populates='sighting')
+    encounters = db.relationship(
+        'Encounter', back_populates='sighting', order_by='Encounter.guid'
+    )
 
     def __repr__(self):
         return (

--- a/app/modules/site_settings/models.py
+++ b/app/modules/site_settings/models.py
@@ -3,7 +3,6 @@
 Site Settings database models
 --------------------
 """
-
 from sqlalchemy_utils import Timestamp
 
 from app.extensions import db
@@ -16,14 +15,12 @@ class SiteSetting(db.Model, Timestamp):
 
     key = db.Column(db.String, primary_key=True, nullable=False)
 
-    from app.modules.fileuploads.models import FileUpload
-
     # file_upload_guid can be changed to nullable if we have
     # non-fileupload site settings
     file_upload_guid = db.Column(
         db.GUID, db.ForeignKey('file_upload.guid', ondelete='CASCADE'), nullable=False
     )
-    file_upload = db.relationship(FileUpload, cascade='delete')
+    file_upload = db.relationship('FileUpload', cascade='delete')
     public = db.Column(db.Boolean, default=True, nullable=False)
 
     def __repr__(self):

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -5,6 +5,7 @@ User database models
 """
 import enum
 import logging
+import uuid
 
 from flask import current_app
 from sqlalchemy_utils import types as column_types
@@ -14,14 +15,6 @@ from app.extensions import db, FeatherModel
 from app.extensions.auth import security
 from app.extensions.edm import EDMObjectMixin
 from app.extensions.api.parameters import _get_is_static_role_property
-
-# In order to support OrganizationUserMemberships and OrganizationUserModerators
-# we must import the model definitions for organizations here
-from app.modules.organizations import models as organizations_models  # NOQA
-from app.modules.projects import models as projects_models  # NOQA
-from app.modules.collaborations import models as collaborations_models  # NOQA
-
-import uuid
 
 
 log = logging.getLogger(__name__)
@@ -172,6 +165,40 @@ class User(db.Model, FeatherModel, UserEDMMixin):
 
     user_collaboration_associations = db.relationship(
         'CollaborationUserAssociations', back_populates='user'
+    )
+
+    asset_groups = db.relationship(
+        'AssetGroup',
+        back_populates='owner',
+        primaryjoin='User.guid == AssetGroup.owner_guid',
+    )
+
+    submitted_asset_groups = db.relationship(
+        'AssetGroup',
+        back_populates='submitter',
+        primaryjoin='User.guid == AssetGroup.submitter_guid',
+    )
+
+    owned_encounters = db.relationship(
+        'Encounter',
+        back_populates='owner',
+        primaryjoin='User.guid == Encounter.owner_guid',
+    )
+
+    submitted_encounters = db.relationship(
+        'Encounter',
+        back_populates='submitter',
+        primaryjoin='User.guid == Encounter.submitter_guid',
+    )
+
+    owned_organizations = db.relationship(
+        'Organization',
+        back_populates='owner',
+        primaryjoin='User.guid == Organization.owner_guid',
+    )
+
+    owned_projects = db.relationship(
+        'Project', back_populates='owner', primaryjoin='User.guid == Project.owner_guid'
     )
 
     PUBLIC_USER_EMAIL = 'public@localhost'

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -171,34 +171,42 @@ class User(db.Model, FeatherModel, UserEDMMixin):
         'AssetGroup',
         back_populates='owner',
         primaryjoin='User.guid == AssetGroup.owner_guid',
+        order_by='AssetGroup.guid',
     )
 
     submitted_asset_groups = db.relationship(
         'AssetGroup',
         back_populates='submitter',
         primaryjoin='User.guid == AssetGroup.submitter_guid',
+        order_by='AssetGroup.guid',
     )
 
     owned_encounters = db.relationship(
         'Encounter',
         back_populates='owner',
         primaryjoin='User.guid == Encounter.owner_guid',
+        order_by='Encounter.guid',
     )
 
     submitted_encounters = db.relationship(
         'Encounter',
         back_populates='submitter',
         primaryjoin='User.guid == Encounter.submitter_guid',
+        order_by='Encounter.guid',
     )
 
     owned_organizations = db.relationship(
         'Organization',
         back_populates='owner',
         primaryjoin='User.guid == Organization.owner_guid',
+        order_by='Organization.guid',
     )
 
     owned_projects = db.relationship(
-        'Project', back_populates='owner', primaryjoin='User.guid == Project.owner_guid'
+        'Project',
+        back_populates='owner',
+        primaryjoin='User.guid == Project.owner_guid',
+        order_by='Project.guid',
     )
 
     PUBLIC_USER_EMAIL = 'public@localhost'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from importlib import import_module
 import os
 import pathlib
 import tempfile
@@ -11,6 +12,21 @@ from flask_login import current_user, login_user, logout_user
 from app import create_app
 
 from . import utils, TEST_ASSET_GROUP_UUID, TEST_EMPTY_ASSET_GROUP_UUID
+
+# Import all models first for db.relationship to avoid model look up
+# error:
+#
+# sqlalchemy.exc.InvalidRequestError: When initializing mapper
+# mapped class AssetGroupSighting->asset_group_sighting, expression
+# 'Sighting' failed to locate a name ('Sighting'). If this is a
+# class name, consider adding this relationship() to the <class
+# 'app.modules.asset_groups.models.AssetGroupSighting'> class after
+# both dependent classes have been defined.
+project_root = pathlib.Path(__file__).parent.parent
+for models in project_root.glob('app/modules/*/models.py'):
+    models_path = models.relative_to(project_root)
+    models_module = str(models_path).replace('.py', '').replace('/', '.')
+    import_module(models_module)
 
 
 # Force FLASK_CONFIG to be testing instead of using what's defined in the environment

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -425,7 +425,9 @@ def read_asset_group_sighting(
     else:
         response = flask_app_client.get(f'{PATH}sighting/{asset_group_sighting_guid}')
     if expected_status_code == 200:
-        test_utils.validate_dict_response(response, 200, {'guid', 'stage', 'config'})
+        test_utils.validate_dict_response(
+            response, 200, {'guid', 'stage', 'config', 'completion', 'assets'}
+        )
     else:
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message'}


### PR DESCRIPTION
## Pull Request Overview

- replacing all backrefs with back_populates : it makes knowing what's in the class easier and allows the order_by to be set 
- For non DB lists, use sorted to get them ordered by guid

---
~Draft as I want some feedback on this idea first~

---

**Edit:** 2021-08-03 by Karen

- Change backref to back_populates in db.relationship

  Using `back_populates` instead of `backref` means we have to define the
  relationship in both classes instead of auto generating it in the other
  class.  It might be easier to understand to the reader when looking at
  the code and it will allow us to specify "order_by" when it is a
  one-to-many relationship.
  
  Import all the models first in `app.modules.init_app` before doing other
  stuff to avoid model lookup error.  Do something similar in
  `tests/conftest.py` so importing DetailedUserSchema works (
  `pytest tests/test_transaction.py`)

- Move AssetGroupSighting.assets to AssetGroupSighting.get_assets

  Make it more obvious that we are using a function `get_assets` instead
  of like other relationship fields.
  
  This doesn't change how AssetGroupSighting is returned in json.

- DEX-387 ordering of entries by the guid in the DB to ensure that is the order used in the UI

