### PR TITLE
Use sage_detection background task in code

### DIFF
--- a/app/modules/asset_groups/tasks.py
+++ b/app/modules/asset_groups/tasks.py
@@ -82,7 +82,7 @@ def git_push(asset_group_guid):
 def sage_detection(asset_group_sighting_guid, model):
     from .models import AssetGroupSighting
 
-    asset_group_sighting = AssetGroupSighting.query.find(asset_group_sighting_guid)
+    asset_group_sighting = AssetGroupSighting.query.get(asset_group_sighting_guid)
     if asset_group_sighting:
         log.debug('Celery running sage detection')
         asset_group_sighting.run_sage_detection(model)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,27 +88,19 @@ def flask_app(gitlab_remote_login_pat):
                 from app.modules.asset_groups import tasks
 
                 tasks_patch = []
-                tasks_patch.append(
-                    mock.patch.object(
-                        tasks.delete_remote,
-                        'delay',
-                        lambda *args, **kwargs: tasks.delete_remote(*args, **kwargs),
+                for func in (
+                    'delete_remote',
+                    'ensure_remote',
+                    'git_push',
+                    'sage_detection',
+                ):
+                    tasks_patch.append(
+                        mock.patch.object(
+                            getattr(tasks, func),
+                            'delay',
+                            lambda *args, **kwargs: getattr(tasks, func)(*args, **kwargs),
+                        ),
                     )
-                )
-                tasks_patch.append(
-                    mock.patch.object(
-                        tasks.ensure_remote,
-                        'delay',
-                        lambda *args, **kwargs: tasks.ensure_remote(*args, **kwargs),
-                    )
-                )
-                tasks_patch.append(
-                    mock.patch.object(
-                        tasks.git_push,
-                        'delay',
-                        lambda *args, **kwargs: tasks.git_push(*args, **kwargs),
-                    )
-                )
                 for patch in tasks_patch:
                     patch.start()
 

--- a/tests/modules/asset_groups/test_models.py
+++ b/tests/modules/asset_groups/test_models.py
@@ -44,6 +44,8 @@ def test_asset_group_sightings_jobs(flask_app, db, admin_user, test_root, reques
 
     uuids = [job_id2, job_id1]
 
+    from app.modules.asset_groups.tasks import sage_detection
+
     # Don't send anything to acm
     with mock.patch('app.modules.asset_groups.models.current_app'):
         with mock.patch('datetime.datetime') as mock_datetime:
@@ -51,8 +53,8 @@ def test_asset_group_sightings_jobs(flask_app, db, admin_user, test_root, reques
                 'app.modules.asset_groups.models.uuid.uuid4', side_effect=uuids.pop
             ):
                 mock_datetime.utcnow.return_value = now
-                ags1.run_sage_detection('ags1-model')
-                ags2.run_sage_detection('ags2-model')
+                sage_detection(str(ags1.guid), 'ags1-model')
+                sage_detection(str(ags2.guid), 'ags2-model')
 
     assert AssetGroupSighting.query.get(ags1.guid).jobs == {
         str(job_id1): {

--- a/tests/modules/job_control/test_models.py
+++ b/tests/modules/job_control/test_models.py
@@ -8,6 +8,7 @@ def test_job_control(flask_app, researcher_1, test_root, db):
     # pylint: disable=invalid-name
     from app.modules.asset_groups.models import AssetGroup, AssetGroupSighting
     from app.modules.job_control.models import JobControl
+    from app.modules.asset_groups.tasks import sage_detection
 
     asset_group = AssetGroup(owner_guid=researcher_1.guid)
     ags = AssetGroupSighting(
@@ -23,7 +24,7 @@ def test_job_control(flask_app, researcher_1, test_root, db):
         utc_now = datetime.datetime(2021, 6, 29, 8, 22, 35)
         with mock.patch('datetime.datetime') as mock_datetime:
             mock_datetime.utcnow.return_value = utc_now
-            ags.run_sage_detection('Animal')
+            sage_detection(str(ags.guid), 'Animal')
         job_id = list(ags.jobs.keys())[0]
 
         # TODO asserts


### PR DESCRIPTION
Instead of calling `asset_group_sighting.run_sage_detection` directly,
call the celery task `sage_detection.delay` in the background so we
return to the user quickly.

