### PR TITLE
Skip gumby tasks if gumby is not installed

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -71,9 +71,12 @@ from tasks import docker_compose as task_docker_compose  # NOQA
 namespaces.append(task_dependencies)
 namespaces.append(task_docker_compose)
 
-from tasks import gumby as gumby_tasks  # NOQA
+try:
+    from tasks import gumby as gumby_tasks  # NOQA
 
-namespaces.append(gumby_tasks)
+    namespaces.append(gumby_tasks)
+except ModuleNotFoundError as e:
+    logger.warning(f'Unable to load tasks.gumby.*\n{str(e)}')
 
 # NOTE: `namespace` or `ns` name is required!
 namespace = Collection(*namespaces)


### PR DESCRIPTION
When gumby isn't installed, we can't run `invoke --list`:

```
$ invoke --list
WARNING:root:Unable to load tasks.app.*
No module named 'tqdm'
Traceback (most recent call last):
  File "/home/karen/src/wildme/py3/bin/invoke", line 8, in <module>
    sys.exit(program.run())
  File "/home/karen/src/wildme/py3/lib/python3.9/site-packages/invoke/program.py", line 373, in run
    self.parse_collection()
  File "/home/karen/src/wildme/py3/lib/python3.9/site-packages/invoke/program.py", line 465, in parse_collection
    self.load_collection()
  File "/home/karen/src/wildme/py3/lib/python3.9/site-packages/invoke/program.py", line 696, in load_collection
    module, parent = loader.load(coll_name)
  File "/home/karen/src/wildme/py3/lib/python3.9/site-packages/invoke/loader.py", line 76, in load
    module = imp.load_module(name, fd, path, desc)
  File "/usr/lib/python3.9/imp.py", line 244, in load_module
    return load_package(name, filename)
  File "/usr/lib/python3.9/imp.py", line 216, in load_package
    return _load(spec)
  File "<frozen importlib._bootstrap>", line 711, in _load
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/karen/src/wildme/houston/tasks/__init__.py", line 74, in <module>
    from tasks import gumby as gumby_tasks  # NOQA
  File "/home/karen/src/wildme/houston/tasks/gumby.py", line 2, in <module>
    from gumby.invoke_tasks import *  # NOQA
ModuleNotFoundError: No module named 'gumby'
```

We need to be able to run invoke docker-compose and dependencies tasks without
installing gumby.

