### PR TITLE
DEX-447 Asset API to rotate image

### DIFF
--- a/app/modules/assets/parameters.py
+++ b/app/modules/assets/parameters.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""
+Input arguments (Parameters) for Assets resources RESTful API
+-------------------------------------------------------------
+"""
+
+from flask_restx_patched import PatchJSONParameters
+from flask_restx_patched._http import HTTPStatus
+from app.extensions.api import abort
+
+from . import schemas
+
+
+class PatchAssetParameters(PatchJSONParameters):
+    OPERATION_CHOICES = (PatchJSONParameters.OP_REPLACE,)
+
+    PATH_CHOICES = ('/image',)
+
+    @classmethod
+    def replace(cls, obj, field, value, state):
+        ret_val = False
+
+        if field == 'image':
+            schema = schemas.PatchAssetSchema()
+            errors = schema.validate(value)
+            if errors:
+                abort(
+                    code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                    message=schema.get_error_message(errors),
+                )
+            obj.rotate(value['rotate']['angle'])
+            ret_val = True
+
+        return ret_val

--- a/app/modules/assets/schemas.py
+++ b/app/modules/assets/schemas.py
@@ -5,7 +5,10 @@ Serialization schemas for Assets resources RESTful API
 """
 
 from flask_marshmallow import base_fields
+from marshmallow import ValidationError
+
 from flask_restx_patched import ModelSchema
+from app.extensions import ExtraValidationSchema
 
 from .models import Asset
 
@@ -51,3 +54,15 @@ class DetailedAssetGroupAssetSchema(BaseAssetSchema):
         'annotations',
         'dimensions',
     )
+
+
+def not_negative(value):
+    if value < 0:
+        raise ValidationError('Value must be greater than 0.')
+
+
+class PatchAssetSchema(ExtraValidationSchema):
+    class AssetRotateSchema(ExtraValidationSchema):
+        angle = base_fields.Integer(validate=not_negative)
+
+    rotate = base_fields.Nested(AssetRotateSchema)

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -82,6 +82,7 @@ OBJECT_USER_METHOD_MAP = {
     ('Sighting', AccessOperation.WRITE): ['user_owns_all_encounters'],
     ('Sighting', AccessOperation.DELETE): ['user_can_edit_all_encounters'],
     ('Asset', AccessOperation.READ_PRIVILEGED): ['user_raw_read'],
+    ('Asset', AccessOperation.WRITE): ['user_is_owner'],
     ('Annotation', AccessOperation.READ): ['user_is_owner'],
     ('Annotation', AccessOperation.WRITE): ['user_is_owner'],
     ('Annotation', AccessOperation.DELETE): ['user_is_owner'],


### PR DESCRIPTION
Add `asset.rotate` which uses `PIL.Image.transpose` for 90 degree
increment rotation and `PIL.Image.rotate` for non 90 degree increment
rotations.  The difference is `PIL.Image.rotate` doesn't change the
image dimensions while `PIL.Image.transpose` does.

Add `asset.get_original_path` which returns either the symlink if the
image hasn't been rotated since creation or the original uploaded image.

The API to rotate the image looks like this:

```
PATCH /api/v1/assets/<asset-guid>

[
    {
        "op": "replace",
        "path": "/image",
        "value": {"rotate": {"angle": 90}}
    }
]
```

---

In response to `tests/modules/assets/resources/test_assets.py`

```
-    # TODO, this is what the test did previously, does this make sense?
-    response = flask_app_client.get('/api/v1/assets/wrong-uuid')
+    response = flask_app_client.get('/api/v1/assets/invalid-uuid')
```

Yes, the test was testing what happened when we get an invalid uuid (I'm
making it clearer by changing "wrong-uuid" to "invalid-uuid").  The
original problem is when we're given an invalid uuid, the path in
`app/modules/assets/resources.py` won't match because it only matches
uuids.  This used to go to `app.modules.frontend.views_frontend.home`
and return 200 and something completely unexpected.

More in commit db84f6c90
