### PR TITLE
DEX-394 remove priviliged checks from rules table, added data_manager role, i…

### DIFF
--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -102,6 +102,11 @@ class Annotation(db.Model, HoustonModel):
                 db.session.delete(ref)
                 break
 
+    def user_is_owner(self, user):
+        # Annotation has no owner, but it has one asset, that has one asset_group that has an owner
+        # (encounter is no longer required on Annotation, so best route to owner is via Asset/Group)
+        return user is not None and user == self.asset.asset_group.owner
+
     # Used for building matching set but abstract the annotation to name mapping
     def get_name(self):
         name = 'unknown'

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -158,6 +158,10 @@ class Asset(db.Model, HoustonModel):
     def is_mime_type_major(self, major):
         return self.mime_type_major() == major
 
+    # Special access to the raw file only for internal users
+    def user_raw_read(self, user):
+        return self.is_detection() and user.is_internal
+
     # will only set .meta values that can be derived automatically from file
     # (will not overwrite any manual/other values); silently fails if unknown type for deriving
     #

--- a/app/modules/collaborations/parameters.py
+++ b/app/modules/collaborations/parameters.py
@@ -6,12 +6,19 @@ Input arguments (Parameters) for Collaborations resources RESTful API
 
 # from flask_marshmallow import base_fields
 from flask_restx_patched import Parameters, PatchJSONParameters
+from flask_marshmallow import base_fields
 
 from . import schemas
 from .models import Collaboration
 
 
 class CreateCollaborationParameters(Parameters, schemas.DetailedCollaborationSchema):
+    user_guid = base_fields.UUID(
+        description='The GUID of the other user',
+        required=True,
+    )
+    title = base_fields.String(required=False)
+
     class Meta(schemas.DetailedCollaborationSchema.Meta):
         pass
 

--- a/app/modules/collaborations/parameters.py
+++ b/app/modules/collaborations/parameters.py
@@ -17,6 +17,11 @@ class CreateCollaborationParameters(Parameters, schemas.DetailedCollaborationSch
         description='The GUID of the other user',
         required=True,
     )
+    # This is used for when a user manager is creating a collaboration between two different users.
+    second_user_guid = base_fields.UUID(
+        description='The GUID of the second user',
+        required=False,
+    )
     title = base_fields.String(required=False)
 
     class Meta(schemas.DetailedCollaborationSchema.Meta):

--- a/app/modules/collaborations/resources.py
+++ b/app/modules/collaborations/resources.py
@@ -94,6 +94,9 @@ class Collaborations(Resource):
             second_user = User.query.get(second_user_guid)
             if not second_user:
                 abort(400, f'User with guid {second_user_guid} not found')
+            if not second_user.is_researcher:
+                abort(400, f'User with guid {second_user_guid} is not a researcher')
+
             user_guids = [other_user_guid, second_user_guid]
             states = ['approved', 'approved']
             initiator_states = [False, False]

--- a/app/modules/collaborations/schemas.py
+++ b/app/modules/collaborations/schemas.py
@@ -6,7 +6,7 @@ Serialization schemas for Collaborations resources RESTful API
 
 # from flask_marshmallow import base_fields
 from flask_restx_patched import ModelSchema
-
+from flask_marshmallow import base_fields
 from .models import Collaboration
 
 
@@ -15,12 +15,19 @@ class BaseCollaborationSchema(ModelSchema):
     Base Collaboration schema exposes only the most general fields.
     """
 
+    members = base_fields.Function(Collaboration.get_user_guids)
+    read_state = base_fields.Function(Collaboration.get_read_state)
+    edit_state = base_fields.Function(Collaboration.get_edit_state)
+
     class Meta:
         # pylint: disable=missing-docstring
         model = Collaboration
         fields = (
             Collaboration.guid.key,
             Collaboration.title.key,
+            'members',
+            'read_state',
+            'edit_state',
         )
         dump_only = (Collaboration.guid.key,)
 

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -112,6 +112,9 @@ class Sighting(db.Model, FeatherModel):
     def user_can_edit_all_encounters(self, user):
         return self.user_owns_all_encounters(user)
 
+    def user_is_owner(self, user):
+        return user in self.get_owners()
+
     def get_encounters(self):
         return self.encounters
 

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -213,6 +213,7 @@ class User(db.Model, FeatherModel, UserEDMMixin):
 
     class StaticRoles(enum.Enum):
         # pylint: disable=missing-docstring,unsubscriptable-object
+        DATA_MANAGER = (0x100000, 'DataManager', 'DataManager', 'is_data_manager')
         USER_MANAGER = (0x80000, 'UserManager', 'UserManager', 'is_user_manager')
         CONTRIBUTOR = (0x40000, 'Contributor', 'Contributor', 'is_contributor')
         RESEARCHER = (0x20000, 'Researcher', 'Researcher', 'is_researcher')
@@ -248,6 +249,9 @@ class User(db.Model, FeatherModel, UserEDMMixin):
     is_user_manager = _get_is_static_role_property(
         'is_user_manager', StaticRoles.USER_MANAGER
     )
+    is_data_manager = _get_is_static_role_property(
+        'is_data_manager', StaticRoles.DATA_MANAGER
+    )
     is_researcher = _get_is_static_role_property('is_researcher', StaticRoles.RESEARCHER)
     is_exporter = _get_is_static_role_property('is_exporter', StaticRoles.EXPORTER)
     is_internal = _get_is_static_role_property('is_internal', StaticRoles.INTERNAL)
@@ -276,6 +280,7 @@ class User(db.Model, FeatherModel, UserEDMMixin):
 
     def get_roles(self):
         roles = []
+        roles += [self.StaticRoles.DATA_MANAGER.shorthand] if self.is_data_manager else []
         roles += [self.StaticRoles.USER_MANAGER.shorthand] if self.is_user_manager else []
         roles += [self.StaticRoles.INTERNAL.shorthand] if self.is_internal else []
         roles += [self.StaticRoles.ADMIN.shorthand] if self.is_admin else []

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -16,64 +16,73 @@ from app.modules.users.permissions.types import AccessOperation
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
-# Map of user permissions. This only applies to real users, anonymous users must be handled separately
-ANY_ROLE_MAP = {
-    ('SiteSetting', AccessOperation.READ, 'Module'): ['is_privileged', 'is_admin'],
-    ('SiteSetting', AccessOperation.WRITE, 'Module'): ['is_privileged', 'is_admin'],
-    ('SiteSetting', AccessOperation.READ, 'Object'): ['is_privileged'],
-    ('SiteSetting', AccessOperation.WRITE, 'Object'): ['is_privileged', 'is_admin'],
-    ('SiteSetting', AccessOperation.DELETE, 'Object'): ['is_privileged', 'is_admin'],
-    ('HoustonConfig', AccessOperation.WRITE, 'Module'): ['is_privileged', 'is_admin'],
-    ('Asset', AccessOperation.READ, 'Module'): ['is_privileged', 'is_admin'],
-    ('AssetGroup', AccessOperation.READ, 'Module'): ['is_privileged', 'is_admin'],
-    ('AssetGroup', AccessOperation.WRITE, 'Module'): ['is_active'],
-    ('AssetGroupSighting', AccessOperation.READ, 'Object'): [
-        'is_privileged',
-        'is_admin',
-        'is_researcher',
-    ],
-    ('AssetGroupSighting', AccessOperation.WRITE, 'Object'): [
-        'is_privileged',
-        'is_admin',
-        'is_researcher',
-    ],
-    ('AssetGroupSighting', AccessOperation.WRITE_PRIVILEGED, 'Object'): ['is_internal'],
-    ('Encounter', AccessOperation.READ, 'Module'): ['is_privileged', 'is_researcher'],
-    ('Encounter', AccessOperation.WRITE, 'Module'): [
-        'is_active'
-    ],  # TODO is this still correct
-    ('Encounter', AccessOperation.READ, 'Object'): ['is_privileged', 'is_researcher'],
-    ('Sighting', AccessOperation.READ, 'Module'): ['is_privileged', 'is_researcher'],
-    ('Sighting', AccessOperation.WRITE, 'Module'): ['is_active'],
-    ('Individual', AccessOperation.READ, 'Module'): ['is_privileged', 'is_researcher'],
-    ('Individual', AccessOperation.WRITE, 'Module'): ['is_privileged', 'is_researcher'],
-    ('Individual', AccessOperation.READ, 'Object'): ['is_privileged', 'is_researcher'],
-    ('Annotation', AccessOperation.READ, 'Module'): ['is_privileged', 'is_researcher'],
-    ('Annotation', AccessOperation.WRITE, 'Module'): ['is_privileged', 'is_researcher'],
-    ('User', AccessOperation.READ, 'Module'): ['is_privileged', 'is_user_manager'],
-    ('User', AccessOperation.WRITE, 'Module'): ['is_active'],  # Creating yourself
-    ('User', AccessOperation.WRITE, 'Object'): [
-        'is_privileged',
-        'is_user_manager',
-        'is_admin',
-    ],
-    ('User', AccessOperation.DELETE, 'Object'): [
-        'is_privileged',
-        'is_user_manager',
-        'is_admin',
-    ],
-    ('User', AccessOperation.READ, 'Object'): [
-        'is_privileged',
-        'is_user_manager',
-        'is_admin',
-    ],
-    ('Keyword', AccessOperation.READ, 'Module'): ['is_active'],
-    ('Keyword', AccessOperation.WRITE, 'Module'): ['is_active'],
-    ('Keyword', AccessOperation.READ, 'Object'): ['is_active'],
+# Map of user permissions on the module. This only applies to real users, anonymous users must be handled separately
+MODULE_USER_MAP = {
+    ('SiteSetting', AccessOperation.READ): ['is_admin'],
+    ('SiteSetting', AccessOperation.WRITE): ['is_admin'],
+    ('HoustonConfig', AccessOperation.WRITE): ['is_admin'],
+    ('Asset', AccessOperation.READ): ['is_admin'],
+    ('AssetGroup', AccessOperation.READ): ['is_admin'],
+    ('AssetGroup', AccessOperation.WRITE): ['is_active'],
+    ('Encounter', AccessOperation.READ): ['is_researcher'],
+    ('Encounter', AccessOperation.WRITE): ['is_active'],  # TODO is this still correct
+    ('Sighting', AccessOperation.READ): ['is_researcher'],
+    ('Sighting', AccessOperation.WRITE): ['is_active'],
+    ('Individual', AccessOperation.READ): ['is_researcher'],
+    ('Individual', AccessOperation.WRITE): ['is_researcher'],
+    ('Annotation', AccessOperation.READ): ['is_researcher'],
+    ('Annotation', AccessOperation.WRITE): ['is_researcher'],
+    ('User', AccessOperation.READ): ['is_user_manager'],
+    ('User', AccessOperation.WRITE): ['is_active'],  # Creating yourself
+    ('Collaboration', AccessOperation.WRITE): ['is_researcher'],
+    ('Collaboration', AccessOperation.READ): ['is_user_manager'],
+    ('Keyword', AccessOperation.READ): ['is_active'],
+    ('Keyword', AccessOperation.WRITE): ['is_active'],
 }
-ANY_OBJECT_METHOD_MAP = {
-    ('SiteSetting', AccessOperation.READ, 'Object'): ['is_public'],
-    ('Encounter', AccessOperation.READ, 'Object'): ['is_public'],
+
+# Map of user permissions on the object. These permissions are not granted by collaboration
+OBJECT_USER_MAP = {
+    ('SiteSetting', AccessOperation.WRITE): ['is_admin'],
+    ('SiteSetting', AccessOperation.DELETE): ['is_admin'],
+    ('AssetGroupSighting', AccessOperation.READ): [
+        'is_admin',
+        'is_researcher',
+    ],
+    ('AssetGroupSighting', AccessOperation.WRITE): [
+        'is_admin',
+        'is_researcher',
+    ],
+    ('AssetGroupSighting', AccessOperation.WRITE_PRIVILEGED): ['is_internal'],
+    ('Encounter', AccessOperation.READ): ['is_researcher'],
+    ('Individual', AccessOperation.READ): ['is_researcher'],
+    ('User', AccessOperation.WRITE): [
+        'is_user_manager',
+        'is_admin',
+    ],
+    ('User', AccessOperation.DELETE): [
+        'is_user_manager',
+        'is_admin',
+    ],
+    ('User', AccessOperation.READ): [
+        'is_user_manager',
+        'is_admin',
+    ],
+    ('Keyword', AccessOperation.READ): ['is_active'],
+    ('Sighting', AccessOperation.WRITE_PRIVILEGED): ['is_internal'],
+}
+
+# Map of methods (that are passed he current user as a param) on the object.
+# These permissions also granted by collaboration/project/etc so must not be privileged/admin
+OBJECT_USER_METHOD_MAP = {
+    ('Sighting', AccessOperation.READ): ['user_is_owner'],
+    ('Sighting', AccessOperation.WRITE): ['user_owns_all_encounters'],
+    ('Sighting', AccessOperation.DELETE): ['user_can_edit_all_encounters'],
+    ('Asset', AccessOperation.READ_PRIVILEGED): ['user_raw_read'],
+    ('Annotation', AccessOperation.READ): ['user_is_owner'],
+    ('Annotation', AccessOperation.WRITE): ['user_is_owner'],
+    ('Annotation', AccessOperation.DELETE): ['user_is_owner'],
+    ('Collaboration', AccessOperation.READ): ['user_can_access'],
+    ('Collaboration', AccessOperation.WRITE): ['user_can_access'],
 }
 
 
@@ -152,7 +161,7 @@ class ModuleActionRule(DenyAbortMixin, Rule):
             if self._action == AccessOperation.WRITE:
                 has_permission = self._is_module((AssetGroup, User, Encounter, Sighting))
         else:
-            roles = ANY_ROLE_MAP.get((self._module.__name__, self._action, 'Module'))
+            roles = MODULE_USER_MAP.get((self._module.__name__, self._action))
             if roles:
                 for role in roles:
                     if hasattr(current_user, role):
@@ -211,11 +220,13 @@ class ObjectActionRule(DenyAbortMixin, Rule):
         super().__init__(**kwargs)
 
     def any_table_driven_permission(self):
-        roles = ANY_ROLE_MAP.get((self._obj.__class__.__name__, self._action, 'Object'))
-        object_methods = ANY_OBJECT_METHOD_MAP.get(
-            (self._obj.__class__.__name__, self._action, 'Object')
+        roles = OBJECT_USER_MAP.get((self._obj.__class__.__name__, self._action))
+
+        object_user_methods = OBJECT_USER_METHOD_MAP.get(
+            (self._obj.__class__.__name__, self._action)
         )
-        if roles is None and object_methods is None:
+
+        if roles is None and object_user_methods is None:
             return False, False
 
         if roles is not None:
@@ -225,87 +236,49 @@ class ObjectActionRule(DenyAbortMixin, Rule):
                 elif getattr(current_user, role):
                     return True, True
 
-        if object_methods is not None:
-            for method in object_methods:
+        if object_user_methods is not None:
+            for method in object_user_methods:
                 if not hasattr(self._obj, method):
                     log.warning(
                         f'{self._obj.__class__.__name__} object does not have accessor {method}'
                     )
-                elif getattr(self._obj, method)():
+                elif getattr(self._obj, method)(current_user):
                     return True, True
+
         return True, False
+
+    def elevated_permission(self, user):
+        if (
+            self._action == AccessOperation.READ_PRIVILEGED
+            or self._action == AccessOperation.WRITE_PRIVILEGED
+        ):
+            return False
+        else:
+            return owner_or_privileged(user, self._obj)
 
     def check(self):
         # This Rule is for checking permissions on objects, so there must be one, Use the ModuleActionRule for
         # permissions checking without objects
         assert self._obj is not None
+        # Anyone can read public data, even anonymous and inactive users
+        has_permission = self._action == AccessOperation.READ and self._obj.is_public()
 
-        was_table_driven, has_permission = self.any_table_driven_permission()
+        if current_user and not current_user.is_anonymous and current_user.is_active:
+            if not has_permission:
+                was_table_driven, has_permission = self.any_table_driven_permission()
 
-        # Anyone can read public data, even anonymous users
-        if not has_permission:
-            has_permission = (
-                self._action == AccessOperation.READ and self._obj.is_public()
-            )
-
-        if not has_permission and current_user and not current_user.is_anonymous:
-
-            has_permission = (
-                # inactive users can do nothing
-                current_user.is_active
-                & (
-                    self._permitted_via_user(current_user)
+            if not has_permission:
+                has_permission = self.elevated_permission(current_user) | (
+                    self._permitted_via_collaboration(current_user)
                     # | self._permitted_via_org(current_user)
                     # | self._permitted_via_project(current_user)
-                    | self._permitted_via_collaboration(current_user)
                 )
+
+        if not has_permission:
+            log.info(
+                'Access permission denied for %r, %r by %r'
+                % (self._action, self._obj, current_user)
             )
-        if not has_permission:
-            log.info('Access permission denied for %r by %r' % (self._obj, current_user))
-        return has_permission
-
-    def _permitted_via_user(self, user):
-        from app.modules.annotations.models import Annotation
-        from app.modules.sightings.models import Sighting
-        from app.modules.assets.models import Asset
-
-        # The exception to the rule of owners and privileged users can do anything is for access to raw
-        # assets as this contains potentially extremely sensitive information and is only required for the
-        # detection task within WBIA
-        if (
-            isinstance(self._obj, Asset)
-            and self._action == AccessOperation.READ_PRIVILEGED
-        ):
-            # users can read write and delete anything they own while some users can do anything
-            has_permission = user.is_internal and self._obj.is_detection()
-        else:
-            has_permission = owner_or_privileged(user, self._obj)
-
-        if not has_permission:
-            # Projects and Orgs disabled for MVP
-            #     # read and write access is permitted for any projects or organisations they're in
-            #     # Details of what they're allowed to write handled in the patch parameters functionality
-            #     # Region would be handled the same way here too
-            #     if isinstance(self._obj, (Project, Organization)):
-            #         has_permission = (
-            #             user in self._obj.get_members()
-            #             and self._action != AccessOperation.DELETE
-            #         )
-
-            if isinstance(self._obj, Annotation):
-                # Annotation has no owner, but it has one asset, that has one asset_group that has an owner
-                # (encounter is no longer required on Annotation, so best route to owner is via Asset/Group)
-                has_permission = user == self._obj.asset.asset_group.owner
-
-        # Sightings depend on if user is the _only_ owner of referenced Encounters
-        if not has_permission and isinstance(self._obj, Sighting):
-            if self._action == AccessOperation.WRITE:
-                has_permission = self._obj.single_encounter_owner() == user
-            if self._action == AccessOperation.DELETE:
-                has_permission = self._obj.user_can_edit_all_encounters(user)
-            if self._action == AccessOperation.READ:
-                has_permission = user in self._obj.get_owners()
-
         return has_permission
 
     # def _permitted_via_org(self, user):
@@ -350,7 +323,28 @@ class ObjectActionRule(DenyAbortMixin, Rule):
     #             project_index = project_index + 1
 
     def _permitted_via_collaboration(self, user):
-        # TODO:
+        tried_users = [user]
+        object_user_methods = OBJECT_USER_METHOD_MAP.get(
+            (self._obj.__class__.__name__, self._action)
+        )
+
+        for collab_assoc in user.user_collaboration_associations:
+            collab_users = collab_assoc.collaboration.get_users()
+            for other_user in collab_users:
+                if other_user not in tried_users:
+                    tried_users.append(other_user)
+                    if other_user.owns_object(self._obj):
+                        return True
+
+                if object_user_methods is not None:
+                    for method in object_user_methods:
+                        if not hasattr(self._obj, method):
+                            log.warning(
+                                f'{self._obj.__class__.__name__} object does not have accessor {method}'
+                            )
+                        elif getattr(self._obj, method)(other_user):
+                            return True
+
         return False
 
 

--- a/tests/modules/assets/resources/test_assets.py
+++ b/tests/modules/assets/resources/test_assets.py
@@ -110,7 +110,7 @@ def test_find_raw_asset(
         researcher_1,
         test_clone_asset_group_data['asset_group_uuid'],
     )
-
+    raw_src_response = None
     try:
         asset_guid = test_clone_asset_group_data['asset_uuids'][0]
 
@@ -143,7 +143,8 @@ def test_find_raw_asset(
         raw_src_response.close()
     finally:
         # Force the server to release the file handler
-        raw_src_response.close()
+        if raw_src_response:
+            raw_src_response.close()
         clone.cleanup()
 
 

--- a/tests/modules/collaborations/resources/test_collaboration_create.py
+++ b/tests/modules/collaborations/resources/test_collaboration_create.py
@@ -47,9 +47,39 @@ def test_create_collaboration(
 
 
 def test_create_approved_collaboration(
-    flask_app_client, researcher_1, researcher_2, user_manager_user, db
+    flask_app_client, researcher_1, researcher_2, user_manager_user, readonly_user, db
 ):
     from app.modules.collaborations.models import Collaboration
+
+    # couple of failure checks
+    data = {
+        'user_guid': str(researcher_2.guid),
+        'second_user_guid': str(readonly_user.guid),
+    }
+    resp_msg = f'User with guid {readonly_user.guid} is not a researcher'
+    collab_utils.create_collaboration(
+        flask_app_client, user_manager_user, data, 400, resp_msg
+    )
+
+    duff_uuid = str(uuid.uuid4())
+    data = {
+        'user_guid': str(researcher_1.guid),
+        'second_user_guid': duff_uuid,
+    }
+    resp_msg = f'User with guid {duff_uuid} not found'
+    collab_utils.create_collaboration(
+        flask_app_client, user_manager_user, data, 400, resp_msg
+    )
+
+    # valid one
+    data = {
+        'user_guid': str(researcher_1.guid),
+        'second_user_guid': str(readonly_user.guid),
+    }
+    resp_msg = f'User with guid {readonly_user.guid} is not a researcher'
+    collab_utils.create_collaboration(
+        flask_app_client, user_manager_user, data, 400, resp_msg
+    )
 
     data = {
         'user_guid': str(researcher_1.guid),

--- a/tests/modules/collaborations/resources/test_collaboration_create.py
+++ b/tests/modules/collaborations/resources/test_collaboration_create.py
@@ -47,14 +47,17 @@ def test_create_collaboration(
 
 
 def test_create_approved_collaboration(
-    flask_app_client, researcher_1, user_manager_user, db
+    flask_app_client, researcher_1, researcher_2, user_manager_user, db
 ):
     from app.modules.collaborations.models import Collaboration
 
-    data = {'user_guid': str(researcher_1.guid)}
+    data = {
+        'user_guid': str(researcher_1.guid),
+        'second_user_guid': str(researcher_2.guid),
+    }
+
     collab = None
     try:
-        user_manager_user.set_static_role(user_manager_user.StaticRoles.RESEARCHER)
         resp = collab_utils.create_collaboration(
             flask_app_client, user_manager_user, data
         )
@@ -67,8 +70,7 @@ def test_create_approved_collaboration(
         members = resp.json.get('members', [])
         assert len(members) == 2
         assert str(researcher_1.guid) in members
-        assert str(user_manager_user.guid) in members
+        assert str(researcher_2.guid) in members
     finally:
-        user_manager_user.unset_static_role(user_manager_user.StaticRoles.RESEARCHER)
         if collab:
             collab.delete()

--- a/tests/modules/collaborations/resources/test_collaboration_create.py
+++ b/tests/modules/collaborations/resources/test_collaboration_create.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-docstring
+import tests.modules.collaborations.resources.utils as collab_utils
+import uuid
+
+
+def test_create_collaboration(
+    flask_app_client, researcher_1, readonly_user, researcher_2, user_manager_user, db
+):
+    duff_uuid = str(uuid.uuid4())
+    data = {'user_guid': duff_uuid}
+    resp_msg = f'User with guid {duff_uuid} not found'
+    collab_utils.create_collaboration(flask_app_client, researcher_1, data, 400, resp_msg)
+
+    data = {'user_guid': str(readonly_user.guid)}
+    resp_msg = f'User with guid {readonly_user.guid} is not a researcher'
+    collab_utils.create_collaboration(flask_app_client, researcher_1, data, 400, resp_msg)
+
+    from app.modules.collaborations.models import Collaboration
+
+    collab = None
+    try:
+        data = {'user_guid': str(researcher_2.guid)}
+        resp = collab_utils.create_collaboration(flask_app_client, researcher_1, data)
+        collabs = Collaboration.query.all()
+        collab = collabs[0]
+        assert len(collabs) == 1
+        assert resp.json['edit_state'] == 'not_initiated'
+        assert resp.json['read_state'] == 'pending'
+        members = resp.json.get('members', [])
+        assert len(members) == 2
+        assert str(researcher_1.guid) in members
+        assert str(researcher_2.guid) in members
+        assert len(collabs) == 1
+
+        # only user manager should be able to read the list
+        collab_utils.read_all_collaborations(flask_app_client, readonly_user, 403)
+        collab_utils.read_all_collaborations(flask_app_client, researcher_1, 403)
+        all_resp = collab_utils.read_all_collaborations(
+            flask_app_client, user_manager_user
+        )
+        assert len(all_resp.json) == 1
+        assert all_resp.json[0]['guid'] == resp.json['guid']
+    finally:
+        if collab:
+            collab.delete()
+
+
+def test_create_approved_collaboration(
+    flask_app_client, researcher_1, user_manager_user, db
+):
+    from app.modules.collaborations.models import Collaboration
+
+    data = {'user_guid': str(researcher_1.guid)}
+    collab = None
+    try:
+        user_manager_user.set_static_role(user_manager_user.StaticRoles.RESEARCHER)
+        resp = collab_utils.create_collaboration(
+            flask_app_client, user_manager_user, data
+        )
+        collabs = Collaboration.query.all()
+        collab = collabs[0]
+        assert len(collabs) == 1
+
+        assert resp.json['edit_state'] == 'not_initiated'
+        assert resp.json['read_state'] == 'approved'
+        members = resp.json.get('members', [])
+        assert len(members) == 2
+        assert str(researcher_1.guid) in members
+        assert str(user_manager_user.guid) in members
+    finally:
+        user_manager_user.unset_static_role(user_manager_user.StaticRoles.RESEARCHER)
+        if collab:
+            collab.delete()

--- a/tests/modules/collaborations/resources/utils.py
+++ b/tests/modules/collaborations/resources/utils.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""
+Collaboration resources utils
+-------------
+"""
+import json
+from tests import utils as test_utils
+
+PATH = '/api/v1/collaborations/'
+
+
+def create_collaboration(
+    flask_app_client, user, data, expected_status_code=200, expected_error=''
+):
+    if user:
+        with flask_app_client.login(user, auth_scopes=('collaborations:write',)):
+            response = flask_app_client.post(
+                '%s' % PATH,
+                content_type='application/json',
+                data=json.dumps(data),
+            )
+    else:
+        response = flask_app_client.post(
+            '%s' % PATH,
+            content_type='application/json',
+            data=json.dumps(data),
+        )
+
+    if expected_status_code == 200:
+        test_utils.validate_dict_response(
+            response, 200, {'guid', 'edit_state', 'read_state', 'title', 'members'}
+        )
+    elif 400 <= expected_status_code < 500:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+        assert response.json['message'] == expected_error, response.json['message']
+    else:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+    return response
+
+
+def patch_collaboration(
+    flask_app_client, collaboration_guid, user, data, expected_status_code=200
+):
+    with flask_app_client.login(user, auth_scopes=('collaborations:write',)):
+        response = flask_app_client.patch(
+            '%s%s' % (PATH, collaboration_guid),
+            content_type='application/json',
+            data=json.dumps(data),
+        )
+
+    if expected_status_code == 200:
+        test_utils.validate_dict_response(response, 200, {'guid'})
+    else:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+    return response
+
+
+def read_collaboration(
+    flask_app_client, user, collaboration_guid, expected_status_code=200
+):
+    if user:
+        with flask_app_client.login(user, auth_scopes=('collaborations:read',)):
+            response = flask_app_client.get(f'{PATH}{collaboration_guid}')
+    else:
+        response = flask_app_client.get(f'{PATH}{collaboration_guid}')
+
+    if expected_status_code == 200:
+        test_utils.validate_dict_response(response, 200, {'guid'})
+    elif expected_status_code == 404:
+        test_utils.validate_dict_response(response, expected_status_code, {'message'})
+    else:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+    return response
+
+
+def read_all_collaborations(flask_app_client, user, expected_status_code=200):
+    with flask_app_client.login(user, auth_scopes=('collaborations:read',)):
+        response = flask_app_client.get(PATH)
+
+    if expected_status_code == 200:
+        test_utils.validate_list_response(response, 200)
+    else:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+    return response

--- a/tests/modules/collaborations/test_models.py
+++ b/tests/modules/collaborations/test_models.py
@@ -21,116 +21,135 @@ def test_collaboration_create_with_members(
 
     guids = [collab_user_a.get_id(), collab_user_b.get_id()]
 
-    simple_collab = Collaboration(title='Simple Collab', user_guids=guids)
+    simple_collab = None
+    specific_collab = None
+    try:
+        simple_collab = Collaboration(title='Simple Collab', user_guids=guids)
 
-    assert len(simple_collab.get_users()) == 2
+        assert len(simple_collab.get_users()) == 2
 
-    specific_collab = Collaboration(
-        title='Specific Collab',
-        user_guids=[collab_user_a.guid, collab_user_b.guid],
-        approval_states=['approved', 'approved'],
-        initiator_states=[True, False],
-    )
+        specific_collab = Collaboration(
+            title='Specific Collab',
+            user_guids=[collab_user_a.guid, collab_user_b.guid],
+            approval_states=['approved', 'approved'],
+            initiator_states=[True, False],
+        )
 
-    assert len(specific_collab.get_users()) == 2
+        assert len(specific_collab.get_users()) == 2
 
-    for association in specific_collab.collaboration_user_associations:
-        assert association.read_approval_state == 'approved'
+        for association in specific_collab.collaboration_user_associations:
+            assert association.read_approval_state == 'approved'
 
-        if association.user.guid == collab_user_a.guid:
-            assert association.initiator is True
-        else:
-            assert association.initiator is False
+            if association.user.guid == collab_user_a.guid:
+                assert association.initiator is True
+            else:
+                assert association.initiator is False
+    finally:
+        if simple_collab:
+            simple_collab.delete()
+        if specific_collab:
+            specific_collab.delete()
 
 
 def test_collaboration_read_state_changes(db, collab_user_a, collab_user_b):
-    collab = Collaboration(
-        title='Collab for state change',
-        user_guids=[collab_user_a.guid, collab_user_b.guid],
-        initiator_states=[True, False],
-    )
-    with db.session.begin():
-        db.session.add(collab)
+    collab = None
+    try:
+        collab = Collaboration(
+            title='Collab for state change',
+            user_guids=[collab_user_a.guid, collab_user_b.guid],
+            initiator_states=[True, False],
+        )
+        with db.session.begin():
+            db.session.add(collab)
 
-    for association in collab.collaboration_user_associations:
-        if association.user_guid == collab_user_a.guid:
-            assert (
-                association.read_approval_state == CollaborationUserState.APPROVED
-            )  # flagged initiator, automatic approval
-        elif association.user_guid == collab_user_b.guid:
-            assert association.read_approval_state == CollaborationUserState.PENDING
-
-        assert association.edit_approval_state == CollaborationUserState.NOT_INITIATED
-
-    def set_read_approval_state(*user_guid_states):
-        for user_guid, state in user_guid_states:
-            collab.set_read_approval_state_for_user(user_guid, state)
         for association in collab.collaboration_user_associations:
+            if association.user_guid == collab_user_a.guid:
+                assert (
+                    association.read_approval_state == CollaborationUserState.APPROVED
+                )  # flagged initiator, automatic approval
+            elif association.user_guid == collab_user_b.guid:
+                assert association.read_approval_state == CollaborationUserState.PENDING
+
+            assert association.edit_approval_state == CollaborationUserState.NOT_INITIATED
+
+        def set_read_approval_state(*user_guid_states):
             for user_guid, state in user_guid_states:
-                if association.user_guid == user_guid:
-                    assert association.read_approval_state == state
+                collab.set_read_approval_state_for_user(user_guid, state)
+            for association in collab.collaboration_user_associations:
+                for user_guid, state in user_guid_states:
+                    if association.user_guid == user_guid:
+                        assert association.read_approval_state == state
 
-    set_read_approval_state(
-        (collab_user_a.guid, CollaborationUserState.APPROVED),
-        (collab_user_b.guid, CollaborationUserState.DECLINED),
-    )
+        set_read_approval_state(
+            (collab_user_a.guid, CollaborationUserState.APPROVED),
+            (collab_user_b.guid, CollaborationUserState.DECLINED),
+        )
 
-    assert collab.get_read_state() == CollaborationUserState.DECLINED
+        assert collab.get_read_state() == CollaborationUserState.DECLINED
 
-    set_read_approval_state(
-        (collab_user_a.guid, CollaborationUserState.PENDING),
-        (collab_user_b.guid, CollaborationUserState.DECLINED),
-    )
+        set_read_approval_state(
+            (collab_user_a.guid, CollaborationUserState.PENDING),
+            (collab_user_b.guid, CollaborationUserState.DECLINED),
+        )
 
-    assert collab.get_read_state() == CollaborationUserState.DECLINED
+        assert collab.get_read_state() == CollaborationUserState.DECLINED
 
-    set_read_approval_state(
-        (collab_user_a.guid, CollaborationUserState.DECLINED),
-        (collab_user_b.guid, CollaborationUserState.PENDING),
-    )
+        set_read_approval_state(
+            (collab_user_a.guid, CollaborationUserState.DECLINED),
+            (collab_user_b.guid, CollaborationUserState.PENDING),
+        )
 
-    assert collab.get_read_state() == CollaborationUserState.DECLINED
+        assert collab.get_read_state() == CollaborationUserState.DECLINED
 
-    set_read_approval_state(
-        (collab_user_a.guid, CollaborationUserState.APPROVED),
-        (collab_user_b.guid, CollaborationUserState.APPROVED),
-    )
+        set_read_approval_state(
+            (collab_user_a.guid, CollaborationUserState.APPROVED),
+            (collab_user_b.guid, CollaborationUserState.APPROVED),
+        )
 
-    assert collab.get_read_state() == CollaborationUserState.APPROVED
+        assert collab.get_read_state() == CollaborationUserState.APPROVED
+
+    finally:
+        if collab:
+            collab.delete()
 
 
 def test_collaboration_edit_state_changes(db, collab_user_a, collab_user_b):
+    collab = None
+    try:
+        collab = Collaboration(
+            title='Collab for state change',
+            user_guids=[collab_user_a.guid, collab_user_b.guid],
+            initiator_states=[True, False],
+        )
 
-    collab = Collaboration(
-        title='Collab for state change',
-        user_guids=[collab_user_a.guid, collab_user_b.guid],
-        initiator_states=[True, False],
-    )
+        assert collab.get_initiators()[0].guid == collab_user_a.guid
 
-    assert collab.get_initiators()[0].guid == collab_user_a.guid
+        for association in collab.collaboration_user_associations:
+            assert association.edit_approval_state == CollaborationUserState.NOT_INITIATED
 
-    for association in collab.collaboration_user_associations:
-        assert association.edit_approval_state == CollaborationUserState.NOT_INITIATED
+        assert collab.get_edit_state() == CollaborationUserState.NOT_INITIATED
 
-    assert collab.get_edit_state() == CollaborationUserState.NOT_INITIATED
+        collab.set_edit_approval_state_for_user(
+            collab_user_a.guid, CollaborationUserState.APPROVED
+        )
 
-    collab.set_edit_approval_state_for_user(
-        collab_user_a.guid, CollaborationUserState.APPROVED
-    )
+        for association in collab.collaboration_user_associations:
+            if association.user_guid == collab_user_a.guid:
+                assert association.read_approval_state == CollaborationUserState.APPROVED
+            if association.user_guid == collab_user_b.guid:
+                assert association.read_approval_state == CollaborationUserState.PENDING
 
-    for association in collab.collaboration_user_associations:
-        if association.user_guid == collab_user_a.guid:
-            assert association.read_approval_state == CollaborationUserState.APPROVED
-        if association.user_guid == collab_user_b.guid:
-            assert association.read_approval_state == CollaborationUserState.PENDING
+        assert collab.get_edit_state() == CollaborationUserState.PENDING
 
-    assert collab.get_edit_state() == CollaborationUserState.PENDING
+        collab.set_edit_approval_state_for_user(
+            collab_user_b.guid, CollaborationUserState.APPROVED
+        )
 
-    collab.set_edit_approval_state_for_user(
-        collab_user_b.guid, CollaborationUserState.APPROVED
-    )
+        assert collab.get_edit_state() == CollaborationUserState.APPROVED
 
-    assert collab.get_edit_state() == CollaborationUserState.APPROVED
+    finally:
+        if collab:
+            collab.delete()
 
 
 def test_fail_create_collaboration(collab_user_a, collab_user_b):

--- a/tests/modules/users/resources/test_signup.py
+++ b/tests/modules/users/resources/test_signup.py
@@ -217,7 +217,7 @@ def test_new_user_creation_roles_admin(flask_app_client, admin_user, db):
     assert response.content_type == 'application/json'
     assert response.json == {
         'status': 422,
-        'message': 'invalid roles: is_researcher2.  Valid roles are is_user_manager, is_contributor, is_researcher, is_exporter, is_internal, is_admin, is_staff, is_active, in_alpha, in_beta',
+        'message': 'invalid roles: is_researcher2.  Valid roles are is_data_manager, is_user_manager, is_contributor, is_researcher, is_exporter, is_internal, is_admin, is_staff, is_active, in_alpha, in_beta',
     }
 
     with flask_app_client.login(admin_user):

--- a/tests/modules/users/test_models.py
+++ b/tests/modules/users/test_models.py
@@ -17,9 +17,16 @@ def test_User_auth(user_instance):
 
 
 @pytest.mark.parametrize(
-    'init_static_roles,is_internal,is_admin,is_staff,is_active',
+    'init_static_roles,is_internal,is_admin,is_staff,is_active,is_data_manager',
     [
-        (_init_static_roles, _is_internal, _is_admin, _is_staff, _is_active)
+        (
+            _init_static_roles,
+            _is_internal,
+            _is_admin,
+            _is_staff,
+            _is_active,
+            _is_data_manager,
+        )
         for _init_static_roles in (
             0,
             (
@@ -27,16 +34,24 @@ def test_User_auth(user_instance):
                 | models.User.StaticRoles.ADMIN.mask
                 | models.User.StaticRoles.STAFF.mask
                 | models.User.StaticRoles.ACTIVE.mask
+                | models.User.StaticRoles.DATA_MANAGER.mask
             ),
         )
         for _is_internal in (False, True)
         for _is_admin in (False, True)
         for _is_staff in (False, True)
         for _is_active in (False, True)
+        for _is_data_manager in (False, True)
     ],
 )
 def test_User_static_roles_setting(
-    init_static_roles, is_internal, is_admin, is_staff, is_active, user_instance
+    init_static_roles,
+    is_internal,
+    is_admin,
+    is_staff,
+    is_active,
+    is_data_manager,
+    user_instance,
 ):
     """
     Static User Roles are saved as bit flags into one ``static_roles``
@@ -66,18 +81,35 @@ def test_User_static_roles_setting(
     else:
         user_instance.unset_static_role(user_instance.StaticRoles.ACTIVE)
 
+    if is_data_manager:
+        user_instance.set_static_role(user_instance.StaticRoles.DATA_MANAGER)
+    else:
+        user_instance.unset_static_role(user_instance.StaticRoles.DATA_MANAGER)
+
     assert (
         user_instance.has_static_role(user_instance.StaticRoles.INTERNAL) is is_internal
     )
     assert user_instance.has_static_role(user_instance.StaticRoles.ADMIN) is is_admin
     assert user_instance.has_static_role(user_instance.StaticRoles.STAFF) is is_staff
     assert user_instance.has_static_role(user_instance.StaticRoles.ACTIVE) is is_active
+    assert (
+        user_instance.has_static_role(user_instance.StaticRoles.DATA_MANAGER)
+        is is_data_manager
+    )
+
     assert user_instance.is_internal is is_internal
     assert user_instance.is_admin is is_admin
     assert user_instance.is_staff is is_staff
     assert user_instance.is_active is is_active
+    assert user_instance.is_data_manager is is_data_manager
 
-    if not is_active and not is_staff and not is_admin and not is_internal:
+    if (
+        not is_active
+        and not is_staff
+        and not is_admin
+        and not is_internal
+        and not is_data_manager
+    ):
         assert user_instance.static_roles == 0
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -266,9 +266,10 @@ def all_count(db):
     from app.modules.assets.models import Asset
     from app.modules.asset_groups.models import AssetGroup
     from app.modules.individuals.models import Individual
+    from app.modules.collaborations.models import Collaboration
 
     count = {}
-    for cls in (Sighting, Encounter, Individual):
+    for cls in (Sighting, Encounter, Individual, Collaboration):
         count[cls.__name__] = row_count(db, cls)
     asset_query = Asset.query
     asset_group_query = AssetGroup.query


### PR DESCRIPTION
…mplemented Collaboration post and get (all) with responses. Collaborations removed on test complete

<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Rules tables refactored significantly to separate out Module and object rules for user roles
- Added map for functions on the object that take the user (which ended up being a lot of the odd scenarios)
- Refactored the calling code so that the tables are checked first and the subsequent code is also checked if permission not granted
- Added data manager role on the user
- Collaborations permissions rules added
- Collaboration Schema updated to add content and functions added in Collaboration model to access
- Post of collaboration for researcher and user manager (who is also a researcher) implemented and tested
- Collaboration test utils added for these and future tests
- Collaborations added to the "must clear these up" check on tests 
- All existsing tests changed to delete the collaborations on completion    

---

**REST API Updates **

The Collaboration APIs are not actually new but some of them are now more fully implemented 
