### PR TITLE
DEX-450: use IAConfig to populate "suggested values" for site-setup of taxonomy

### DIFF
--- a/app/modules/configuration/resources.py
+++ b/app/modules/configuration/resources.py
@@ -39,6 +39,32 @@ class EDMConfigurationDefinition(Resource):
             path,
             target=target,
         )
+        from app.modules.ia_config_reader import IaConfig
+
+        ia_config_reader = IaConfig()
+        species = ia_config_reader.get_configured_species()
+        if not isinstance(
+            data['response']['configuration']['site.species']['suggestedValues'], list
+        ):
+            data['response']['configuration']['site.species']['suggestedValues'] = ()
+        for sn in species:  # only adds a species that is not already in suggestedValues
+            if (
+                next(
+                    (
+                        x
+                        for x in data['response']['configuration']['site.species'][
+                            'suggestedValues'
+                        ]
+                        if x.get('scientificName', None) == sn
+                    ),
+                    None,
+                )
+                is None
+            ):
+                data['response']['configuration']['site.species'][
+                    'suggestedValues'
+                ].insert(0, {'scientificName': sn, 'commonNames': [sn]})
+
         # TODO also traverse private here FIXME
         return data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -120,6 +120,8 @@ services:
       # https://github.com/WildMeOrg/Wildbook/commit/6d65e70e43691f1b281bb76edf151e5c7cdb7403
       ADMIN_EMAIL: "${EDM_AUTHENTICATIONS_USERNAME__DEFAULT}"
       ADMIN_PASSWORD: "${EDM_AUTHENTICATIONS_PASSWORD__DEFAULT}"
+      # JAVA_OPTS from old-world wildbook, which gives us 4G heap memory
+      JAVA_OPTS: "-Djava.awt.headless=true -XX:+UseConcMarkSweepGC -Xms4096m -Xmx4096m"
 
   houston:
     # https://github.com/WildMeOrg/houston


### PR DESCRIPTION
## Pull Request Overview

- Use IAConfig's `get_configured_species()` to populate site setting `site.species` _suggested values_
- Note: this will **append** to (not replace) any _existing_ suggested values that is defined in configurationDefinition for `site.species`
- _Bonus commit:_ this also sneaks in the 4GB tomcat (EDM) java heap space environment variable for `docker-compose.yml`