### PR TITLE
DEX-422 gitlab sshkey

### DIFF
--- a/.dockerfiles/docker-entrypoint-init.d/set_up_gitlab.sh
+++ b/.dockerfiles/docker-entrypoint-init.d/set_up_gitlab.sh
@@ -3,6 +3,7 @@ set -Eueo pipefail
 
 HERE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PYTHON_GITLAB_CFG="${DATA_ROOT}/.python-gitlab.cfg"
+GIT_SSH_KEY_FILEPATH="${DATA_ROOT}/id_ssh_key"
 GITLAB_REMOTE_URI="${GITLAB_REMOTE_URI:-${GITLAB_PROTO:-https}://${GITLAB_HOST}:${GITLAB_PORT}}"
 
 write_initial_config() {
@@ -70,6 +71,19 @@ EOF
 
     echo "Write 'houston' PAT to ${HOUSTON_DOTENV}"
     dotenv -f ${HOUSTON_DOTENV} set GITLAB_REMOTE_LOGIN_PAT -- "${houston_pat}"
+
+    echo "Create a SSH key pair for the 'houston' user"
+    ssh-keygen -t rsa -b 4096 -C "Houston (${user_id})" -f "${GIT_SSH_KEY_FILEPATH}" -N ""
+    echo "Send the 'houston' user's public ssh key to gitlab"
+    resp=$(gitlab user-key create --user-id ${user_id} --title "Houston Application" --key "$(cat ${GIT_SSH_KEY_FILEPATH}.pub)")
+    # See also https://docs.gitlab.com/ee/ssh/
+    echo "Testing ssh connectivity"
+    gitlab_host=$(python -c "import os; print(os.getenv('GITLAB_REMOTE_URI').strip('/').split('/')[-1])")
+    # Test the SSH connection to the gitlab host
+    # Note, `-o StrictHostKeyChecking=no` option forces the connection to be added to known_hosts
+    ssh -i ${GIT_SSH_KEY_FILEPATH} -T "git@${gitlab_host}" -o StrictHostKeyChecking=no
+    echo "Write 'houston' ssh key to ${HOUSTON_DOTENV}"
+    dotenv -f ${HOUSTON_DOTENV} set GIT_SSH_KEY -- "$(cat ${GIT_SSH_KEY_FILEPATH})"
 
     # Fix permissions on files
     chmod 644 ${HOUSTON_DOTENV} ${PYTHON_GITLAB_CFG}

--- a/.dockerfiles/docker-entrypoint-init.d/set_up_gitlab.sh
+++ b/.dockerfiles/docker-entrypoint-init.d/set_up_gitlab.sh
@@ -73,6 +73,10 @@ EOF
     dotenv -f ${HOUSTON_DOTENV} set GITLAB_REMOTE_LOGIN_PAT -- "${houston_pat}"
 
     echo "Create a SSH key pair for the 'houston' user"
+    if [ -f "${GIT_SSH_KEY_FILEPATH}" ]; then
+        echo "Found and removing existing SSH key pair"
+        rm -f ${GIT_SSH_KEY_FILEPATH} ${GIT_SSH_KEY_FILEPATH}.pub
+    fi
     ssh-keygen -t rsa -b 4096 -C "Houston (${user_id})" -f "${GIT_SSH_KEY_FILEPATH}" -N ""
     echo "Send the 'houston' user's public ssh key to gitlab"
     resp=$(gitlab user-key create --user-id ${user_id} --title "Houston Application" --key "$(cat ${GIT_SSH_KEY_FILEPATH}.pub)")

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -5,11 +5,12 @@ AssetGroups database models
 """
 
 import enum
-import re
 from flask import current_app
 from flask_login import current_user  # NOQA
 import requests.exceptions
 import utool as ut
+import git
+from git import Git as BaseGit, Repo as BaseRepo
 
 from app.extensions.gitlab import GitlabInitializationError
 from app.extensions import db, HoustonModel, parallel
@@ -25,7 +26,6 @@ import logging
 import tqdm
 import uuid
 import json
-import git
 import os
 import pathlib
 import shutil
@@ -49,41 +49,6 @@ def compute_xxhash64_digest_filepath(filepath):
     return digest
 
 
-class GitLabPAT(object):
-    def __init__(self, repo=None, url=None):
-        assert repo is not None or url is not None, 'Must specify one of repo or url'
-
-        self.repo = repo
-        if url is None:
-            assert repo is not None, 'both repo and url parameters provided, choose one'
-            url = repo.remotes.origin.url
-        self.original_url = url
-
-        remote_personal_access_token = current_app.config.get(
-            'GITLAB_REMOTE_LOGIN_PAT', None
-        )
-        self.authenticated_url = re.sub(
-            #: match on either http or https
-            r'(https?)://(.*)$',
-            #: replace with basic-auth entities
-            r'\1://oauth2:%s@\2' % (remote_personal_access_token,),
-            self.original_url,
-        )
-
-    def __enter__(self):
-        # Update remote URL with PAT
-        if self.repo is not None:
-            self.repo.remotes.origin.set_url(self.authenticated_url)
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        if self.repo is not None:
-            self.repo.remotes.origin.set_url(self.original_url)
-        if exc_type:
-            return False
-        return True
-
-
 class AssetGroupMajorType(str, enum.Enum):
     filesystem = 'filesystem'
     archive = 'archive'
@@ -101,6 +66,34 @@ class AssetGroupSightingStage(str, enum.Enum):
     curation = 'curation'
     processed = 'processed'
     failed = 'failed'
+
+
+class _Git(BaseGit):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Assign the SSH command to include the id key file for authentication
+        self.update_environment(GIT_SSH_COMMAND=current_app.config['GIT_SSH_COMMAND'])
+
+
+class Repo(BaseRepo):
+    GitCommandWrapperType = _Git
+
+    # This class is copied from the original with one minor adjustment
+    # to use the class' `GitCommandWrapperType` definition as opposed
+    # to the direct reference to the `Git` class.
+    @classmethod
+    def clone_from(
+        cls, url, to_path, progress=None, env=None, multi_options=None, **kwargs
+    ):
+        # git = Git(os.getcwd())
+        git = cls.GitCommandWrapperType(os.getcwd())
+        if env is not None:
+            git.update_environment(**env)
+        from git.db import GitCmdObjectDB
+
+        return cls._clone(
+            git, url, to_path, GitCmdObjectDB, progress, multi_options, **kwargs
+        )
 
 
 # AssetGroup can have many sightings, so needs a table
@@ -653,7 +646,7 @@ class AssetGroup(db.Model, HoustonModel):
         # Create the repo
         git_path = os.path.join(group_path, '.git')
         if not os.path.exists(git_path):
-            repo = git.Repo.init(group_path)
+            repo = Repo.init(group_path)
             assert len(repo.remotes) == 0
             git_remote_public_name = current_app.config.get('GIT_PUBLIC_NAME', None)
             git_remote_email = current_app.config.get('GIT_EMAIL', None)
@@ -661,7 +654,7 @@ class AssetGroup(db.Model, HoustonModel):
             repo.git.config('user.name', git_remote_public_name)
             repo.git.config('user.email', git_remote_email)
         else:
-            repo = git.Repo(group_path)
+            repo = Repo(group_path)
 
         asset_group_path = os.path.join(group_path, '_asset_group')
         if not os.path.exists(asset_group_path):
@@ -773,14 +766,13 @@ class AssetGroup(db.Model, HoustonModel):
         repo = self.get_repository()
         assert repo is not None
 
-        with GitLabPAT(repo):
-            log.info('Pulling from authorized URL')
-            try:
-                repo.git.pull(repo.remotes.origin, repo.head.ref)
-            except git.exc.GitCommandError as e:
-                log.info(f'git pull failed for {self.guid}: {str(e)}')
-            else:
-                log.info('...pulled')
+        log.info('Pulling from remote repository')
+        try:
+            repo.git.pull(repo.remotes.origin, repo.head.ref)
+        except git.exc.GitCommandError as e:
+            log.info(f'git pull failed for {self.guid}: {str(e)}')
+        else:
+            log.info('...pulled')
 
         self.update_metadata_from_repo(repo)
 
@@ -791,16 +783,15 @@ class AssetGroup(db.Model, HoustonModel):
         assert repo is None
 
         asset_group_abspath = self.get_absolute_path()
-        gitlab_url = project.web_url
+        remote_url = project.ssh_url_to_repo
 
-        with GitLabPAT(url=gitlab_url) as glpat:
-            args = (
-                gitlab_url,
-                asset_group_abspath,
-            )
-            log.info('Cloning remote asset_group:\n\tremote: %r\n\tlocal:  %r' % args)
-            glpat.repo = git.Repo.clone_from(glpat.authenticated_url, asset_group_abspath)
-            log.info('...cloned')
+        args = (
+            remote_url,
+            asset_group_abspath,
+        )
+        log.info('Cloning remote asset_group:\n\tremote: %r\n\tlocal:  %r' % args)
+        repo = Repo.clone_from(remote_url, asset_group_abspath)
+        log.info('...cloned')
 
         repo = self.get_repository()
         assert repo is not None
@@ -1362,7 +1353,7 @@ class AssetGroup(db.Model, HoustonModel):
     def get_repository(self):
         repo_path = pathlib.Path(self.get_absolute_path())
         if (repo_path / '.git').exists():
-            return git.Repo(repo_path)
+            return Repo(repo_path)
 
     def ensure_repository(self):
         repo = self.get_repository()
@@ -1374,7 +1365,7 @@ class AssetGroup(db.Model, HoustonModel):
             if project:
                 repo = self.git_clone(project)
             else:
-                repo = git.Repo.init(self.get_absolute_path())
+                repo = Repo.init(self.get_absolute_path())
         self._ensure_repository_files()
         return repo
 

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -81,6 +81,7 @@ class Repo(BaseRepo):
     # This class is copied from the original with one minor adjustment
     # to use the class' `GitCommandWrapperType` definition as opposed
     # to the direct reference to the `Git` class.
+    # Fixed in https://github.com/gitpython-developers/GitPython/pull/1322
     @classmethod
     def clone_from(
         cls, url, to_path, progress=None, env=None, multi_options=None, **kwargs

--- a/config.py
+++ b/config.py
@@ -290,6 +290,27 @@ class AssetGroupConfig(object):
     GIT_EMAIL = os.getenv('GIT_EMAIL', 'dev@wildme.org')
     GITLAB_NAMESPACE = os.getenv('GITLAB_NAMESPACE', 'TEST')
     GITLAB_REMOTE_LOGIN_PAT = os.getenv('GITLAB_REMOTE_LOGIN_PAT')
+    # FIXME: Note, if you change the SSH key, you should also delete the ssh_id file (see GIT_SSH_KEY_FILEPATH)
+    GIT_SSH_KEY = os.getenv('GIT_SSH_KEY')
+
+    @property
+    def GIT_SSH_KEY_FILEPATH(self):
+        # Assuming mixed-in with BaseConfig
+        fp = DATA_ROOT / 'id_ssh_key'
+        if self.GIT_SSH_KEY is None:
+            # Assume the user knows what they are doing and bail out
+            # FIXME: It's possible to get here because parts of the application
+            #        needs loaded before all the configuration is available.
+            return fp
+        # Assume if the file exists, we're all good.
+        if not fp.exists():
+            with fp.open('w') as fb:
+                fb.write(self.GIT_SSH_KEY)
+        return fp
+
+    @property
+    def GIT_SSH_COMMAND(self):
+        return f'ssh -i {self.GIT_SSH_KEY_FILEPATH} -o StrictHostKeyChecking=no'
 
 
 def _parse_elasticsearch_hosts(raw_hosts_line):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -157,6 +157,7 @@ services:
       retries: 10
     volumes: &houston-volumes
       - houston-var:/data
+      - .dockerfiles/docker-entrypoint.sh:/docker-entrypoint.sh
       - .dockerfiles/docker-entrypoint-init.d:/docker-entrypoint-init.d
       - .dockerfiles/docker-entrypoint-always-init.d:/docker-entrypoint-always-init.d
       # FIXME: pull in development code while working on bringing up the container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -150,6 +150,11 @@ services:
       GIT_PUBLIC_NAME: "${GIT_PUBLIC_NAME}"
       GIT_EMAIL: "${GIT_EMAIL}"
       GITLAB_NAMESPACE: "${GITLAB_NAMESPACE}"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:5000/api/v1/site-info/"]
+      timeout: 45s
+      interval: 10s
+      retries: 10
     volumes: &houston-volumes
       - houston-var:/data
       - .dockerfiles/docker-entrypoint-init.d:/docker-entrypoint-init.d
@@ -163,6 +168,9 @@ services:
     command: [ "wait-for", "db:5432", "--", "wait-for", "edm:8080", "--", "celery", "-A", "app.extensions.celery.celery", "beat", "-s", "/data/var/celerybeat-schedule", "-l", "DEBUG"]
     networks:
       - intranet
+    depends_on:
+      houston:
+        condition: service_healthy
     environment: *houston-environment
     volumes: *houston-volumes
 
@@ -172,6 +180,9 @@ services:
     command: [ "wait-for", "db:5432", "--", "wait-for", "edm:8080", "--", "celery", "-A", "app.extensions.celery.celery", "worker", "-l", "DEBUG"]
     networks:
       - intranet
+    depends_on:
+      houston:
+        condition: service_healthy
     environment: *houston-environment
     volumes: *houston-volumes
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,3 +62,5 @@ filterwarnings =
     ignore:.*Using or importing the ABCs from 'collections' instead of from 'collections.abc'.*:DeprecationWarning
     ignore:.*inspect.getargspec.*:DeprecationWarning
     ignore:.*Only explicitly-declared fields will be included in the Schema Object.*:UserWarning
+    ignore:`np.typeDict` is a deprecated.*:DeprecationWarning
+    ignore:The _yaml extension module is now located at yaml._yaml and its location is subject to change.*:DeprecationWarning

--- a/tests/test_app_creation.py
+++ b/tests/test_app_creation.py
@@ -2,7 +2,7 @@
 # pylint: disable=missing-docstring
 import pytest
 
-from app import CONFIG_NAME_MAPPER, create_app
+from app import create_app
 
 
 @pytest.fixture(autouse=True)
@@ -49,10 +49,3 @@ def test_create_app_specific_config(monkeypatch):
 def test_create_app_with_non_existing_config():
     with pytest.raises(SystemExit):
         create_app('non-existing-config', testing=True)
-
-
-def test_create_app_with_broken_import_config():
-    CONFIG_NAME_MAPPER['broken-import-config'] = 'broken-import-config'
-    with pytest.raises(SystemExit):
-        create_app('broken-import-config', testing=True)
-    del CONFIG_NAME_MAPPER['broken-import-config']


### PR DESCRIPTION
# Authenticate repositories using SSH Key

## Pull Request Overview

This adjustment makes all cloned repos remote URL SSH based. As such, we are then able to use SSH Key authentication rather than re-write the URL with credentials included. 

There is new gitlab setup code to create and publish the SSH key. In production this procedure would be done out-of-band either manually or as a service provisioning step. At that point we'd pass in `GIT_SSH_KEY`, which is not currently enabled as part of this PR.

## Review notes

### Load configuration from object rather than class

Loading form an object allows for the use of class properties.
These come in handy for configuration items
that are derived from other configuration items.

Moved away from string based configure mapping,
because we no longer support importing a custom config class from a string.

### Add configuration option for an SSH key

I don't like how this is coded because it doesn't allow for the application
to update the ssh key file when the key has changed.
There isn't a good way to trigger the desired behavior.
Punting with a FIXME note for the time being.

### Modify gitlab setup to gen and publish ssh key

This generates an SSH key pair for `git clone <ssh-remote>`.

The connection to gitlab is tested in the script. This operation acts
as both a test and to enter the host into ssh's known_hosts.

###  Ignore DeprecationWarnings in tests

These DeprecationWarnings are outside the scope of our direct
influence. Best to ignore them, thus removing them from our test output.

### Replace Gitlab PAT auth with SSH Key auth

The repositories will now use an SSH key for authentication.
This allows the remote url to remain the same throughout the life of
the repository.

### Make note of where the upstream fix resides

The fix is not yet accepted and may not be accepted.
The upstream acceptance of the change will allow us to remove the
`clone_from` override.

###  Have celery wait on main app to start before starting

This prevents any startup issues around missing configuration.

This modification also adds a health status to the houston service. When the status is healthy the celery services start.

### Include docker-entrypoint script as a mounted file in container

Because sometimes ya need to change it and the only other way to see those changes is to rebuild the image.
