### PR TITLE
Skip pull if build is specified in docker-compose.rebuild

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -247,7 +247,7 @@ that are not being established try rebuilding all containerized Docker resources
 
 
 If there are specifically Gitlab authentication or startup issues, try rebuilding Gitlab:
-`invoke docker-compose.rebuild-gitlab`
+`invoke docker-compose.rebuild -s gitlab`
 
 
 #### Mounted Directories

--- a/tasks/docker_compose.py
+++ b/tasks/docker_compose.py
@@ -12,6 +12,8 @@ logger = logging.getLogger(__name__)
 
 @task
 def rebuild(context, service=[]):
+    if 'gitlab' in service and 'houston' not in service:
+        service.append('houston')
     services = service
     services_ = ', '.join(services)
     logger.info(f'Stop and remove codex services {services_}')
@@ -34,8 +36,3 @@ def rebuild(context, service=[]):
     context.run(f'docker-compose build {" ".join(services)}', echo=True)
     command = ['docker-compose', 'up', '-d'] + services
     logger.info(f'You can now do "{" ".join(command)}"')
-
-
-@task
-def rebuild_gitlab(context):
-    rebuild(context, service=['gitlab', 'houston'])

--- a/tasks/docker_compose.py
+++ b/tasks/docker_compose.py
@@ -5,6 +5,8 @@ docker-compose tasks for invoke
 import logging
 
 from invoke import task
+from invoke.exceptions import Exit
+import yaml
 
 
 logger = logging.getLogger(__name__)
@@ -12,6 +14,13 @@ logger = logging.getLogger(__name__)
 
 @task
 def rebuild(context, service=[]):
+    docker_compose_config = context.run('docker-compose config', hide='out')
+    config = yaml.safe_load(docker_compose_config.stdout)
+    for s in service:
+        if s not in config['services']:
+            raise Exit(
+                f'Invalid service "{s}".  Valid services: {", ".join(config["services"])}'
+            )
     if 'gitlab' in service and 'houston' not in service:
         service.append('houston')
     services = service
@@ -30,8 +39,12 @@ def rebuild(context, service=[]):
         echo=True,
         warn=True,
     )
-    logger.info(f'Pull image updates {services_}')
-    context.run(f'docker-compose pull {" ".join(services)}', echo=True)
+    pull_services = []
+    if service:
+        # Only pull if "build" is not specified
+        pull_services = [s for s in service if not config['services'][s].get('build')]
+    logger.info(f'Pull image updates {", ".join(pull_services)}')
+    context.run(f'docker-compose pull {" ".join(pull_services)}', echo=True)
     logger.info(f'Rebuild images {services_}')
     context.run(f'docker-compose build {" ".join(services)}', echo=True)
     command = ['docker-compose', 'up', '-d'] + services

--- a/tests/tasks/test_docker_compose.py
+++ b/tests/tasks/test_docker_compose.py
@@ -1,18 +1,26 @@
 # -*- coding: utf-8 -*-
+import pathlib
 from unittest import mock
 
-from invoke import MockContext
+import invoke.exceptions
+from invoke import MockContext, Result
+import pytest
 
 import tasks.docker_compose
+
+
+with (pathlib.Path(__file__).parent.parent.parent / 'docker-compose.yml').open() as f:
+    DOCKER_COMPOSE = f.read()
 
 
 def test_rebuild_specific_services():
     with mock.patch('tasks.docker_compose.logger') as logger:
         context = MockContext(
             run={
+                'docker-compose config': Result(DOCKER_COMPOSE),
                 'docker-compose rm --stop -f db houston': True,
                 'docker volume ls -q -f dangling=true -f name=houston_db* -f name=houston_houston* | xargs docker volume rm': True,
-                'docker-compose pull db houston': True,
+                'docker-compose pull db': True,
                 'docker-compose build db houston': True,
             },
         )
@@ -20,7 +28,7 @@ def test_rebuild_specific_services():
         assert logger.info.call_args_list == [
             mock.call('Stop and remove codex services db, houston'),
             mock.call('Remove codex volumes db, houston'),
-            mock.call('Pull image updates db, houston'),
+            mock.call('Pull image updates db'),
             mock.call('Rebuild images db, houston'),
             mock.call('You can now do "docker-compose up -d db houston"'),
         ]
@@ -30,6 +38,7 @@ def test_rebuild():
     with mock.patch('tasks.docker_compose.logger') as logger:
         context = MockContext(
             run={
+                'docker-compose config': Result(DOCKER_COMPOSE),
                 'docker-compose down --remove-orphans': True,
                 'docker volume ls -q -f dangling=true -f name=houston_* | xargs docker volume rm': True,
                 'docker-compose pull ': True,
@@ -50,9 +59,10 @@ def test_rebuild_gitlab():
     with mock.patch('tasks.docker_compose.logger') as logger:
         context = MockContext(
             run={
+                'docker-compose config': Result(DOCKER_COMPOSE),
                 'docker-compose rm --stop -f gitlab houston': True,
                 'docker volume ls -q -f dangling=true -f name=houston_gitlab* -f name=houston_houston* | xargs docker volume rm': True,
-                'docker-compose pull gitlab houston': True,
+                'docker-compose pull gitlab': True,
                 'docker-compose build gitlab houston': True,
             },
         )
@@ -60,7 +70,21 @@ def test_rebuild_gitlab():
         assert logger.info.call_args_list == [
             mock.call('Stop and remove codex services gitlab, houston'),
             mock.call('Remove codex volumes gitlab, houston'),
-            mock.call('Pull image updates gitlab, houston'),
+            mock.call('Pull image updates gitlab'),
             mock.call('Rebuild images gitlab, houston'),
             mock.call('You can now do "docker-compose up -d gitlab houston"'),
         ]
+
+
+def test_invalid_service():
+    with mock.patch('tasks.docker_compose.logger'):
+        context = MockContext(
+            run={
+                'docker-compose config': Result(DOCKER_COMPOSE),
+            },
+        )
+        with pytest.raises(invoke.exceptions.Exit) as exc_info:
+            tasks.docker_compose.rebuild(context, service=['invalid'])
+        assert exc_info.value.message.startswith(
+            'Invalid service "invalid".  Valid services: '
+        )

--- a/tests/tasks/test_docker_compose.py
+++ b/tests/tasks/test_docker_compose.py
@@ -47,7 +47,20 @@ def test_rebuild():
 
 
 def test_rebuild_gitlab():
-    with mock.patch('tasks.docker_compose.rebuild') as rebuild:
-        context = MockContext()
-        tasks.docker_compose.rebuild_gitlab(context)
-        assert rebuild.call_args == mock.call(context, service=['gitlab', 'houston'])
+    with mock.patch('tasks.docker_compose.logger') as logger:
+        context = MockContext(
+            run={
+                'docker-compose rm --stop -f gitlab houston': True,
+                'docker volume ls -q -f dangling=true -f name=houston_gitlab* -f name=houston_houston* | xargs docker volume rm': True,
+                'docker-compose pull gitlab houston': True,
+                'docker-compose build gitlab houston': True,
+            },
+        )
+        tasks.docker_compose.rebuild(context, service=['gitlab'])
+        assert logger.info.call_args_list == [
+            mock.call('Stop and remove codex services gitlab, houston'),
+            mock.call('Remove codex volumes gitlab, houston'),
+            mock.call('Pull image updates gitlab, houston'),
+            mock.call('Rebuild images gitlab, houston'),
+            mock.call('You can now do "docker-compose up -d gitlab houston"'),
+        ]


### PR DESCRIPTION
- Merge docker-compose.rebuild-gitlab into docker-compose.rebuild

  We don't really need a separate command for rebuilding gitlab... we'll
  just use `invoke docker-compose.rebuild -s gitlab`.

- Skip pull if build is specified in docker-compose.rebuild

  The houston service has "build" and "image" specified, in the
  `docker-compose.rebuild` script, we are definitely building the image,
  so there is no need to download the image (skip pull).

