### PR TITLE
Adjust AssetGroupSighting detect API code

### DIFF
--- a/.env
+++ b/.env
@@ -53,6 +53,11 @@ EDM_AUTHENTICATIONS_PASSWORD__DEFAULT=4dm1n
 
 ACM_AUTHENTICATIONS_URI__DEFAULT=http://acm:5000/
 
+# OAuth client id and secret
+OAUTH_USER_EMAIL=oauth-user@wildme.org
+HOUSTON_CLIENT_ID=5ecba12d-d102-498e-805f-5531b448a67e
+HOUSTON_CLIENT_SECRET=6wql6OZ5TyRRDFFfC0SPhzFCyBXVQHVWOxgLBge24crbh4vuTQhOlTvedZ3Nay21
+
 ELASTICSEARCH_HOSTS=elasticsearch:9200
 
 # These are used by the set_up_gitlab.sh init script

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -387,34 +387,26 @@ class AssetGroupSighting(db.Model, HoustonModel):
         # response, process it here
         return True
 
-    def detected(self, job_id, data):
-        import uuid
-
+    def detected(self, job_id, response):
         if self.stage != AssetGroupSightingStage.detection:
             raise HoustonException(f'AssetGroupSighting {self.guid} is not detecting')
 
-        if str(job_id) not in self.jobs:
+        job = self.jobs.get(str(job_id))
+        if job is None:
             raise HoustonException(f'job_id {job_id} not found')
 
-        status = data.get('status')
+        status = response.get('status')
         if not status:
             raise HoustonException('No status in response from Sage')
 
-        success = status.get('success', False)
-        if not success:
+        if status != 'completed':
             self.stage = AssetGroupSightingStage.failed
             # This is not an exception as the message from Sage was valid
-            code = status.get('code', 'unset')
-            message = status.get('message', 'unset')
             # TODO this will be where the audit log fits in too
             log.warning(
-                f'JobID {str(job_id)} failed with code: {code} message: {message}'
+                f'JobID {str(job_id)} failed with status: {status} exception: {response.get("json_result")}'
             )
             return
-
-        response = data.get('response')
-        if not response:
-            raise HoustonException('No response field in message from Sage')
 
         job_id_msg = response.get('jobid')
         if not job_id_msg:
@@ -430,21 +422,27 @@ class AssetGroupSighting(db.Model, HoustonModel):
         if not json_result:
             raise HoustonException('No json_result in message from Sage')
 
-        image_uuids = json_result.get('image_uuid_list', [])
-        results = json_result.get('results_list', [])
-        if len(image_uuids) != len(results):
+        sage_image_uuids = json_result.get('image_uuid_list', [])
+        results_list = json_result.get('results_list', [])
+        if len(sage_image_uuids) != len(results_list):
             raise HoustonException(
-                f'image list len {len(image_uuids)} does not match results len {len(results)}'
+                f'image list len {len(sage_image_uuids)} does not match results len {len(results_list)}'
+            )
+        if len(sage_image_uuids) != len(job['asset_ids']):
+            raise HoustonException(
+                f'image list from sage {len(sage_image_uuids)} does not match local image list {len(job["asset_ids"])}'
             )
 
-        for asset_id in range(len(image_uuids)):
-            asset = Asset.find(uuid.UUID(image_uuids[asset_id]))
+        for i, asset_id in enumerate(job['asset_ids']):
+            asset = Asset.find(asset_id)
             if not asset:
-                raise HoustonException(f'Asset Id {results[asset_id]} not found')
+                raise HoustonException(f'Asset Id {asset_id} not found')
 
-            for annot_id in range(len(results[asset_id])):
-                annot_data = results[asset_id][annot_id]
-                annot_uuid = annot_data.get('uuid', None)
+            results = results_list[i]
+
+            for annot_id in range(len(results)):
+                annot_data = results[annot_id]
+                annot_uuid = annot_data.get('uuid', {}).get('__UUID__')
                 ia_class = annot_data.get('class', None)
                 if not annot_uuid or not ia_class:
                     raise HoustonException(

--- a/config.py
+++ b/config.py
@@ -4,6 +4,8 @@ import os
 import logging
 import datetime
 from pathlib import Path
+import random
+import string
 
 import pytz
 from dotenv import load_dotenv
@@ -196,6 +198,19 @@ class BaseConfig(object):
 
     RESTX_JSON = {
         'cls': flask.json.JSONEncoder,
+    }
+
+    OAUTH_USER = {
+        'email': os.getenv('OAUTH_USER_EMAIL', 'oauth-user@wildme.org'),
+        'password': os.getenv(
+            'OAUTH_USER_PASSWORD',
+            ''.join(
+                random.choice(string.ascii_letters + string.digits) for _ in range(20)
+            ),
+        ),
+        'is_internal': True,
+        'client_id': os.getenv('OAUTH_CLIENT_ID'),
+        'client_secret': os.getenv('OAUTH_CLIENT_SECRET'),
     }
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,8 @@ services:
     environment:
       # FIXME: Run as root to fix the PermissionError in volumes
       EXEC_PRIVILEGED: 1
+      HOUSTON_CLIENT_ID: "${HOUSTON_CLIENT_ID}"
+      HOUSTON_CLIENT_SECRET: "${HOUSTON_CLIENT_SECRET}"
     ports:
       # FIXME: exposed for developer verification
       - "82:5000"
@@ -150,6 +152,9 @@ services:
       GIT_PUBLIC_NAME: "${GIT_PUBLIC_NAME}"
       GIT_EMAIL: "${GIT_EMAIL}"
       GITLAB_NAMESPACE: "${GITLAB_NAMESPACE}"
+      OAUTH_CLIENT_ID: "${HOUSTON_CLIENT_ID}"
+      OAUTH_CLIENT_SECRET: "${HOUSTON_CLIENT_SECRET}"
+      OAUTH_USER_EMAIL: "${OAUTH_USER_EMAIL}"
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:5000/api/v1/site-info/"]
       timeout: 45s

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -3,10 +3,11 @@
 Asset_group resources utils
 -------------
 """
-import json
-import shutil
-import os
 import config
+import json
+import os
+import re
+import shutil
 from unittest import mock
 
 from tests import utils as test_utils
@@ -135,10 +136,31 @@ def create_asset_group_sim_sage(
             assert set(params.keys()) >= {
                 'endpoint',
                 'jobid',
-                'callback_url',
-                'image_uuid_list',
                 'input',
+                'image_uuid_list',
+                'callback_url',
+                'callback_detailed',
             }
+            assert set(params['input'].keys()) >= {
+                'start_detect',
+                'labeler_algo',
+                'labeler_model_tag',
+                'model_tag',
+            }
+            assert params['endpoint'] == '/api/engine/detect/cnn/lightnet/'
+            assert re.match('[a-f0-9-]{36}', params['jobid'])
+            assert re.match(
+                r'houston\+http://houston:5000/api/v1/asset_group/sighting/[a-f0-9-]{36}/sage_detected/'
+                + params['jobid'],
+                params['callback_url'],
+            )
+            assert all(
+                re.match(
+                    r'houston\+http://houston:5000/api/v1/asset/src_raw/[a-f0-9-]{36}',
+                    uri,
+                )
+                for uri in params['image_uuid_list']
+            )
         except Exception:
             # Calling code cannot clear up the asset group as the resp is not passed if any of the assertions fail
             # meaning that all subsequent tests would fail.

--- a/tests/modules/asset_groups/test_models.py
+++ b/tests/modules/asset_groups/test_models.py
@@ -62,6 +62,7 @@ def test_asset_group_sightings_jobs(flask_app, db, admin_user, test_root, reques
             'model': 'african_terrestrial',
             'active': True,
             'start': now,
+            'asset_ids': [str(asset_group.assets[0].guid)],
         },
     }
     assert AssetGroupSighting.query.get(ags2.guid).jobs == {
@@ -69,6 +70,7 @@ def test_asset_group_sightings_jobs(flask_app, db, admin_user, test_root, reques
             'model': 'african_terrestrial',
             'active': True,
             'start': now,
+            'asset_ids': [],
         },
     }
 

--- a/tests/modules/test_ia_pipeline.py
+++ b/tests/modules/test_ia_pipeline.py
@@ -48,7 +48,7 @@ def test_ia_pipeline_sim_detect_response(
 
         # Simulate response from Sage
         sage_resp = asset_group_utils.build_sage_detection_response(
-            asset_group_uuid, job_uuid
+            asset_group_sighting1_guid, job_uuid
         )
         asset_group_utils.send_sage_detection_response(
             flask_app_client,


### PR DESCRIPTION
- Create oauth user for acm before first request

  Add code to create oauth user for acm to use before first request.  ACM
  needs a oauth client id and secret in order to get the images from
  houston.  This adds a static client id and secret which is shared by
  houston and acm and it is created before the first request so ACM will
  be able to authenticate.

- Adjust AssetGroupSighting data sent to wbia detect API

  - Use `urllib.parse.urljoin` to create urls
  - Prepend `houston+` to urls that require oauth2 authentication
  - Change `image_uuid_list` to a list of asset urls
  - Move `callback_url` and `callback_detailed` from inside `input` to
    outside
  - Save asset ids with the job info in AssetGroupSighting

- Adjust code for AssetGroupSighting detection callback handler

  - Remove the extra level of API status code and message that's returned
    from normal sage APIs.  This works differently because it's a
    callback.
  - Disregard the image uuids returned from sage because those are
    different from the houston ones, the asset ids are stored with the job
    info
  - Update the tests with real results from sage
