### PR TITLE
Fix current_user patch in test_asset_meta_and_delete

### DIFF
--- a/tests/modules/assets/test_models.py
+++ b/tests/modules/assets/test_models.py
@@ -41,10 +41,9 @@ def set_up_assets(flask_app, db, test_root, admin_user, request):
     data = TestCreationData(transaction_id)
     data.set_sighting_field(-1, 'assetReferences', [jpg.name for jpg in jpgs])
     metadata = AssetGroupMetadata(data.get())
-    with mock.patch(
-        'app.modules.asset_groups.metadata.current_user', return_value=admin_user
-    ):
+    with mock.patch('app.modules.asset_groups.metadata.current_user', new=admin_user):
         metadata.process_request()
+    assert metadata.owner == admin_user
     asset_group = AssetGroup.create_from_metadata(metadata)
     cleanup(lambda: db.session.delete(asset_group))
 


### PR DESCRIPTION
Instead of

```
with mock.patch(
    'app.modules.asset_groups.metadata.current_user', return_value=admin_user
):
```

which only returns `admin_user` when `current_user` is called, e.g.
`current_user()`.  What we need is the `current_user` itself to be
`admin_user`:

```
with mock.patch('app.modules.asset_groups.metadata.current_user', new=admin_user):
```

The `metadata.owner` was "Public User".

