### PR TITLE
rerunning detection

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -372,7 +372,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
         ]
         return model_config
 
-    def run_sage_detection(self, model):
+    def send_detection_to_sage(self, model):
         job_id = uuid.uuid4()
         detection_request = self.build_detection_request(job_id, model)
 
@@ -495,11 +495,9 @@ class AssetGroupSighting(db.Model, HoustonModel):
 
     # Record that the asset has been updated for future re detection
     def asset_updated(self, asset):
-        if 'updatedAssets' in self.config:
-            if asset.guid not in self.config['updatedAssets']:
-                self.config['updatedAssets'].append(asset.guid)
-        else:
-            self.config['updatedAssets'] = [asset.guid]
+        updated_assets = self.config.setdefault('updatedAssets', [])
+        if asset.guid not in updated_assets:
+            updated_assets.append(asset.guid)
 
         # Ensure it's written to DB
         self.config = self.config

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -251,7 +251,9 @@ class AssetGroupSighting(db.Model, HoustonModel):
         return sighting
 
     def has_filename(self, filename):
-        return filename in self.config.get('assetReferences', [])
+        return (
+            filename in self.config.get('assetReferences', []) if self.config else False
+        )
 
     # Returns a percentage complete value 0-100
     def get_completion(self):

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -495,7 +495,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
 
     # Record that the asset has been updated for future re detection
     def asset_updated(self, asset):
-        if self.config['updatedAssets']:
+        if 'updatedAssets' in self.config:
             if asset.guid not in self.config['updatedAssets']:
                 self.config['updatedAssets'].append(asset.guid)
         else:
@@ -505,6 +505,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
         self.config = self.config
 
     def rerun_detection(self):
+        log.info('Rerunning Sage detection')
         if self.stage == AssetGroupSightingStage.curation:
             self.stage = AssetGroupSightingStage.detection
             self.start_detection()
@@ -516,6 +517,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
     def start_detection(self):
         from app.modules.asset_groups.tasks import sage_detection
 
+        log.info('Starting Sage detection')
         asset_group_config = self.asset_group.config
         assert 'speciesDetectionModel' in asset_group_config
         assert self.stage == AssetGroupSightingStage.detection

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -499,6 +499,7 @@ class AssetGroupSightingDetect(Resource):
             asset_group_sighting.rerun_detection()
         except HoustonException as ex:
             abort(ex.status_code, ex.message, errorFields=ex.get_val('error', 'Error'))
+        return asset_group_sighting
 
 
 @api.route('/sighting/<uuid:asset_group_sighting_guid>/sage_detected/<uuid:job_guid>')

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -474,6 +474,33 @@ class AssetGroupSightingCommit(Resource):
         return sighting
 
 
+@api.route('/sighting/<uuid:asset_group_sighting_guid>/detect')
+@api.login_required(oauth_scopes=['asset_group_sightings:write'])
+@api.response(
+    code=HTTPStatus.NOT_FOUND,
+    description='Asset_group_sighting not found.',
+)
+@api.resolve_object_by_model(AssetGroupSighting, 'asset_group_sighting')
+class AssetGroupSightingDetect(Resource):
+    """
+    Rerun detection on the Asset Group Sighting after changes made
+    """
+
+    @api.permission_required(
+        permissions.ObjectAccessPermission,
+        kwargs_on_request=lambda kwargs: {
+            'obj': kwargs['asset_group_sighting'],
+            'action': AccessOperation.WRITE,
+        },
+    )
+    @api.response(schemas.DetailedAssetGroupSightingSchema())
+    def post(self, asset_group_sighting):
+        try:
+            asset_group_sighting.rerun_detection()
+        except HoustonException as ex:
+            abort(ex.status_code, ex.message, errorFields=ex.get_val('error', 'Error'))
+
+
 @api.route('/sighting/<uuid:asset_group_sighting_guid>/sage_detected/<uuid:job_guid>')
 @api.login_required(oauth_scopes=['asset_group_sightings:write'])
 @api.response(

--- a/app/modules/asset_groups/tasks.py
+++ b/app/modules/asset_groups/tasks.py
@@ -83,5 +83,5 @@ def sage_detection(asset_group_sighting_guid, model):
 
     asset_group_sighting = AssetGroupSighting.query.get(asset_group_sighting_guid)
     if asset_group_sighting:
-        log.debug('Celery running sage detection')
-        asset_group_sighting.run_sage_detection(model)
+        log.debug(f'Celery running sage detection for {asset_group_sighting_guid}')
+        asset_group_sighting.send_detection_to_sage(model)

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -259,6 +259,10 @@ class Asset(db.Model, HoustonModel):
         # Save the new image
         image_object.save(symlink.resolve())
         self.reset_derived_images()
+        log.info(f'Rerunning detection, deleting annotations {self.annotations}')
+        for annotation in self.annotations:
+            annotation.delete()
+        self.annotations = []
         self.asset_group.asset_updated(self)
 
     # note: Image seems to *strip exif* sufficiently here (tested with gps, comments, etc) so this may be enough!
@@ -293,3 +297,7 @@ class Asset(db.Model, HoustonModel):
         if not guid:
             return None
         return cls.query.get(guid)
+
+    def user_is_owner(self, user):
+        # Asset has no owner, but it has one asset_group that has an owner
+        return user is not None and user == self.asset_group.owner

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -259,6 +259,7 @@ class Asset(db.Model, HoustonModel):
         # Save the new image
         image_object.save(symlink.resolve())
         self.reset_derived_images()
+        self.asset_group.asset_updated(self)
 
     # note: Image seems to *strip exif* sufficiently here (tested with gps, comments, etc) so this may be enough!
     # also note: this fails horribly in terms of exif orientation.  wom-womp

--- a/flask_restx_patched/namespace.py
+++ b/flask_restx_patched/namespace.py
@@ -400,11 +400,14 @@ class Namespace(OriginalNamespace):
                                     import app.extensions.logging as AuditLog  # NOQA
 
                                     if hasattr(ex, 'code'):
-                                        if 400 > ex.code > 409:
+                                        if (
+                                            isinstance(ex.code, int)
+                                            and 409 > ex.code > 409
+                                        ):
+                                            AuditLog.houston_fault(None, str(ex))
+                                        else:
                                             AuditLog.houston_fault(None, str(ex))
                                     # TODO is there something more sensible to do other than reraising here?
-                                    else:
-                                        AuditLog.houston_fault(None, str(ex))
                                     raise
 
                         return wrapper

--- a/flask_restx_patched/namespace.py
+++ b/flask_restx_patched/namespace.py
@@ -399,14 +399,14 @@ class Namespace(OriginalNamespace):
                                 except Exception as ex:
                                     import app.extensions.logging as AuditLog  # NOQA
 
-                                    if hasattr(ex, 'code'):
-                                        if (
-                                            isinstance(ex.code, int)
-                                            and 409 > ex.code > 409
-                                        ):
-                                            AuditLog.houston_fault(None, str(ex))
-                                        else:
-                                            AuditLog.houston_fault(None, str(ex))
+                                    # User errors are not audited, everything else is
+                                    if not (
+                                        hasattr(ex, 'code')
+                                        and isinstance(ex.code, int)
+                                        and 400 > ex.code > 409
+                                    ):
+                                        AuditLog.houston_fault(None, str(ex))
+
                                     # TODO is there something more sensible to do other than reraising here?
                                     raise
 

--- a/tests/modules/asset_groups/resources/test_create_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_create_asset_group.py
@@ -373,15 +373,17 @@ def test_create_asset_group_repeat_detection(
     )
 
     from app.modules.asset_groups.models import (
-        AssetGroup,
         AssetGroupSighting,
         AssetGroupSightingStage,
     )
 
-    # Rotate one of the assets
-    asset_group = AssetGroup.query.get(asset_group_uuid)
-    assets_in_first_ags = asset_group.asset_group_sightings[0].get_assets()
-    asset_guid = assets_in_first_ags[0]['guid']
+    # Rotate one of the assets, Must be sure that it is always the one with the ANNOTATION_UUIDS in it
+    from app.modules.annotations.models import Annotation
+
+    annot = Annotation.query.get(asset_group_utils.ANNOTATION_UUIDS[0])
+    asset_guid = annot.asset.guid
+    asset_group_uuid = annot.asset.asset_group_guid
+
     patch_data = [
         {
             'op': 'replace',

--- a/tests/modules/asset_groups/test_models.py
+++ b/tests/modules/asset_groups/test_models.py
@@ -128,7 +128,7 @@ def test_asset_group_sighting_get_completion(
     # Use a real detection model to trigger a request sent to Sage
     data.set_field('speciesDetectionModel', ['african_terrestrial'])
     # and the sim_sage util to catch it
-    resp = asset_group_utils.create_asset_group_sim_sage(
+    resp = asset_group_utils.create_asset_group_sim_sage_init_resp(
         flask_app, flask_app_client, researcher_1, data.get()
     )
     asset_group_guid = resp.json['guid']

--- a/tests/modules/assets/resources/utils.py
+++ b/tests/modules/assets/resources/utils.py
@@ -21,7 +21,7 @@ def patch_asset(flask_app_client, asset_guid, user, data, expected_status_code=2
 
     if expected_status_code == 200:
         test_utils.validate_dict_response(
-            response, 200, {'submission', 'src', 'guid', 'filename'}
+            response, 200, {'asset_group', 'src', 'guid', 'filename'}
         )
     else:
         test_utils.validate_dict_response(

--- a/tests/modules/audit_logs/resources/test_audit_log.py
+++ b/tests/modules/audit_logs/resources/test_audit_log.py
@@ -104,7 +104,7 @@ def test_most_ia_pipeline_audit_log(
     # Use a real detection model to trigger a request sent to Sage
     data.set_field('speciesDetectionModel', ['african_terrestrial'])
     # and the sim_sage util to catch it
-    resp = asset_group_utils.create_asset_group_sim_sage(
+    resp = asset_group_utils.create_asset_group_sim_sage_init_resp(
         flask_app, flask_app_client, researcher_1, data.get()
     )
     asset_group_uuid = resp.json['guid']

--- a/tests/modules/test_ia_pipeline.py
+++ b/tests/modules/test_ia_pipeline.py
@@ -32,7 +32,7 @@ def test_ia_pipeline_sim_detect_response(
         # Use a real detection model to trigger a request sent to Sage
         data.set_field('speciesDetectionModel', ['african_terrestrial'])
         # and the sim_sage util to catch it
-        resp = asset_group_utils.create_asset_group_sim_sage(
+        resp = asset_group_utils.create_asset_group_sim_sage_init_resp(
             flask_app, flask_app_client, researcher_1, data.get()
         )
         asset_group_uuid = resp.json['guid']


### PR DESCRIPTION


## Pull Request Overview

- Rerunning detection on a limited (or full) set of assets
- Allows a user to rotate an image and then rerun detection. Deletes the annotations on the Asset before doing so 
- This found a few "odd" names of things in the main code and especially the tests where there were a few bits of confusion
- This will hopefully resolve that.

New Rest API
POST to asset_groups/sightings/{AGS UUID}detect
Reruns detection on all assets or a limited subset. 

Questions outstanding : Should this not be allowed for the full set? Do we want a belts&braces check here that all annotations for these assets have been deleted? 
