### PR TITLE
Revise logstash query to correspond with index mapping change

### DIFF
--- a/.dockerfiles/logstash/pipelines/wildbook-markedindividual.conf
+++ b/.dockerfiles/logstash/pipelines/wildbook-markedindividual.conf
@@ -20,10 +20,8 @@ SELECT
   mi."NICKNAME" as nickname,
   -- alias = Keyword()
       multv."VALUES"::json->\'Alternate ID\'->>0 as alias,
-  -- genus = Keyword()
-  split_part(tax."SCIENTIFICNAME", \' \', 1) as genus,
-  -- species = Keyword()
-  split_part(tax."SCIENTIFICNAME", \' \', 2) as species,
+  -- taxonomy = Keyword()
+  tax."SCIENTIFICNAME" as taxonomy,
   -- last_sighting = Date()
   -- ... dynamically produced by elasticsearch via inspection of eoncounters
   -- sex = EnumField(Sex, required=False)
@@ -49,10 +47,8 @@ SELECT
       -- ... unclear where this is going to be coming from; ownership is now in houston
       -- date_occurred = Date()
       (cdt."DATETIME"::timestamp || \' \' || cdt."TIMEZONE")::timestamp with time zone as date_occurred,
-      -- genus = Keyword()
-      split_part(tax."SCIENTIFICNAME", \' \', 1) as genus,
-      -- species = Keyword()
-      split_part(tax."SCIENTIFICNAME", \' \', 2) as species
+      -- taxonomy = Keyword()
+      tax."SCIENTIFICNAME" as taxonomy,
       -- has_annotation = Boolean(required=True)
       -- ... this point of data will be in houston
     FROM


### PR DESCRIPTION

## Pull Request Overview

@brmscheiner requested the taxonomy be squashed into one searchable field

This adjusts the logstash SQL query to correspond with the change in https://github.com/WildMeOrg/gumby/pull/4, which squashes genus and species fields into a single taxonomy field.
