### PR TITLE
432 Notification Preferences now added to API (read and patch) and are used

### DIFF
--- a/app/modules/notifications/models.py
+++ b/app/modules/notifications/models.py
@@ -96,7 +96,7 @@ class Notification(db.Model, HoustonModel):
         return (
             '<{class_name}('
             'guid={self.guid}, '
-            'template={self.message_type}, '
+            'message_type={self.message_type}, '
             "recipient='{self.recipient}'"
             ')>'.format(class_name=self.__class__.__name__, self=self)
         )
@@ -199,20 +199,21 @@ class NotificationPreferences(HoustonModel):
 
     @classmethod
     def validate_preferences(cls, new_prefs):
-        valid_types = set([pref.name for pref in NotificationType])
+        valid_types = set([pref.value for pref in NotificationType])
         if isinstance(new_prefs, dict) and set(new_prefs.keys()) <= valid_types:
             for new_pref_type in new_prefs:
-                valid_channels = set([pref.name for pref in NotificationChannel])
+                valid_channels = set([pref.value for pref in NotificationChannel])
+                new_preference = new_prefs[new_pref_type]
                 if not (
-                    isinstance(new_pref_type, dict)
-                    and set(new_pref_type.keys()) <= valid_channels
+                    isinstance(new_preference, dict)
+                    and set(new_preference.keys()) <= valid_channels
                 ):
                     raise HoustonException(
                         log_message=f'Invalid Notification channel, options are {valid_channels}'
                     )
                 else:
-                    for new_chan in new_pref_type:
-                        if not isinstance(new_chan.value, bool):
+                    for new_chan in new_preference:
+                        if not isinstance(new_preference[new_chan], bool):
                             raise HoustonException(
                                 log_message='all values set in NotificationPreferences must be boolean '
                             )

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -555,6 +555,14 @@ class User(db.Model, FeatherModel, UserEDMMixin):
             )
         return json_resp
 
+    def get_notification_preferences(self):
+        from app.modules.notifications.models import UserNotificationPreferences
+
+        # User preferences are the system ones plus the ones stored in this class
+        # Return the combination to the REST API
+        preferences = UserNotificationPreferences.get_user_preferences(self)
+        return preferences
+
     def unprocessed_asset_groups(self):
         return [
             asset_group.guid

--- a/app/modules/users/parameters.py
+++ b/app/modules/users/parameters.py
@@ -17,6 +17,7 @@ import PIL
 
 from app.extensions.api.parameters import PaginationParameters
 from app.extensions.api import abort
+from app.utils import HoustonException
 
 from . import schemas
 
@@ -139,6 +140,7 @@ class PatchUserDetailsParameters(PatchJSONParameters):
         User.shares_data.key,
         User.default_identification_catalogue.key,
         User.profile_fileupload_guid.key,
+        User.notification_preferences.key,
         User.is_active.fget.__name__,
         User.is_exporter.fget.__name__,
         User.is_internal.fget.__name__,
@@ -238,6 +240,13 @@ class PatchUserDetailsParameters(PatchJSONParameters):
 
         if field == User.profile_fileupload_guid.key:
             value = cls.add_replace_profile_fileupload(value)
+        elif field == User.notification_preferences.key:
+            from app.modules.notifications.models import NotificationPreferences
+
+            try:
+                NotificationPreferences.validate_preferences(value)
+            except HoustonException as ex:
+                abort(ex.status_code, ex.message)
 
         return super(PatchUserDetailsParameters, cls).replace(obj, field, value, state)
 

--- a/app/modules/users/schemas.py
+++ b/app/modules/users/schemas.py
@@ -87,6 +87,8 @@ class DetailedUserSchema(UserListSchema):
             User.location.key,
             User.forum_id.key,
             User.website.key,
+            # TODO this should be the defaults if the user has none
+            User.notification_preferences.key,
             'collaborations',
         )
 

--- a/app/modules/users/schemas.py
+++ b/app/modules/users/schemas.py
@@ -77,6 +77,7 @@ class DetailedUserSchema(UserListSchema):
     """ Detailed user schema exposes all fields used to render a normal user profile. """
 
     collaborations = base_fields.Function(User.get_collaborations_as_json)
+    notification_preferences = base_fields.Function(User.get_notification_preferences)
 
     class Meta(UserListSchema.Meta):
         fields = UserListSchema.Meta.fields + (
@@ -87,8 +88,7 @@ class DetailedUserSchema(UserListSchema):
             User.location.key,
             User.forum_id.key,
             User.website.key,
-            # TODO this should be the defaults if the user has none
-            User.notification_preferences.key,
+            'notification_preferences',
             'collaborations',
         )
 

--- a/tests/modules/notifications/resources/test_notifications.py
+++ b/tests/modules/notifications/resources/test_notifications.py
@@ -100,3 +100,26 @@ def test_patch_notification(
         {'sender_name', 'sender_email', 'collaboration_guid'}
     )
     assert res_2_notif.json['is_read']
+
+
+def test_notification_preferences(
+    db, flask_app_client, researcher_1, researcher_2, user_manager_user
+):
+    notif_1_data = NotificationBuilder(researcher_1)
+    # Just needs anything with a guid
+    notif_1_data.set_collaboration(user_manager_user)
+
+    Notification.create(NotificationType.collab_request, researcher_2, notif_1_data)
+
+    researcher_2_notifs = notif_utils.read_all_notifications(
+        flask_app_client, researcher_2
+    )
+    breakpoint()
+    collab_requests_from_res1 = list(
+        filter(
+            lambda notif: notif['message_type'] == 'collaboration_request'
+            and notif['sender_email'] == researcher_1.email,
+            researcher_2_notifs.json,
+        )
+    )
+    assert len(collab_requests_from_res1) > 1

--- a/tests/modules/users/resources/test_signup.py
+++ b/tests/modules/users/resources/test_signup.py
@@ -269,6 +269,7 @@ def test_new_user_creation_roles_admin(flask_app_client, admin_user, db):
         'viewed': response.json['viewed'],
         'website': None,
         'collaborations': [],
+        'notification_preferences': [],
     }
 
     # Cleanup

--- a/tests/modules/users/resources/test_signup.py
+++ b/tests/modules/users/resources/test_signup.py
@@ -246,6 +246,8 @@ def test_new_user_creation_roles_admin(flask_app_client, admin_user, db):
     assert response.status_code == 200
     assert response.content_type == 'application/json'
     user_guid = response.json['guid']
+    from app.modules.notifications.models import NOTIFICATION_DEFAULTS
+
     assert response.json == {
         'affiliation': '',
         'created': response.json['created'],
@@ -269,7 +271,7 @@ def test_new_user_creation_roles_admin(flask_app_client, admin_user, db):
         'viewed': response.json['viewed'],
         'website': None,
         'collaborations': [],
-        'notification_preferences': [],
+        'notification_preferences': NOTIFICATION_DEFAULTS,
     }
 
     # Cleanup

--- a/tests/modules/users/resources/utils.py
+++ b/tests/modules/users/resources/utils.py
@@ -5,6 +5,7 @@ Asset_group resources utils
 """
 
 from tests import utils as test_utils
+import json
 
 PATH = '/api/v1/users/'
 
@@ -23,4 +24,29 @@ def read_user(flask_app_client, user, sub_path, expected_status_code=200):
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message'}
         )
+    return response
+
+
+def patch_user(
+    flask_app_client,
+    user,
+    data,
+    expected_status_code=200,
+    expected_error='',
+):
+    with flask_app_client.login(user, auth_scopes=('users:write',)):
+        response = flask_app_client.patch(
+            '%s%s' % (PATH, user.guid),
+            content_type='application/json',
+            data=json.dumps(data),
+        )
+
+    if expected_status_code == 200:
+        test_utils.validate_dict_response(response, 200, {'guid'})
+    else:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+        assert response.json['message'] == expected_error, response.json['message']
+
     return response

--- a/tests/modules/users/test_schemas.py
+++ b/tests/modules/users/test_schemas.py
@@ -54,6 +54,7 @@ def test_DetailedUserSchema_dump_user_instance(user_instance):
         'forum_id',
         'website',
         'collaborations',
+        'notification_preferences',
     }
 
 


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Notification Preferences can be read and patched via API
- Notification preferences used for REST API output

---


**REST API Updates [OPTIONAL]**

Detailed User schema now contains notification preferences for the user which are a superset of the site NotificationPreferences with the User specific preferences.
These can then be patched individually or in entirety via the Rest API

