### PR TITLE
DEX 416 allow user manager to set roles in newly created user

### DIFF
--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -76,11 +76,15 @@ class Users(Resource):
         roles = args.pop('roles', [])
         if roles and (
             current_user.is_anonymous
-            or not (current_user.is_privileged or current_user.is_admin)
+            or not (
+                current_user.is_privileged
+                or current_user.is_admin
+                or current_user.is_user_manager
+            )
         ):
             abort(
                 code=HTTPStatus.FORBIDDEN,
-                message='You must be an admin or privileged to set roles for a new user',
+                message='You must be an admin, user manager or privileged to set roles for a new user',
             )
         for role in roles:
             args[role] = True

--- a/tests/modules/users/resources/test_signup.py
+++ b/tests/modules/users/resources/test_signup.py
@@ -160,7 +160,7 @@ def test_new_user_creation_roles_anonymous(flask_app_client):
     assert response.content_type == 'application/json'
     assert response.json == {
         'status': 403,
-        'message': 'You must be an admin or privileged to set roles for a new user',
+        'message': 'You must be an admin, user manager or privileged to set roles for a new user',
     }
 
 
@@ -179,7 +179,7 @@ def test_new_user_creation_roles_unprivileged(flask_app_client, regular_user):
     assert response.content_type == 'application/json'
     assert response.json == {
         'status': 403,
-        'message': 'You must be an admin or privileged to set roles for a new user',
+        'message': 'You must be an admin, user manager or privileged to set roles for a new user',
     }
 
     with flask_app_client.login(regular_user):
@@ -197,8 +197,20 @@ def test_new_user_creation_roles_unprivileged(flask_app_client, regular_user):
     assert response.content_type == 'application/json'
     assert response.json == {
         'status': 403,
-        'message': 'You must be an admin or privileged to set roles for a new user',
+        'message': 'You must be an admin, user manager or privileged to set roles for a new user',
     }
+
+
+def test_new_user_creation_roles_user_manager(flask_app_client, user_manager_user):
+    with flask_app_client.login(user_manager_user):
+        create_new_user(
+            flask_app_client,
+            data={
+                'email': 'user42@localhost',
+                'password': 'password',
+                'roles': ['in_alpha'],
+            },
+        )
 
 
 def test_new_user_creation_roles_admin(flask_app_client, admin_user, db):


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- User manager can set roles on user creation
- tests updated to checek this and handle new error message

---

