### PR TITLE
Make individuals PATCH /encounters work for non lists too

### DIFF
--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -234,6 +234,11 @@ class IndividualByID(Resource):
             db.session, default_error_message='Failed to update Individual details.'
         )
 
+        # If value for /encounters is not a list, make it into a list
+        for arg in args:
+            if arg['path'] == '/encounters' and isinstance(arg['value'], str):
+                arg['value'] = [arg['value']]
+
         houston_args = [
             arg
             for arg in args

--- a/tests/modules/individuals/resources/test_individual_crud.py
+++ b/tests/modules/individuals/resources/test_individual_crud.py
@@ -173,7 +173,7 @@ def test_add_remove_encounters(db, flask_app_client, researcher_1):
 
     # remove the one we just verified was there
     remove_encounters = [
-        utils.patch_remove_op('encounters', [str(enc_1.guid)]),
+        utils.patch_remove_op('encounters', str(enc_1.guid)),
     ]
 
     individual_utils.patch_individual(


### PR DESCRIPTION
The API supported only lists but this is actually not universal.
The sighting patch API uses a single value when patching /encounters.

Change the code slightly to make the value into a list.

---

@brmscheiner This should fix the error you're seeing.

To reproduce the error:

> Log in and create a sighting, then go to the sighting page and the animals tab. Click on the cluster options menu and create a new individual
> 
> From that point you can either go to the individual page and attempt to remove the encounter from the individual
> 
> Or you can create another sighting and attempt to assign it to the first individual