### PR TITLE
Avoid recloning of asset group fixtures in tests

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -585,7 +585,7 @@ class AssetGroup(db.Model, HoustonModel):
 
     @property
     def bulk_upload(self):
-        return 'uploadType' in self.config and self.config['uploadType'] == 'bulk'
+        return isinstance(self.config, dict) and self.config.get('uploadType') == 'bulk'
 
     @property
     def anonymous(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,3 +3,6 @@
 The Application tests collection
 ================================
 """
+
+TEST_ASSET_GROUP_UUID = '00000000-0000-0000-0000-000000000003'
+TEST_EMPTY_ASSET_GROUP_UUID = '00000000-0000-0000-0000-000000000001'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,9 @@ from unittest import mock
 import sqlalchemy
 import pytest
 from flask_login import current_user, login_user, logout_user
-from tests import utils
-
 from app import create_app
+
+from . import utils, TEST_ASSET_GROUP_UUID, TEST_EMPTY_ASSET_GROUP_UUID
 
 
 # Force FLASK_CONFIG to be testing instead of using what's defined in the environment
@@ -338,7 +338,7 @@ def test_asset_group_uuid(flask_app, db, researcher_1, test_asset_group_file_dat
     from app.extensions.gitlab import GitlabInitializationError
     from app.modules.asset_groups.models import AssetGroup, AssetGroupMajorType
 
-    guid = '00000000-0000-0000-0000-000000000003'
+    guid = TEST_ASSET_GROUP_UUID
     asset_group = AssetGroup.query.get(guid)
     if asset_group is None:
         asset_group = AssetGroup(
@@ -367,7 +367,7 @@ def test_asset_group_uuid(flask_app, db, researcher_1, test_asset_group_file_dat
 def test_empty_asset_group_uuid(flask_app, db, researcher_1):
     from app.modules.asset_groups.models import AssetGroup, AssetGroupMajorType
 
-    guid = '00000000-0000-0000-0000-000000000001'
+    guid = TEST_EMPTY_ASSET_GROUP_UUID
     asset_group = AssetGroup.query.get(guid)
     if asset_group is None:
         asset_group = AssetGroup(

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -10,6 +10,7 @@ import config
 from unittest import mock
 
 from tests import utils as test_utils
+from tests import TEST_ASSET_GROUP_UUID, TEST_EMPTY_ASSET_GROUP_UUID
 
 PATH = '/api/v1/asset_groups/'
 
@@ -531,18 +532,12 @@ class CloneAssetGroup(object):
             shutil.rmtree(asset_group_path)
 
     def cleanup(self):
-        from app.modules.asset_groups.tasks import delete_remote
-
-        # Restore original state
-        if self.asset_group is not None:
-            # Don't delete the gitlab project by default
-            with mock.patch('app.modules.asset_groups.tasks.delete_remote'):
+        # Restore original state if not one of the asset group fixtures
+        if str(self.guid) not in (TEST_ASSET_GROUP_UUID, TEST_EMPTY_ASSET_GROUP_UUID):
+            if self.asset_group is not None:
                 self.asset_group.delete()
-            # If not one of the asset group fixtures, delete it from gitlab
-            if not str(self.guid).startswith('00000000-0000-0000-0000'):
-                delete_remote(str(self.guid))
-            self.asset_group = None
-        self.remove_files()
+                self.asset_group = None
+            self.remove_files()
 
 
 # Clone the asset_group


### PR DESCRIPTION
- Fix AssetGroup.bulk_upload when config is None

  In case `config` is None:
  
  ```
      @property
      def bulk_upload(self):
  >       return 'uploadType' in self.config and self.config['uploadType'] == 'bulk'
  E       TypeError: argument of type 'NoneType' is not iterable
  
  app/modules/asset_groups/models.py:588: TypeError
  ```
  
  We need to check `config` is a dict before checking that "uploadType" is
  in self.config.

- Avoid recloning of asset group fixtures in tests

  Change counting of all objects to skip asset group fixtures and change
  `CloneAssetGroup.cleanup` to not delete the asset group if it's one of
  the asset group fixtures.

