### PR TITLE
Allow Gumby tasks to be invoked from Houston code space

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -71,6 +71,10 @@ from tasks import docker_compose as task_docker_compose  # NOQA
 namespaces.append(task_dependencies)
 namespaces.append(task_docker_compose)
 
+from tasks import gumby as gumby_tasks  # NOQA
+
+namespaces.append(gumby_tasks)
+
 # NOTE: `namespace` or `ns` name is required!
 namespace = Collection(*namespaces)
 

--- a/tasks/gumby.py
+++ b/tasks/gumby.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+from gumby.invoke_tasks import *  # NOQA


### PR DESCRIPTION
## Pull Request Overview

Allow Gumby tasks to be invoked from Houston code space

---

**Invoke CLI Updates**

This adds the `gumby` library defined invoke task to Houston under the gumby namespace: `invoke gumby.<task>`.

For example:
```
$ invoke gumby.init
$ invoke gumby.load-random-data
```
