### PR TITLE
Use marshmallow schema to validate notification json

### DIFF
--- a/app/modules/notifications/models.py
+++ b/app/modules/notifications/models.py
@@ -25,7 +25,7 @@ class NotificationType(str, enum.Enum):
 
 # Can send messages out on multiple channels
 class NotificationChannel(str, enum.Enum):
-    rest = 'Rest API'
+    rest = 'restAPI'
     email = 'email'
 
 
@@ -198,29 +198,12 @@ class NotificationPreferences(HoustonModel):
 
     @classmethod
     def validate_preferences(cls, new_prefs):
-        valid_types = set([pref.value for pref in NotificationType])
-        if isinstance(new_prefs, dict) and set(new_prefs.keys()) <= valid_types:
-            for new_pref_type in new_prefs:
-                valid_channels = set([pref.value for pref in NotificationChannel])
-                new_preference = new_prefs[new_pref_type]
-                if not (
-                    isinstance(new_preference, dict)
-                    and set(new_preference.keys()) <= valid_channels
-                ):
-                    raise HoustonException(
-                        log, f'Invalid Notification channel, options are {valid_channels}'
-                    )
-                else:
-                    for new_chan in new_preference:
-                        if not isinstance(new_preference[new_chan], bool):
-                            raise HoustonException(
-                                log,
-                                'all values set in NotificationPreferences must be boolean ',
-                            )
-        else:
-            raise HoustonException(
-                log, f'Invalid Notification Type, options are {valid_types}'
-            )
+        from .schemas import NotificationPreferenceSchema
+
+        schema = NotificationPreferenceSchema()
+        errors = schema.validate(new_prefs)
+        if errors:
+            raise HoustonException(log, schema.get_error_message(errors))
 
 
 class SystemNotificationPreferences(db.Model, NotificationPreferences):

--- a/app/modules/notifications/models.py
+++ b/app/modules/notifications/models.py
@@ -118,17 +118,13 @@ class Notification(db.Model, HoustonModel):
     def channels_to_send(self, digest=False):
         # pylint: disable=invalid-name
         # In future the channels to send right now will be different for digest generation
-        channels = None
         user_prefs = UserNotificationPreferences.get_user_preferences(self.recipient)
-        if self.message_type in user_prefs.keys():
-            channels = user_prefs[self.message_type]
-            for name in channels.keys():
-                # Don't blame me, I tried to make this line more readable, brunette insisted that it
-                # was more readable when the params were nowhere near the function name
-                if channels[name] and not user_prefs[NotificationType.all].get(
-                    name, True
-                ):
-                    channels[name] = False
+        channels = user_prefs.get(self.message_type, {})
+        for name in channels:
+            # If user set a channel to False in "all", it overrides the
+            # local channel setting
+            if not user_prefs[NotificationType.all].get(name, True):
+                channels[name] = False
 
         return channels
 

--- a/app/modules/notifications/schemas.py
+++ b/app/modules/notifications/schemas.py
@@ -4,11 +4,22 @@ Serialization schemas for Notifications resources RESTful API
 ----------------------------------------------------
 """
 
-# from flask_marshmallow import base_fields
 from flask_restx_patched import ModelSchema
 from flask_marshmallow import base_fields
 
+from app.extensions import ExtraValidationSchema
 from .models import Notification
+
+
+class NotificationPreferenceSchema(ExtraValidationSchema):
+    class NotificationChannelSchema(ExtraValidationSchema):
+        restAPI = base_fields.Bool()
+        email = base_fields.Bool()
+
+    all = base_fields.Nested(NotificationChannelSchema)
+    raw = base_fields.Nested(NotificationChannelSchema)
+    collaboration_request = base_fields.Nested(NotificationChannelSchema)
+    merge_request = base_fields.Nested(NotificationChannelSchema)
 
 
 class BaseNotificationSchema(ModelSchema):

--- a/app/utils.py
+++ b/app/utils.py
@@ -22,5 +22,8 @@ class HoustonException(Exception):
         logger.warning(f'Failed: {log_message} {self.status_code}')
         audit_log(logger, f'Failed: {log_message} {self.status_code}', AuditType.Fault)
 
+    def __str__(self):
+        return self.message
+
     def get_val(self, argval, default):
         return self._kwargs.get(argval, default)

--- a/tests/modules/notifications/resources/test_notifications.py
+++ b/tests/modules/notifications/resources/test_notifications.py
@@ -160,7 +160,7 @@ def test_notification_preferences(
     data = [
         test_utils.patch_replace_op(
             'notification_preferences',
-            {'collaboration_request': {'Rest API': False, 'email': False}},
+            {'collaboration_request': {'restAPI': False, 'email': False}},
         )
     ]
     user_utils.patch_user(flask_app_client, researcher_2, data)
@@ -175,7 +175,7 @@ def test_notification_preferences(
     # Test patch of all requests
     data = [
         test_utils.patch_replace_op(
-            'notification_preferences', {'all': {'Rest API': False, 'email': False}}
+            'notification_preferences', {'all': {'restAPI': False, 'email': False}}
         )
     ]
     user_utils.patch_user(flask_app_client, researcher_2, data)
@@ -191,7 +191,7 @@ def test_notification_preferences(
     data = [
         test_utils.patch_replace_op(
             'notification_preferences',
-            {'collaboration_request': {'Rest API': True, 'email': False}},
+            {'collaboration_request': {'restAPI': True, 'email': False}},
         )
     ]
     user_utils.patch_user(flask_app_client, researcher_2, data)


### PR DESCRIPTION
The advantage of doing it this way is we can clearly see how the json
should look like and we don't have to rewrite validation code for other
APIs that also accept custom json.

--- 

On Friday in discord, we talked about using marshmallow schema for validation so I tried it out.