### PR TITLE
Asset code cleanup

### DIFF
--- a/app/modules/app_ui.py
+++ b/app/modules/app_ui.py
@@ -13,12 +13,10 @@ from flask import (
     redirect,
     render_template,
     request,
-    send_file,
     url_for,
 )
 from flask_login import login_user, logout_user, login_required, current_user
 
-from app.modules.assets.models import Asset
 from app.modules.auth.views import (
     _url_for,
     _is_safe_url,
@@ -174,18 +172,6 @@ def user_logout(*args, **kwargs):
     flash('You were successfully logged out.', 'warning')
 
     return flask.redirect(_url_for('backend.home'))
-
-
-@backend_blueprint.route('/asset/<code>', methods=['GET'])
-# @login_required
-@ensure_admin_exists
-def asset(code, *args, **kwargs):
-    # pylint: disable=unused-argument
-    """
-    This endpoint is the account page for the logged-in user
-    """
-    asset = Asset.query.filter_by(code=code).first_or_404()
-    return send_file(asset.absolute_filepath, mimetype='image/jpeg')
 
 
 @backend_blueprint.route('/admin_init', methods=['GET'])

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -64,6 +64,9 @@ class Asset(db.Model, HoustonModel):
         'Annotation', back_populates='asset', order_by='Annotation.guid'
     )
 
+    DERIVED_EXTENSION = 'jpg'
+    DERIVED_MIME_TYPE = 'image/jpeg'
+
     def __repr__(self):
         return (
             '<{class_name}('
@@ -120,8 +123,7 @@ class Asset(db.Model, HoustonModel):
     def get_derived_path(self):
         asset_group_abspath = self.asset_group.get_absolute_path()
         assets_path = os.path.join(asset_group_abspath, '_assets')
-        asset_symlink_filepath = os.path.join(assets_path, 'derived', self.get_filename())
-        return asset_symlink_filepath
+        return os.path.join(assets_path, 'derived')
 
     def update_symlink(self, asset_asset_group_filepath):
         assert os.path.exists(asset_asset_group_filepath)
@@ -195,8 +197,9 @@ class Asset(db.Model, HoustonModel):
             'thumb': [256, 256],
         }
         assert format in FORMAT
-        target_path = '.'.join(
-            [os.path.splitext(self.get_derived_path())[0], format, 'jpg']
+        target_path = os.path.join(
+            self.get_derived_path(),
+            '.'.join([str(self.guid), format, self.DERIVED_EXTENSION]),
         )
         if os.path.exists(target_path):
             return target_path
@@ -224,10 +227,12 @@ class Asset(db.Model, HoustonModel):
     def get_or_make_master_format_path(self):
         source_path = self.get_symlink()
         assert os.path.exists(source_path)
-        target_path = self.get_derived_path()
-        if not os.path.exists(os.path.dirname(target_path)):
-            os.mkdir(os.path.dirname(target_path))
-        target_path = '.'.join([os.path.splitext(target_path)[0], 'master', 'jpg'])
+        target_dir = self.get_derived_path()
+        if not os.path.exists(target_dir):
+            os.mkdir(target_dir)
+        target_path = os.path.join(
+            target_dir, '.'.join([str(self.guid), 'master', self.DERIVED_EXTENSION])
+        )
         if os.path.exists(target_path):
             return target_path
         log.info('make_master_format() creating master format as %r' % (target_path,))

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -111,15 +111,6 @@ class Asset(db.Model, HoustonModel):
     def get_original_filename(self):
         return os.path.basename(self.path)
 
-    def get_relative_path(self):
-        relpath = os.path.join(
-            'asset_groups',
-            str(self.asset_group.guid),
-            '_assets',
-            self.get_filename(),
-        )
-        return relpath
-
     def get_symlink(self):
         asset_group_abspath = self.asset_group.get_absolute_path()
         assets_path = os.path.join(asset_group_abspath, '_assets')

--- a/app/modules/assets/resources.py
+++ b/app/modules/assets/resources.py
@@ -130,9 +130,7 @@ class AssetSrcUByID(Resource):
         except Exception:
             logging.exception('Got exception from get_or_make_format_path()')
             raise werkzeug.exceptions.NotImplemented
-        return send_file(
-            asset_format_path, 'image/jpeg'
-        )  # TODO we need to alter mime_type to reflect path, if ever it changes from jpg
+        return send_file(asset_format_path, asset.DERIVED_MIME_TYPE)
 
 
 @api.route('/src_raw/<uuid:asset_guid>', doc=False)
@@ -151,5 +149,4 @@ class AssetSrcRawByID(Resource):
         },
     )
     def get(self, asset):
-        # TODO does WBIA depend on the mime_type being jpg and do we need to change it if it's not
         return send_file(asset.get_symlink())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -346,6 +346,14 @@ def test_asset_group_file_data(test_root):
             uuid.UUID('00000000-0000-0000-0000-000000000012'),
             test_root / 'fluke.jpg',
         ),
+        (
+            uuid.UUID('00000000-0000-0000-0000-000000000013'),
+            test_root / 'phoenix.jpg',
+        ),
+        (
+            uuid.UUID('00000000-0000-0000-0000-000000000014'),
+            test_root / 'coelacanth.png',
+        ),
     ]
 
 

--- a/tests/modules/asset_groups/resources/test_ensure_submission.py
+++ b/tests/modules/asset_groups/resources/test_ensure_submission.py
@@ -8,9 +8,7 @@ from tests.modules.asset_groups.resources import utils
 def test_ensure_asset_group_by_uuid(
     flask_app_client, researcher_1, db, test_asset_group_uuid
 ):
-    clone = utils.clone_asset_group(
-        flask_app_client, researcher_1, test_asset_group_uuid
-    )
+    clone = utils.clone_asset_group(flask_app_client, researcher_1, test_asset_group_uuid)
     clone.cleanup()
 
 
@@ -48,7 +46,7 @@ def test_ensure_clone_asset_group_by_uuid(
     )
 
     # Checks that there are two valid Assets in the database
-    assert len(clone.asset_group.assets) == 2
+    assert len(clone.asset_group.assets) == 4
     temp_assets = sorted(clone.asset_group.assets)
     expected_guid_list = [
         uuid.UUID(test_clone_asset_group_data['asset_uuids'][0]),

--- a/tests/modules/assets/resources/test_assets.py
+++ b/tests/modules/assets/resources/test_assets.py
@@ -185,7 +185,7 @@ def test_read_all_assets(
     admin_response = asset_utils.read_all_assets(flask_app_client, admin_user)
     asset_utils.read_all_assets(flask_app_client, researcher_1, 403)
 
-    assert len(admin_response.json) == 2
+    assert len(admin_response.json) == 4
     # both of these lists should be lexical order
     assert admin_response.json[0]['guid'] == test_clone_asset_group_data['asset_uuids'][0]
     assert admin_response.json[1]['guid'] == test_clone_asset_group_data['asset_uuids'][1]

--- a/tests/modules/assets/resources/utils.py
+++ b/tests/modules/assets/resources/utils.py
@@ -36,7 +36,6 @@ def read_src_asset(flask_app_client, user, asset_guid, expected_status_code=200)
 
     if expected_status_code == 200:
         assert response.status_code == expected_status_code
-        assert response.content_type == 'image/jpeg'
     else:
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message'}
@@ -50,7 +49,6 @@ def read_raw_src_asset(flask_app_client, user, asset_guid, expected_status_code=
 
     if expected_status_code == 200:
         assert response.status_code == expected_status_code
-        assert response.content_type == 'image/jpeg'
     else:
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message'}


### PR DESCRIPTION
- Remove unused Asset method get_relative_path

  I grepped for `get_relative_path` and it is not used anywhere.  It was
  used to be in `Asset.path` when it was a property instead of a database
  field.

- Add all the images in the asset group fixture

  We used to have only "zebra.jpg" and "fluke.jpg" but now we also have
  "phoenix.jpg" and "coelacanth.png".

- Move derived file ext and mime type to constants in Asset

  We hardcoded the content type to be "image/jpeg" in resources.py and
  the file extension to be "jpg" in models.py.  Probably best to move them
  to constants so it's easier to see what's going on.
  
  By the way, I tried sending a png file to sage detection and it came
  back with results so I guess it's working even when it's not jpegs.

- Remove `/asset/<code>` from app_ui.py

  It tries to query a database field "code" which has been removed a long
  time ago... I'm pretty sure this endpoint should be removed as well.


---

**Question:** Do we always want to change images to jpegs when we create the thumbnails?