### PR TITLE
DEX-420: show SiteSettings (FileUploads) as part of configuration GET

### DIFF
--- a/app/modules/configuration/resources.py
+++ b/app/modules/configuration/resources.py
@@ -100,7 +100,10 @@ class EDMConfiguration(Resource):
             site_settings = SiteSetting.query.filter_by(public=True).order_by('key')
             ss_json = {}
             for ss in site_settings:
-                ss_json[ss.key] = f'/api/v1/fileuploads/src/{str(ss.file_upload.guid)}'
+                if ss.file_upload is not None:
+                    ss_json[
+                        ss.key
+                    ] = f'/api/v1/fileuploads/src/{str(ss.file_upload.guid)}'
             data['response']['configuration']['site.images'] = ss_json
         return data
 

--- a/app/modules/configuration/resources.py
+++ b/app/modules/configuration/resources.py
@@ -12,6 +12,7 @@ from flask_restx_patched import Resource
 from app.extensions.api import Namespace
 
 from app.modules.users.models import User
+from app.modules.site_settings.models import SiteSetting
 
 import json
 
@@ -96,6 +97,11 @@ class EDMConfiguration(Resource):
             data['response']['configuration'][
                 'site.adminUserInitialized'
             ] = User.admin_user_initialized()
+            site_settings = SiteSetting.query.filter_by(public=True).order_by('key')
+            ss_json = {}
+            for ss in site_settings:
+                ss_json[ss.key] = f'/api/v1/fileuploads/src/{str(ss.file_upload.guid)}'
+            data['response']['configuration']['site.images'] = ss_json
         return data
 
     @edm_configuration.login_required(oauth_scopes=['configuration:write'])


### PR DESCRIPTION

## Pull Request Overview

- Uses **FileUpload** values set for a given _key_ via [DEX-25](https://github.com/WildMeOrg/houston/pull/113)
- Adds list of these values as part of Configuration module as `site.images`

## Example
Use Tus-uploaded files to set `logo` key (from DEX-25)

```
POST /api/v1/site-settings/
{
    "key": "logo",
    "transactionId": "74d4b82b-ec18-4ede-844d-d96773ebcdc5",
    "transactionPath": "my-logo.png"
}
```

See results when retrieving site configuration:
```
GET /api/v1/configuration/default/__bundle_setup
{
    "site.name":  "whatever",
          [ ... ]
    "site.images": {
        "logo": "/api/v1/fileuploads/src/b4022067-dcff-4997-adab-230f1cc66557"
    }
}
```

## Notes:
- Currently `site.imagees` will show any arbitrary _key_ value, as long as the SiteSetting is set `public`= True (default behavior of POST).