### PR TITLE
457 generate audit logs plus new helper interfaces

### DIFF
--- a/app/extensions/logging/__init__.py
+++ b/app/extensions/logging/__init__.py
@@ -8,61 +8,25 @@ from flask_login import current_user  # NOQA
 import enum
 
 
-class AuditType(str, enum.Enum):
-    Create = 'Create'
-    Delete = 'Delete'
-    Update = 'Update'  # Generic Update
-    Fault = 'Fault'
-    Other = 'Other'  # None of the above
-
-
-# somewhere between Error and Critical to guarantee that it appears in the logs but is not interpreted as a
-# real error by the reader
-AUDIT = 45
-
-
-# logger for calling file needed as a parameter to ensure that the file and line numbers are correct in logs
-def audit_log(logger, msg, audit_type=AuditType.Other, *args, **kwargs):
-    assert object
-
-    user_email = 'anonymous user'
-    if current_user and not current_user.is_anonymous:
-        msg = f'{msg} executed by user :{current_user.guid} {current_user.email}'
-        user_email = current_user.email
-    else:
-        msg = f' {msg} executed by anonymous user'
-    logger.log(AUDIT, msg, *args, **kwargs)
-    from app.modules.audit_logs.models import AuditLog
-
-    AuditLog.create(msg, audit_type, user_email)
-
-
-# As per above but this time an object must be passed that must have a guid member
-def audit_log_object(logger, obj, msg, audit_type, *args, **kwargs):
-    assert obj
-    assert hasattr(obj, 'guid')
-    assert isinstance(audit_type, AuditType)
-    orig_msg = msg
-
-    module_name = obj.__class__.__name__
-    msg = f'{audit_type} of {module_name} {obj.guid} {msg}'
-    user_email = 'anonymous user'
-    if current_user and not current_user.is_anonymous:
-        msg = f'{msg} executed by user :{current_user.guid} {current_user.email}'
-        user_email = current_user.email
-    else:
-        msg = f' {msg} executed by anonymous user'
-    logger.log(AUDIT, msg, *args, **kwargs)
-    from app.modules.audit_logs.models import AuditLog
-
-    AuditLog.create(orig_msg, audit_type, user_email, module_name, obj.guid)
-
-
 class Logging(object):
     """
     This is a helper extension, which adjusts logging configuration for the
     application.
     """
+
+    # somewhere between Error and Critical to guarantee that it appears in the logs but is not interpreted as a
+    # real error by the reader
+    AUDIT = 45
+
+    class AuditType(str, enum.Enum):
+        UserCreate = 'User Create'
+        SystemCreate = 'System Create'
+        Delete = 'Delete'
+        Update = 'Update'  # Generic Update
+        FrontEndFault = 'Front End Fault'  # Bad message received on API
+        BackEndFault = 'Back End Fault'  # Faulty message received from ACM/EDM etc
+        HoustonFault = 'Houston Fault'  # Internal Error within Houston
+        Other = 'Other'  # None of the above
 
     def __init__(self, app=None):
         if app:
@@ -93,4 +57,86 @@ class Logging(object):
             sqla_logger.removeHandler(hdlr)
         sqla_logger.addHandler(logging.NullHandler())
 
-        logging.addLevelName(AUDIT, 'AUDIT')
+        logging.addLevelName(self.AUDIT, 'AUDIT')
+
+    # logger for calling file needed as a parameter to ensure that the file and line numbers are correct in logs
+    @classmethod
+    def audit_log(cls, logger, msg, audit_type=AuditType.Other, *args, **kwargs):
+        assert object
+
+        user_email = 'anonymous user'
+        if current_user and not current_user.is_anonymous:
+            msg = f'{msg} executed by user :{current_user.guid} {current_user.email}'
+            user_email = current_user.email
+        else:
+            msg = f' {msg} executed by anonymous user'
+        logger.log(cls.AUDIT, msg, *args, **kwargs)
+        from app.modules.audit_logs.models import AuditLog
+
+        AuditLog.create(msg, audit_type, user_email)
+
+    @classmethod
+    def audit_log_object(
+        cls, logger, obj, msg='', audit_type=AuditType.Other, *args, **kwargs
+    ):
+        assert obj
+        assert hasattr(obj, 'guid')
+        assert isinstance(audit_type, cls.AuditType)
+        orig_msg = msg
+
+        module_name = obj.__class__.__name__
+        msg = f'{audit_type} of {module_name} {obj.guid} {msg}'
+        user_email = 'anonymous user'
+        if current_user and not current_user.is_anonymous:
+            msg = f'{msg} executed by user :{current_user.guid} {current_user.email}'
+            user_email = current_user.email
+        else:
+            msg = f' {msg} executed by anonymous user'
+        logger.log(cls.AUDIT, msg, *args, **kwargs)
+        from app.modules.audit_logs.models import AuditLog
+
+        AuditLog.create(orig_msg, audit_type, user_email, module_name, obj.guid)
+
+    @classmethod
+    def user_create_object(cls, logger, obj, msg='', *args, **kwargs):
+        cls.audit_log_object(logger, obj, msg, cls.AuditType.UserCreate, *args, **kwargs)
+
+    @classmethod
+    def system_create_object(cls, logger, obj, msg='', *args, **kwargs):
+        cls.audit_log_object(logger, obj, msg, cls.AuditType.UserCreate, *args, **kwargs)
+
+    @classmethod
+    def backend_fault(cls, logger, msg='', obj=None, *args, **kwargs):
+        if obj:
+            cls.audit_log_object(
+                logger, obj, msg, cls.AuditType.BackendFault, *args, **kwargs
+            )
+        else:
+            cls.audit_log(logger, msg, *args, **kwargs)
+
+    @classmethod
+    def delete_object(cls, logger, obj, msg='', *args, **kwargs):
+        cls.audit_log_object(logger, obj, msg, cls.AuditType.Delete, *args, **kwargs)
+
+    @classmethod
+    def patch_object(cls, logger, obj, patch_args, *args, **kwargs):
+        from app.modules.audit_logs.models import AuditMaxMessageLength
+
+        msg = ''
+        for patch in patch_args:
+
+            new_msg = f"{patch['op']} {patch['field_name']}"
+            if 'value' in patch:
+                new_msg += f", {patch['value']} "
+            else:
+                new_msg += ' '
+            # If the message gets too long, spread it across multiple audit entries
+            if len(new_msg) + len(msg) >= AuditMaxMessageLength:
+                cls.audit_log_object(
+                    logger, obj, msg, cls.AuditType.Update, *args, **kwargs
+                )
+                msg = new_msg
+            else:
+                msg += new_msg
+
+        cls.audit_log_object(logger, obj, msg, cls.AuditType.Update, *args, **kwargs)

--- a/app/modules/annotations/resources.py
+++ b/app/modules/annotations/resources.py
@@ -15,6 +15,7 @@ from app.extensions.api import Namespace, abort
 from app.extensions.api.parameters import PaginationParameters
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
+import app.extensions.logging as AuditLog
 
 from . import parameters, schemas
 from .models import Annotation
@@ -89,6 +90,7 @@ class Annotations(Resource):
         )
         with context:
             annotation = Annotation(**args)
+            AuditLog.user_create_object(log, annotation)
             db.session.add(annotation)
         return annotation
 
@@ -142,6 +144,8 @@ class AnnotationByID(Resource):
                 args, obj=annotation
             )
             db.session.merge(annotation)
+            AuditLog.patch_object(log, annotation, args)
+
         return annotation
 
     @api.permission_required(
@@ -158,5 +162,6 @@ class AnnotationByID(Resource):
         """
         Delete a Annotation by ID.
         """
+        AuditLog.delete_object(log, annotation)
         annotation.delete()
         return None

--- a/app/modules/audit_logs/models.py
+++ b/app/modules/audit_logs/models.py
@@ -10,6 +10,8 @@ from app.extensions import db
 
 import uuid
 
+AuditMaxMessageLength = 240
+
 
 class AuditLog(db.Model, Timestamp):
     """
@@ -26,7 +28,7 @@ class AuditLog(db.Model, Timestamp):
     item_guid = db.Column(db.GUID, nullable=True)
     user_email = db.Column(db.String(length=120), nullable=False)
 
-    message = db.Column(db.String(length=240), nullable=True)
+    message = db.Column(db.String(length=AuditMaxMessageLength), nullable=True)
     # One of AuditType
     audit_type = db.Column(db.String, nullable=False)
 
@@ -42,14 +44,13 @@ class AuditLog(db.Model, Timestamp):
     @classmethod
     def create(cls, msg, audit_type, user_email, module_name=None, item_guid=None):
 
-        # only store max 240 chars
-        if len(msg) > 240:
-            msg = msg[0:240]
+        # only store max
+        if len(msg) > AuditMaxMessageLength:
+            msg = msg[0:AuditMaxMessageLength]
 
         if module_name or item_guid:
             # Must set both of them or neither
-            assert item_guid
-            assert module_name
+            assert item_guid and module_name
             log_entry = AuditLog(
                 module_name=module_name,
                 item_guid=item_guid,

--- a/app/modules/audit_logs/parameters.py
+++ b/app/modules/audit_logs/parameters.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""
+Input arguments (Parameters) for Audit_logs resources RESTful API
+-----------------------------------------------------------
+"""
+from flask_marshmallow import base_fields
+
+from app.extensions.api.parameters import PaginationParameters
+
+
+class GetCollaborationParameters(PaginationParameters):
+    module_name = base_fields.String(
+        description='Optional Module Required', required=False
+    )

--- a/app/modules/audit_logs/resources.py
+++ b/app/modules/audit_logs/resources.py
@@ -11,12 +11,12 @@ from flask_restx_patched import Resource
 from flask_restx._http import HTTPStatus
 
 from app.extensions.api import Namespace
-from app.extensions.api.parameters import PaginationParameters
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 
 from . import schemas
 from .models import AuditLog
+from .parameters import GetCollaborationParameters
 
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -37,7 +37,7 @@ class AuditLogs(Resource):
             'action': AccessOperation.READ,
         },
     )
-    @api.parameters(PaginationParameters())
+    @api.parameters(GetCollaborationParameters())
     def get(self, args):
         """
         List of AuditLog.
@@ -47,6 +47,9 @@ class AuditLogs(Resource):
         unique_logs = []
         all_logs = AuditLog.query.all()
         for log_entry in all_logs:
+            if 'module_name' in args and args['module_name'] != log_entry.module_name:
+                continue
+
             name_and_guid = {
                 'module_name': log_entry.module_name,
                 'item_guid': log_entry.item_guid,
@@ -69,7 +72,7 @@ class AuditLogs(Resource):
 )
 class AuditLogByID(Resource):
     """
-    Manipulations with a specific AuditLog.
+    Manipulations with the AuditLogs for a specific object.
     """
 
     @api.permission_required(

--- a/app/modules/encounters/models.py
+++ b/app/modules/encounters/models.py
@@ -4,9 +4,13 @@ Encounters database models
 --------------------
 """
 import uuid
+import logging
 
 from app.extensions import db, FeatherModel
 from app.modules.individuals.models import Individual
+import app.extensions.logging as AuditLog
+
+log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class Encounter(db.Model, FeatherModel):
@@ -92,6 +96,7 @@ class Encounter(db.Model, FeatherModel):
                 self.annotations.append(annotation)
 
     def delete(self):
+        AuditLog.delete_object(log, self)
         with db.session.begin():
             db.session.delete(self)
 

--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -23,6 +23,7 @@ from app.extensions.api import abort
 
 from . import parameters, schemas
 from .models import Encounter
+import app.extensions.logging as AuditLog
 
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -163,6 +164,7 @@ class EncounterByID(Resource):
             with context:
                 db.session.merge(encounter)
         # rtn['_patchResults'] = rdata.get('patchResults', None)  # FIXME i think this gets lost cuz not part of results_data
+        AuditLog.patch_object(log, encounter, args)
         return result_data
 
     @api.permission_required(

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -7,6 +7,10 @@ Individuals database models
 from app.extensions import FeatherModel, db
 from flask import current_app
 import uuid
+import logging
+import app.extensions.logging as AuditLog
+
+log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
 class Individual(db.Model, FeatherModel):
@@ -90,6 +94,7 @@ class Individual(db.Model, FeatherModel):
         return rt_val
 
     def delete(self):
+        AuditLog.delete_object(log, self)
         with db.session.begin():
             db.session.delete(self)
 

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -20,6 +20,7 @@ from app.utils import HoustonException
 
 from . import parameters, schemas
 from .models import Individual
+import app.extensions.logging as AuditLog
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace('individuals', description='Individuals')  # pylint: disable=invalid-name
@@ -156,7 +157,7 @@ class Individuals(Resource):
             encounters=encounters,
             version=result_data.get('version'),
         )
-
+        AuditLog.user_create_object(log, individual)
         context = api.commit_or_abort(
             db.session, default_error_message='Failed to create a new Individual'
         )
@@ -287,7 +288,7 @@ class IndividualByID(Resource):
             # TODO handle individual deletion if last encounter removed
 
         db.session.merge(individual)
-
+        AuditLog.patch_object(log, individual, args)
         return individual
 
     @api.permission_required(

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -101,7 +101,6 @@ class User(db.Model, FeatherModel, UserEDMMixin):
         if 'password' not in kwargs:
             raise ValueError('User must have a password')
         super().__init__(*args, **kwargs)
-        AuditLog.user_create_object(log, self, msg=f'{self.email}')
 
     guid = db.Column(
         db.GUID, default=uuid.uuid4, primary_key=True

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -18,6 +18,7 @@ from app.extensions.api import Namespace
 from . import permissions, schemas, parameters
 from app.modules.users.permissions.types import AccessOperation
 from .models import db, User
+import app.extensions.logging as AuditLog
 
 
 log = logging.getLogger(__name__)
@@ -161,7 +162,7 @@ class UserByID(Resource):
             parameters.PatchUserDetailsParameters.perform_patch(args, user)
             db.session.merge(user)
         db.session.refresh(user)
-
+        AuditLog.patch_object(log, user, args)
         return user
 
     @api.login_required(oauth_scopes=['users:write'])

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -108,7 +108,7 @@ class Users(Resource):
             new_user = User(**args)
             db.session.add(new_user)
         db.session.refresh(new_user)
-
+        AuditLog.user_create_object(log, new_user, msg=f'{new_user.email}')
         return new_user
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -6,11 +6,13 @@ Houston Common utils
 """
 
 from flask_login import current_user  # NOQA
-from app.extensions.logging import audit_log, AuditType
+import app.extensions.logging as AuditLog  # NOQA
 
 
 class HoustonException(Exception):
-    def __init__(self, logger, log_message, **kwargs):
+    def __init__(
+        self, logger, log_message, fault=AuditLog.AuditType.FrontEndFault, **kwargs
+    ):
         self.message = kwargs.get('message', log_message)
         self.status_code = kwargs.get('status_code', 400)
 
@@ -19,8 +21,7 @@ class HoustonException(Exception):
         if log_message == '' and self.message != '':
             log_message = self.message
 
-        logger.warning(f'Failed: {log_message} {self.status_code}')
-        audit_log(logger, f'Failed: {log_message} {self.status_code}', AuditType.Fault)
+        AuditLog.audit_log(logger, f'Failed: {log_message} {self.status_code}', fault)
 
     def __str__(self):
         return self.message

--- a/flask_restx_patched/namespace.py
+++ b/flask_restx_patched/namespace.py
@@ -394,7 +394,14 @@ class Namespace(OriginalNamespace):
                         @wraps(func)
                         def wrapper(*args, **kwargs):
                             with permission(**kwargs_on_request(kwargs)):
-                                return func(*args, **kwargs)
+                                try:
+                                    return func(*args, **kwargs)
+                                except Exception as ex:
+                                    import app.extensions.logging as AuditLog  # NOQA
+
+                                    AuditLog.houston_fault(None, str(ex))
+                                    # TODO is there something more sensible to do other than reraising here?
+                                    raise
 
                         return wrapper
 

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -15,6 +15,11 @@ from tests import TEST_ASSET_GROUP_UUID, TEST_EMPTY_ASSET_GROUP_UUID
 
 PATH = '/api/v1/asset_groups/'
 
+ANNOTATION_UUIDS = [
+    '1891ca05-5fa5-4e52-bb30-8ee80941c2fc',
+    '0c6f3a16-c3f0-4f8d-a47d-951e49b0dacb',
+]
+
 
 class TestCreationData(object):
     def __init__(self, transaction_id, populate_default=True):
@@ -217,7 +222,7 @@ def build_sage_detection_response(asset_group_sighting_guid, job_uuid):
                 [
                     {
                         'id': 1,
-                        'uuid': {'__UUID__': '1891ca05-5fa5-4e52-bb30-8ee80941c2fc'},
+                        'uuid': {'__UUID__': ANNOTATION_UUIDS[0]},
                         'xtl': 459,
                         'ytl': 126,
                         'left': 459,
@@ -235,7 +240,7 @@ def build_sage_detection_response(asset_group_sighting_guid, job_uuid):
                     },
                     {
                         'id': 2,
-                        'uuid': {'__UUID__': '0c6f3a16-c3f0-4f8d-a47d-951e49b0dacb'},
+                        'uuid': {'__UUID__': ANNOTATION_UUIDS[1]},
                         'xtl': 26,
                         'ytl': 145,
                         'left': 26,

--- a/tests/modules/audit_logs/resources/test_audit_log.py
+++ b/tests/modules/audit_logs/resources/test_audit_log.py
@@ -3,6 +3,8 @@
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.modules.users.resources.utils as user_utils
 import tests.modules.audit_logs.resources.utils as audit_utils
+import tests.modules.sightings.resources.utils as sighting_utils
+import tests.extensions.tus.utils as tus_utils
 
 
 def test_audit_asset_group_creation(
@@ -45,6 +47,11 @@ def test_audit_asset_group_creation(
         )
         assert expected_sighting in sighting_audit_items.json
         assert expected_encounter not in sighting_audit_items.json
+        encounter_audit_items = audit_utils.read_all_audit_logs(
+            flask_app_client, researcher_1, module_name='Encounter'
+        )
+        assert expected_sighting not in encounter_audit_items.json
+        assert expected_encounter in encounter_audit_items.json
 
         audit_utils.read_audit_log(flask_app_client, contributor_1, sighting_uuid, 403)
         sighting_audit = audit_utils.read_audit_log(
@@ -65,3 +72,105 @@ def test_audit_asset_group_creation(
             import tests.modules.sightings.resources.utils as sighting_utils
 
             sighting_utils.delete_sighting(flask_app_client, researcher_1, sighting_uuid)
+
+
+# Basically a duplication of the ia pipeline up to Sighting creation and making sure that the required audit
+# logs are present
+def test_most_ia_pipeline_audit_log(
+    flask_app,
+    flask_app_client,
+    researcher_1,
+    regular_user,
+    staff_user,
+    internal_user,
+    test_root,
+    db,
+    request,
+):
+    # pylint: disable=invalid-name
+    from app.modules.asset_groups.models import (
+        AssetGroupSighting,
+        AssetGroupSightingStage,
+    )
+    from app.modules.sightings.models import Sighting
+
+    transaction_id, test_filename = asset_group_utils.create_bulk_tus_transaction(
+        test_root
+    )
+    request.addfinalizer(lambda: tus_utils.cleanup_tus_dir(transaction_id))
+    asset_group_uuid = None
+
+    data = asset_group_utils.get_bulk_creation_data(transaction_id, test_filename)
+    # Use a real detection model to trigger a request sent to Sage
+    data.set_field('speciesDetectionModel', ['african_terrestrial'])
+    # and the sim_sage util to catch it
+    resp = asset_group_utils.create_asset_group_sim_sage(
+        flask_app, flask_app_client, researcher_1, data.get()
+    )
+    asset_group_uuid = resp.json['guid']
+    request.addfinalizer(
+        lambda: asset_group_utils.delete_asset_group(
+            flask_app_client, researcher_1, asset_group_uuid
+        )
+    )
+    asset_group_sighting1_guid = resp.json['asset_group_sightings'][0]['guid']
+
+    ags1 = AssetGroupSighting.query.get(asset_group_sighting1_guid)
+    assert ags1
+
+    job_uuids = [guid for guid in ags1.jobs.keys()]
+    assert len(job_uuids) == 1
+    job_uuid = job_uuids[0]
+    assert ags1.jobs[job_uuid]['model'] == 'african_terrestrial'
+
+    # Simulate response from Sage
+    sage_resp = asset_group_utils.build_sage_detection_response(
+        asset_group_sighting1_guid, job_uuid
+    )
+    asset_group_utils.send_sage_detection_response(
+        flask_app_client,
+        internal_user,
+        asset_group_sighting1_guid,
+        job_uuid,
+        sage_resp,
+    )
+    assert ags1.stage == AssetGroupSightingStage.curation
+
+    # commit it (without Identification)
+    response = asset_group_utils.commit_asset_group_sighting(
+        flask_app_client, researcher_1, asset_group_sighting1_guid
+    )
+    sighting_uuid = response.json['guid']
+    request.addfinalizer(
+        lambda: sighting_utils.delete_sighting(
+            flask_app_client, staff_user, sighting_uuid
+        )
+    )
+    sighting = Sighting.query.get(sighting_uuid)
+    encounters = sighting.get_encounters()
+    assert len(encounters) == 2
+
+    # Everything up to here was setting the stage, now to start the test of the contents of the audit log.
+    expected_sighting = {'module_name': 'Sighting', 'item_guid': sighting_uuid}
+    expected_encounter = {
+        'module_name': 'Encounter',
+        'item_guid': str(encounters[0].guid),
+    }
+    expected_annotation = {
+        'module_name': 'Annotation',
+        'item_guid': asset_group_utils.ANNOTATION_UUIDS[0],
+    }
+
+    sighting_audit_items = audit_utils.read_all_audit_logs(
+        flask_app_client, researcher_1, module_name='Sighting'
+    )
+    encounter_audit_items = audit_utils.read_all_audit_logs(
+        flask_app_client, researcher_1, module_name='Encounter'
+    )
+    annotation_audit_items = audit_utils.read_all_audit_logs(
+        flask_app_client, researcher_1, module_name='Annotation'
+    )
+
+    assert expected_sighting in sighting_audit_items.json
+    assert expected_encounter in encounter_audit_items.json
+    assert expected_annotation in annotation_audit_items.json

--- a/tests/modules/audit_logs/resources/test_audit_log.py
+++ b/tests/modules/audit_logs/resources/test_audit_log.py
@@ -33,12 +33,18 @@ def test_audit_asset_group_creation(
 
         sighting = Sighting.query.get(sighting_uuid)
         audit_utils.read_all_audit_logs(flask_app_client, contributor_1, 403)
-        audit_items = audit_utils.read_all_audit_logs(flask_app_client, researcher_1)
-        assert {'module_name': 'Sighting', 'item_guid': sighting_uuid} in audit_items.json
-        assert {
+
+        expected_sighting = {'module_name': 'Sighting', 'item_guid': sighting_uuid}
+        expected_encounter = {
             'module_name': 'Encounter',
             'item_guid': str(sighting.encounters[0].guid),
-        } in audit_items.json
+        }
+
+        sighting_audit_items = audit_utils.read_all_audit_logs(
+            flask_app_client, researcher_1, module_name='Sighting'
+        )
+        assert expected_sighting in sighting_audit_items.json
+        assert expected_encounter not in sighting_audit_items.json
 
         audit_utils.read_audit_log(flask_app_client, contributor_1, sighting_uuid, 403)
         sighting_audit = audit_utils.read_audit_log(

--- a/tests/modules/audit_logs/resources/utils.py
+++ b/tests/modules/audit_logs/resources/utils.py
@@ -28,9 +28,14 @@ def read_audit_log(flask_app_client, user, audit_log_guid, expected_status_code=
     return response
 
 
-def read_all_audit_logs(flask_app_client, user, expected_status_code=200):
+def read_all_audit_logs(
+    flask_app_client, user, expected_status_code=200, module_name=None
+):
     with flask_app_client.login(user, auth_scopes=('audit_logs:read',)):
-        response = flask_app_client.get(PATH, query_string={'limit': 30})
+        query = {'limit': 30}
+        if module_name:
+            query['module_name'] = module_name
+        response = flask_app_client.get(PATH, query_string=query)
     expected_keys = {'item_guid', 'module_name'}
     if expected_status_code == 200:
         test_utils.validate_list_of_dictionaries_response(response, 200, expected_keys)

--- a/tests/modules/audit_logs/resources/utils.py
+++ b/tests/modules/audit_logs/resources/utils.py
@@ -32,7 +32,7 @@ def read_all_audit_logs(
     flask_app_client, user, expected_status_code=200, module_name=None
 ):
     with flask_app_client.login(user, auth_scopes=('audit_logs:read',)):
-        query = {'limit': 30}
+        query = {'limit': 40}
         if module_name:
             query['module_name'] = module_name
         response = flask_app_client.get(PATH, query_string=query)

--- a/tests/modules/notifications/resources/test_notifications.py
+++ b/tests/modules/notifications/resources/test_notifications.py
@@ -201,6 +201,5 @@ def test_notification_preferences(
     collab_requests_from_res1 = get_notifications(
         researcher_2_notifs.json, researcher_1.email, 'collaboration_request'
     )
-    if len(collab_requests_from_res1) == 0:
-        breakpoint()
+
     assert len(collab_requests_from_res1) != 0


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Helpers for creating audit logs in Logger class (made the imports easier)
- More helpers added to abstract how it's implemented to the calling code 
- Much more useage of Audit logging added

---

**REST API Updates **

The /api/v1/audit_logs GET now takes an optional 'module_name' parameter which means that it returns only the audit log options for that module
