### PR TITLE
Fix minor bugs in AssetGroupSighting get_completion and complete

### DIFF
--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -140,6 +140,8 @@ class JSON(db.TypeDecorator):
         def process(value):
             if value is None:
                 return None
+            elif isinstance(value, dict):
+                return value
             return json_deserializer(value)
 
         return process(value)


### PR DESCRIPTION
- Fix minor bugs in AssetGroupSighting get_completion and complete

  When calling `AssetGroupSighting.get_completion` when the stage is
  "detection":
  
  ```
  app/modules/asset_groups/models.py:271: in get_completion
      complete_jobs = [job for job in self.jobs if not job['active']]
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  
  .0 = <dict_keyiterator object at 0x7f9e849aa310>
  
  >   complete_jobs = [job for job in self.jobs if not job['active']]
  E   TypeError: string indices must be integers
  
  app/modules/asset_groups/models.py:271: TypeError
  ```
  
  This is because `self.jobs` is a dict which means `for job in self.jobs`
  is the `job` is actually the job id.  Changing `self.jobs` to
  `self.jobs.values()` fixes the problem.
  
  When calling `AssetGroupSighting.complete` to change from "curation" to
  "processed", it checks all the jobs are active but all the jobs are set
  to inactive after `AssetGroupSighting.job_complete` to change from
  "detection" to "curation", this is probably a bug so change it to check
  that all the jobs are inactive.

- Fix JSON result processor TypeError

  This happened when accessing `/api/v1/assets/src_raw/<asset-guid>`:
  
  ```
  2021-08-17 16:00:00,496 [INFO] [werkzeug] 172.22.0.2 - - [17/Aug/2021 16:00:00] "GET /api/v1/assets/src_raw/ed89bc78-0728-42a4-8b96-d630374c4fd2 HTTP/1.1" 500 -
  Traceback (most recent call last):
    File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 2464, in __call__
      return self.wsgi_app(environ, start_response)
    ...
    File "/code/app/extensions/auth/oauth2.py", line 210, in wrapper
      return origin_decorated_func(*args, **kwargs)
    File "/usr/local/lib/python3.9/site-packages/flask_oauthlib/provider/oauth2.py", line 612, in decorated
      return f(*args, **kwargs)
    File "/usr/local/lib/python3.9/site-packages/permission/permission.py", line 23, in decorator
      return func(*args, **kwargs)
    File "/code/flask_restx_patched/namespace.py", line 61, in wrapper
      return func_or_class(*args, **kwargs)
    File "/code/flask_restx_patched/namespace.py", line 396, in wrapper
      with permission(**kwargs_on_request(kwargs)):
    File "/usr/local/lib/python3.9/site-packages/permission/permission.py", line 32, in __enter__
      if not self.check():
    File "/usr/local/lib/python3.9/site-packages/permission/permission.py", line 54, in check
      result, self.deny = self.rule.run()
    File "/usr/local/lib/python3.9/site-packages/permission/permission.py", line 107, in run
      if not check():
    File "/code/app/modules/users/permissions/rules.py", line 268, in check
      was_table_driven, has_permission = self.any_table_driven_permission()
    File "/code/app/modules/users/permissions/rules.py", line 245, in any_table_driven_permission
      elif getattr(self._obj, method)(current_user):
    File "/code/app/modules/assets/models.py", line 163, in user_raw_read
      return self.is_detection() and user.is_internal
    File "/code/app/modules/assets/models.py", line 93, in is_detection
      return self.asset_group.is_detection_in_progress()
    File "/code/app/modules/asset_groups/models.py", line 1263, in is_detection_in_progress
      return self.is_partially_in_stage(AssetGroupSightingStage.detection)
    File "/code/app/modules/asset_groups/models.py", line 1243, in is_partially_in_stage
      if self.asset_group_sightings:
    File "/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/attributes.py", line 294, in __get__
      return self.impl.get(instance_state(instance), dict_)
    File "/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/attributes.py", line 730, in get
      value = self.callable_(state, passive)
    File "/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/strategies.py", line 759, in _load_for_state
      return self._emit_lazyload(
    File "<string>", line 1, in <lambda>
  
    File "/usr/local/lib/python3.9/site-packages/sqlalchemy/orm/strategies.py", line 900, in _emit_lazyload
      q(session)
    ...
    File "/usr/local/lib/python3.9/site-packages/sqlalchemy/sql/type_api.py", line 1283, in process
      return process_value(value, dialect)
    File "/code/app/extensions/__init__.py", line 145, in process_result_value
      return process(value)
    File "/code/app/extensions/__init__.py", line 143, in process
      return json_deserializer(value)
    File "/code/app/extensions/__init__.py", line 138, in json_deserializer
      return json.loads(*args, **kwargs, object_hook=custom_json_decoder)
    File "/usr/local/lib/python3.9/json/__init__.py", line 339, in loads
      raise TypeError(f'the JSON object must be str, bytes or bytearray, '
  TypeError: the JSON object must be str, bytes or bytearray, not dict
  ```
  
  So it appears that sometimes it's already a dict and there's no need to
  deserialize it...
