### PR TITLE
472 revoking read collaboration also revokes edit collaboration if ap…

### DIFF
--- a/app/modules/collaborations/models.py
+++ b/app/modules/collaborations/models.py
@@ -230,6 +230,15 @@ class Collaboration(db.Model, HoustonModel):
                         association.read_approval_state, state
                     ):
                         association.read_approval_state = state
+                        # If a user revokes view and previously allowed edit, they automatically
+                        # revoke edit too
+                        if (
+                            state == CollaborationUserState.REVOKED
+                            and association.edit_approval_state
+                            == CollaborationUserState.APPROVED
+                        ):
+
+                            association.edit_approval_state = state
                         success = True
         return success
 

--- a/tests/modules/collaborations/test_models.py
+++ b/tests/modules/collaborations/test_models.py
@@ -7,6 +7,7 @@ import logging
 
 from app.modules.collaborations.models import Collaboration
 from app.modules.collaborations.models import CollaborationUserState
+from unittest import mock
 
 log = logging.getLogger(__name__)
 
@@ -93,22 +94,41 @@ def test_collaboration_edit_state_changes(db, collab_user_a, collab_user_b, requ
     assert json_user_data[str(collab_user_a.guid)]['initiator']
     assert not json_user_data[str(collab_user_b.guid)]['initiator']
 
-    for association in collab.collaboration_user_associations:
-        assert association.edit_approval_state == CollaborationUserState.NOT_INITIATED
-
-    collab.set_edit_approval_state_for_user(
-        collab_user_a.guid, CollaborationUserState.APPROVED
+    collab.set_read_approval_state_for_user(
+        collab_user_b.guid, CollaborationUserState.APPROVED
     )
 
     for association in collab.collaboration_user_associations:
+        assert association.edit_approval_state == CollaborationUserState.NOT_INITIATED
+
+    with mock.patch(
+        'app.modules.collaborations.models.current_user', return_value=collab_user_a
+    ):
+        collab.initiate_edit_with_other_user()
+
+    for association in collab.collaboration_user_associations:
         if association.user_guid == collab_user_a.guid:
-            assert association.read_approval_state == CollaborationUserState.APPROVED
+            assert association.edit_approval_state == CollaborationUserState.APPROVED
         if association.user_guid == collab_user_b.guid:
-            assert association.read_approval_state == CollaborationUserState.PENDING
+            assert association.edit_approval_state == CollaborationUserState.PENDING
 
     collab.set_edit_approval_state_for_user(
         collab_user_b.guid, CollaborationUserState.APPROVED
     )
+    for association in collab.collaboration_user_associations:
+        if association.user_guid == collab_user_a.guid:
+            assert association.edit_approval_state == CollaborationUserState.APPROVED
+        if association.user_guid == collab_user_b.guid:
+            assert association.edit_approval_state == CollaborationUserState.APPROVED
+
+    # Check that revoking read also revokes edit
+    collab.set_read_approval_state_for_user(
+        collab_user_b.guid, CollaborationUserState.REVOKED
+    )
+    for association in collab.collaboration_user_associations:
+        if association.user_guid == collab_user_b.guid:
+            assert association.edit_approval_state == CollaborationUserState.REVOKED
+            assert association.read_approval_state == CollaborationUserState.REVOKED
 
 
 def test_fail_create_collaboration(collab_user_a, collab_user_b):

--- a/tests/modules/collaborations/test_models.py
+++ b/tests/modules/collaborations/test_models.py
@@ -99,12 +99,13 @@ def test_collaboration_edit_state_changes(db, collab_user_a, collab_user_b, requ
     )
 
     for association in collab.collaboration_user_associations:
+        assert association.read_approval_state == CollaborationUserState.APPROVED
         assert association.edit_approval_state == CollaborationUserState.NOT_INITIATED
 
-    with mock.patch(
-        'app.modules.collaborations.models.current_user', return_value=collab_user_a
-    ):
+    with mock.patch('app.modules.collaborations.models.current_user', new=collab_user_a):
         collab.initiate_edit_with_other_user()
+
+    # TODO test that edit_initiator is set correctly
 
     for association in collab.collaboration_user_associations:
         if association.user_guid == collab_user_a.guid:
@@ -116,10 +117,7 @@ def test_collaboration_edit_state_changes(db, collab_user_a, collab_user_b, requ
         collab_user_b.guid, CollaborationUserState.APPROVED
     )
     for association in collab.collaboration_user_associations:
-        if association.user_guid == collab_user_a.guid:
-            assert association.edit_approval_state == CollaborationUserState.APPROVED
-        if association.user_guid == collab_user_b.guid:
-            assert association.edit_approval_state == CollaborationUserState.APPROVED
+        assert association.edit_approval_state == CollaborationUserState.APPROVED
 
     # Check that revoking read also revokes edit
     collab.set_read_approval_state_for_user(


### PR DESCRIPTION
…proved

<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Revokes edit approval if granted once view approval is revoked
- Test added 
---

