### PR TITLE
DEX-399 added user manager write User access, tidied up roles to use …

### DIFF
--- a/tests/modules/users/test_permissions.py
+++ b/tests/modules/users/test_permissions.py
@@ -496,3 +496,28 @@ def test_ObjectAccessPermission_contributor_user(
 
     my_encounter.delete()
     owned_encounter.delete()
+
+
+def test_ObjectAccessPermission_user_manager_user(
+    db,
+    user_manager_user_login,
+    temp_user,
+):
+    # pylint: disable=unused-argument
+    from app.modules.users.models import User
+
+    # Can access other users
+    validate_can_read_module(User)
+    validate_can_write_module(User)
+
+    validate_can_read_object(temp_user)
+    validate_can_write_object(temp_user)
+    validate_can_delete_object(temp_user)
+
+    obj = Mock()
+    obj.is_public = lambda: False
+
+    # user manager user should not be able to access non user stuff
+    validate_cannot_read_object(obj)
+    validate_cannot_write_object(obj)
+    validate_cannot_delete_object(obj)


### PR DESCRIPTION
…table where possible

<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- User manager can now read write and delete users 
- Rules handling simplified to use table driven rules where appropriate leaving only the 'odd' ones as special cases 
@karenc main difference to what you did is that the table is now a first pass and any extra permissions are in addition to that.  
---

