### PR TITLE
Refactor asset code and fix check_jobs and sage_detection tasks

### DIFF
--- a/app/extensions/restManager/RestManager.py
+++ b/app/extensions/restManager/RestManager.py
@@ -365,7 +365,11 @@ class RestManager(RestManagerUserMixin):
         ]
         is_json = False
         for header_key in allowed_header_key_list:
-            header_value = request.headers.get(header_key, None)
+            try:
+                header_value = request.headers.get(header_key, None)
+            except RuntimeError:  # Working outside of request context.
+                # e.g. celery tasks
+                header_value = None
             header_existing = headers.get(header_key, None)
             if header_value is not None and header_existing is None:
                 headers[header_key] = header_value

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -331,7 +331,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
         base_url = current_app.config.get('BASE_URL')
         callback_url = urljoin(
             base_url,
-            f'/api/v1/asset_group/sighting/{str(self.guid)}/sage_detected/{str(job_uuid)}',
+            f'/api/v1/asset_groups/sighting/{str(self.guid)}/sage_detected/{str(job_uuid)}',
         )
 
         ia_config_reader = IaConfig(current_app.config.get('CONFIG_MODEL'))
@@ -346,7 +346,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
             'callback_detailed': True,
             'input': detector_config,
         }
-        asset_url = urljoin(base_url, '/api/v1/asset/src_raw/')
+        asset_url = urljoin(base_url, '/api/v1/assets/src_raw/')
 
         asset_guids = []
         for filename in self.config.get('assetReferences'):

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -155,13 +155,13 @@ def create_asset_group_sim_sage(
             assert params['endpoint'] == '/api/engine/detect/cnn/lightnet/'
             assert re.match('[a-f0-9-]{36}', params['jobid'])
             assert re.match(
-                r'houston\+http://houston:5000/api/v1/asset_group/sighting/[a-f0-9-]{36}/sage_detected/'
+                r'houston\+http://houston:5000/api/v1/asset_groups/sighting/[a-f0-9-]{36}/sage_detected/'
                 + params['jobid'],
                 params['callback_url'],
             )
             assert all(
                 re.match(
-                    r'houston\+http://houston:5000/api/v1/asset/src_raw/[a-f0-9-]{36}',
+                    r'houston\+http://houston:5000/api/v1/assets/src_raw/[a-f0-9-]{36}',
                     uri,
                 )
                 for uri in params['image_uuid_list']

--- a/tests/modules/assets/test_models.py
+++ b/tests/modules/assets/test_models.py
@@ -4,6 +4,8 @@ import shutil
 from unittest import mock
 import uuid
 
+from PIL import Image
+
 
 def set_up_assets(flask_app, db, test_root, admin_user, request):
     from app.modules.annotations.models import Annotation
@@ -99,3 +101,25 @@ def test_asset_meta_and_delete(flask_app, db, test_root, admin_user, request):
     # Delete the last asset should delete the asset group
     asset_group.assets[-1].delete()
     assert AssetGroup.query.get(asset_group.guid) is None
+
+
+def test_derived_images(test_asset_group_uuid):
+    from app.modules.asset_groups.models import AssetGroup
+
+    asset_group = AssetGroup.query.get(test_asset_group_uuid)
+    zebra = [
+        asset
+        for asset in asset_group.assets
+        if asset.get_original_filename() == 'zebra.jpg'
+    ][0]
+
+    assert zebra.get_dimensions() == {'width': 1000, 'height': 664}
+    master_path = zebra.get_or_make_format_path('master')
+    with Image.open(master_path) as im:
+        assert im.size == (1000, 664)
+    mid_path = zebra.get_or_make_format_path('mid')
+    with Image.open(mid_path) as im:
+        assert im.size == (1000, 664)
+    thumb_path = zebra.get_or_make_format_path('thumb')
+    with Image.open(thumb_path) as im:
+        assert im.size == (256, 170)


### PR DESCRIPTION
- Add test for asset derived images


- Add test for asset update_symlink


- Refactor asset derived images code and use pathlib in general

  - Move `FORMAT` into `FORMATS` as a class attribute so it can be
    accessed by different methods
  - Change `os.path` to `pathlib.Path` for nicer path APIs instead of
    string manipulation

- Catch RuntimeError in check jobs task

  We have a periodic task that checks all the asset group sighting jobs sent to
  acm.  There's a runtime error because RestManager tries to access the
  current request `flask.request` in order to get some header values:
  
  ```
  [2021-09-07 14:41:16,026: ERROR/ForkPoolWorker-7] Task app.modules.job_control.tasks.check_jobs[ca9c3c27-2faa-4669-a7f8-159b8d8231fd] raised unexpected: RuntimeError('Working outside of request context.\n\nThis typically means that you attempted to use functionality that needed\nan active HTTP request.  Consult the documentation on testing for\ninformation about how to avoid this problem.')                                                Traceback (most recent call last):
    File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 450, in trace_task
      R = retval = fun(*args, **kwargs)
    File "/code/app/__init__.py", line 167, in __call__
      return self.run(*args, **kwargs)
    File "/code/app/modules/job_control/tasks.py", line 17, in check_jobs
      JobControl.check_jobs()                                                                                                                          File "/code/app/modules/job_control/models.py", line 18, in check_jobs
      AssetGroupSighting.check_jobs()                                                                                                                  File "/code/app/modules/asset_groups/models.py", line 285, in check_jobs
      asset_group_sighting.check_all_job_status()
    File "/code/app/modules/asset_groups/models.py", line 292, in check_all_job_status
      current_app.acm.request_passthrough_result(
    File "/code/app/extensions/acm/__init__.py", line 125, in request_passthrough_result
      response, response_data, result = self.request_passthrough_parsed(
    File "/code/app/extensions/acm/__init__.py", line 72, in request_passthrough_parsed
      response = self.request_passthrough(tag, method, passthrough_kwargs, args, target)
    File "/code/app/extensions/restManager/RestManager.py", line 368, in request_passthrough
      header_value = request.headers.get(header_key, None)
    File "/usr/local/lib/python3.9/site-packages/werkzeug/local.py", line 348, in __getattr__
      return getattr(self._get_current_object(), name)
    File "/usr/local/lib/python3.9/site-packages/werkzeug/local.py", line 307, in _get_current_object
      return self.__local()
    File "/usr/local/lib/python3.9/site-packages/flask/globals.py", line 38, in _lookup_req_object
      raise RuntimeError(_request_ctx_err_msg)
  RuntimeError: Working outside of request context.
  ```
  
  Catch this error and set the header values to none and continue with the
  code.

- Fix callback and asset urls sent to sage detection

  The urls were wrong... Instead of `/api/v1/asset/...` and
  `/api/v1/asset_group/...`, we needed `/api/v1/assets/...` and
  `/api/v2/asset_groups/...`.

- Fix sage_detection task not finding asset group sighting

  In `AssetGroup.begin_ia_pipeline`, we called the `sage_detection` task
  before adding the new sighting to `db.session` causing the
  `sage_detection` task to sometimes not be able to find the new sighting.
  
  Change the code to add the new sighting before calling the
  `sage_detection` task.
