### PR TITLE
345 make asset group sighting like sighting

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -286,14 +286,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
 
     # returns a None-safe getter for a given config field
     def config_field_getter(field_name):
-        def getter(self):
-            if self.config and field_name in self.config:
-                value = self.config[field_name]
-            else:
-                value = None
-            return value
-
-        return getter
+        return lambda self: self.config and self.config.get(field_name)
 
     @classmethod
     def check_jobs(cls):

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -284,6 +284,17 @@ class AssetGroupSighting(db.Model, HoustonModel):
         # calculation generates a floating point value, reporting that would be claiming precision without accuracy
         return round(completion)
 
+    # returns a None-safe getter for a given config field
+    def config_field_getter(field_name):
+        def getter(self):
+            if self.config and field_name in self.config:
+                value = self.config[field_name]
+            else:
+                value = None
+            return value
+
+        return getter
+
     @classmethod
     def check_jobs(cls):
         for asset_group_sighting in AssetGroupSighting.query.all():

--- a/app/modules/asset_groups/parameters.py
+++ b/app/modules/asset_groups/parameters.py
@@ -52,10 +52,6 @@ class PatchAssetGroupDetailsParameters(PatchJSONParameters):
                     ret_val = True
         return ret_val
 
-    @classmethod
-    def remove(cls, obj, field, value, state):
-        raise NotImplementedError()
-
 
 class PatchAssetGroupSightingDetailsParameters(PatchJSONParameters):
     # pylint: disable=abstract-method,missing-docstring
@@ -128,10 +124,6 @@ class PatchAssetGroupSightingDetailsParameters(PatchJSONParameters):
 
         return ret_val
 
-    @classmethod
-    def remove(cls, obj, field, value, state):
-        raise NotImplementedError()
-
 
 class PatchAssetGroupSightingAsSightingParameters(PatchJSONParameters):
     # pylint: disable=abstract-method,missing-docstring
@@ -203,10 +195,6 @@ class PatchAssetGroupSightingAsSightingParameters(PatchJSONParameters):
 
         return ret_val
 
-    @classmethod
-    def remove(cls, obj, field, value, state):
-        raise NotImplementedError()
-
 
 class PatchAssetGroupSightingEncounterDetailsParameters(PatchJSONParameters):
     # pylint: disable=abstract-method,missing-docstring
@@ -256,7 +244,3 @@ class PatchAssetGroupSightingEncounterDetailsParameters(PatchJSONParameters):
         # force the write to the database
         obj.config = obj.config
         return ret_val
-
-    @classmethod
-    def remove(cls, obj, field, value, state):
-        raise NotImplementedError()

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -326,7 +326,7 @@ class AssetGroupSightingByID(Resource):
     )
     @api.login_required(oauth_scopes=['asset_group_sightings:write'])
     @api.parameters(parameters.PatchAssetGroupSightingDetailsParameters())
-    @api.response(schemas.DetailedAssetGroupSightingSchema())
+    @api.response(schemas.DetailedAssetGroupSightingAsSightingSchema())
     def patch(self, args, asset_group_sighting):
         context = api.commit_or_abort(
             db.session,

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -311,9 +311,7 @@ class AssetGroupSightingByID(Resource):
     @api.login_required(oauth_scopes=['asset_group_sightings:read'])
     def get(self, asset_group_sighting):
         """
-        Get Asset_group_sighting details by ID. Note this uses a schema that
-        formats the AGS like a standard sighting, which is done by pulling out
-        config fields to the top-level json
+        Get Asset_group_sighting details by ID.
         """
         return asset_group_sighting
 

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -307,15 +307,15 @@ class AssetGroupSightingByID(Resource):
             'action': AccessOperation.READ,
         },
     )
-    @api.response(schemas.DetailedAssetGroupSightingSchema())
+    @api.response(schemas.DetailedAssetGroupSightingAsSightingSchema())
     @api.login_required(oauth_scopes=['asset_group_sightings:read'])
     def get(self, asset_group_sighting):
         """
-        Get Asset_group_sighting details by ID.
+        Get Asset_group_sighting details by ID. Note this uses a schema that
+        formats the AGS like a standard sighting, which is done by pulling out
+        config fields to the top-level json
         """
-        # We need this to be formatted like a sighting for frontend rendering etc
-        sighting_like = self.format_like_sighting(asset_group_sighting)
-        return sighting_like
+        return asset_group_sighting
 
     @api.permission_required(
         permissions.ObjectAccessPermission,
@@ -345,14 +345,6 @@ class AssetGroupSightingByID(Resource):
             db.session.merge(asset_group_sighting)
         sighting_like = self.format_like_sighting(asset_group_sighting)
         return sighting_like
-
-    # to format an AGS like a sighting, we just have to move everything in 'config' out a level
-    def format_like_sighting(self, asset_group_sighting):
-        sighting = asset_group_sighting.copy()
-        # move sighting['config']'s entries into sighting itself
-        config = sighting.pop('config')
-        sighting.update(config)
-        return sighting
 
 
 @api.route('/sighting/<uuid:asset_group_sighting_guid>/encounter/<uuid:encounter_guid>')

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -313,7 +313,9 @@ class AssetGroupSightingByID(Resource):
         """
         Get Asset_group_sighting details by ID.
         """
-        return asset_group_sighting
+        # We need this to be formatted like a sighting for frontend rendering etc
+        sighting_like = self.format_like_sighting(asset_group_sighting)
+        return sighting_like
 
     @api.permission_required(
         permissions.ObjectAccessPermission,
@@ -341,7 +343,16 @@ class AssetGroupSightingByID(Resource):
                     code=error.status_code,
                 )
             db.session.merge(asset_group_sighting)
-        return asset_group_sighting
+        sighting_like = self.format_like_sighting(asset_group_sighting)
+        return sighting_like
+
+    # to format an AGS like a sighting, we just have to move everything in 'config' out a level
+    def format_like_sighting(self, asset_group_sighting):
+        sighting = asset_group_sighting.copy()
+        # move sighting['config']'s entries into sighting itself
+        config = sighting.pop('config')
+        sighting.update(config)
+        return sighting
 
 
 @api.route('/sighting/<uuid:asset_group_sighting_guid>/encounter/<uuid:encounter_guid>')

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -382,7 +382,7 @@ class AssetGroupSightingAsSighting(Resource):
         },
     )
     @api.login_required(oauth_scopes=['asset_group_sightings:write'])
-    @api.parameters(parameters.PatchAssetGroupSightingDetailsParameters())
+    @api.parameters(parameters.PatchAssetGroupSightingAsSightingParameters())
     @api.response(schemas.AssetGroupSightingAsSightingSchema())
     def patch(self, args, asset_group_sighting):
         context = api.commit_or_abort(

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -307,7 +307,7 @@ class AssetGroupSightingByID(Resource):
             'action': AccessOperation.READ,
         },
     )
-    @api.response(schemas.DetailedAssetGroupSightingAsSightingSchema())
+    @api.response(schemas.AssetGroupSightingAsSightingSchema())
     @api.login_required(oauth_scopes=['asset_group_sightings:read'])
     def get(self, asset_group_sighting):
         """
@@ -326,7 +326,7 @@ class AssetGroupSightingByID(Resource):
     )
     @api.login_required(oauth_scopes=['asset_group_sightings:write'])
     @api.parameters(parameters.PatchAssetGroupSightingDetailsParameters())
-    @api.response(schemas.DetailedAssetGroupSightingAsSightingSchema())
+    @api.response(schemas.AssetGroupSightingAsSightingSchema())
     def patch(self, args, asset_group_sighting):
         context = api.commit_or_abort(
             db.session,
@@ -343,8 +343,7 @@ class AssetGroupSightingByID(Resource):
                     code=error.status_code,
                 )
             db.session.merge(asset_group_sighting)
-        sighting_like = self.format_like_sighting(asset_group_sighting)
-        return sighting_like
+        return asset_group_sighting
 
 
 @api.route('/sighting/<uuid:asset_group_sighting_guid>/encounter/<uuid:encounter_guid>')

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -83,16 +83,8 @@ class AssetGroupSightingAsSightingSchema(BaseAssetGroupSightingSchema):
     )
 
     class Meta(BaseAssetGroupSightingSchema.Meta):
-        fields = BaseAssetGroupSightingSchema.Meta.fields + (
-            AssetGroupSighting.stage.key,
-            'assets',
-            'completion',
-            'decimalLatitude',
-            'decimalLongitude',
-            'locationId',
-            'startTime',
-            'encounters',
-        )
+        # adds 'stage' to the fields already defined above
+        additional = ('stage',)
         dump_only = BaseAssetGroupSightingSchema.Meta.dump_only
 
     # Ensures we don't return fields with None values

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -84,7 +84,16 @@ class AssetGroupSightingAsSightingSchema(BaseAssetGroupSightingSchema):
 
     class Meta(BaseAssetGroupSightingSchema.Meta):
         # adds 'stage' to the fields already defined above
-        additional = ('stage',)
+        fields = BaseAssetGroupSightingSchema.Meta.fields + (
+            AssetGroupSighting.stage.key,
+            'assets',
+            'completion',
+            'decimalLatitude',
+            'decimalLongitude',
+            'locationId',
+            'startTime',
+            'encounters',
+        )
         dump_only = BaseAssetGroupSightingSchema.Meta.dump_only
 
     # Ensures we don't return fields with None values

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -9,6 +9,17 @@ from flask_restx_patched import ModelSchema
 
 from .models import AssetGroup, AssetGroupSighting
 
+# We need api endpoints for AssetGroupSightings which behave just like the
+# Sighting endpoints to standardize frontend interactions. For that reason we need
+# to know which sighting fields to expect in an AssetGroupSighting.config dict
+SIGHTING_FIELDS_IN_AGS_CONFIG = {
+    'decimalLatitude',
+    'decimalLongitude',
+    'encounters',
+    'locationId',
+    'startTime',
+}
+
 
 class BaseAssetGroupSightingSchema(ModelSchema):
     """
@@ -53,6 +64,9 @@ class AssetGroupSightingAsSightingSchema(BaseAssetGroupSightingSchema):
 
     assets = base_fields.Function(AssetGroupSighting.get_assets)
     completion = base_fields.Function(AssetGroupSighting.get_completion)
+
+    # Note: these config_field_getter vars should conform to SIGHTING_FIELDS_IN_AGS_CONFIG
+    # at the top of this file
     decimalLatitude = base_fields.Function(
         AssetGroupSighting.config_field_getter('decimalLatitude')
     )

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -82,18 +82,9 @@ class AssetGroupSightingAsSightingSchema(BaseAssetGroupSightingSchema):
         AssetGroupSighting.config_field_getter('encounters')
     )
 
-    class Meta(BaseAssetGroupSightingSchema.Meta):
+    class Meta:
         # adds 'stage' to the fields already defined above
-        fields = BaseAssetGroupSightingSchema.Meta.fields + (
-            AssetGroupSighting.stage.key,
-            'assets',
-            'completion',
-            'decimalLatitude',
-            'decimalLongitude',
-            'locationId',
-            'startTime',
-            'encounters',
-        )
+        additional = ('stage',)
         dump_only = BaseAssetGroupSightingSchema.Meta.dump_only
 
     # Ensures we don't return fields with None values

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -126,6 +126,11 @@ class CreateAssetGroupSchema(BaseAssetGroupSchema):
             AssetGroup.created.key,
             AssetGroup.updated.key,
         )
+        dump_only = BaseAssetGroupSchema.Meta.dump_only + (
+            AssetGroup.owner_guid.key,
+            AssetGroup.created.key,
+            AssetGroup.updated.key,
+        )
 
 
 class DetailedAssetGroupSchema(CreateAssetGroupSchema):

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -6,6 +6,7 @@ Serialization schemas for Asset_groups resources RESTful API
 
 from flask_marshmallow import base_fields
 from flask_restx_patched import ModelSchema
+from marshmallow import post_dump
 
 from .models import AssetGroup, AssetGroupSighting
 
@@ -93,6 +94,14 @@ class AssetGroupSightingAsSightingSchema(BaseAssetGroupSightingSchema):
             'encounters',
         )
         dump_only = BaseAssetGroupSightingSchema.Meta.dump_only
+
+    # Ensures we don't return fields with None values
+    @post_dump
+    def remove_none_fields(self, data):
+        for field in SIGHTING_FIELDS_IN_AGS_CONFIG:
+            if data[field] is None:
+                del data[field]
+        return data
 
 
 class BaseAssetGroupSchema(ModelSchema):

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -92,6 +92,7 @@ class AssetGroupSightingAsSightingSchema(BaseAssetGroupSightingSchema):
             'startTime',
             'encounters',
         )
+        dump_only = BaseAssetGroupSightingSchema.Meta.dump_only
 
 
 class BaseAssetGroupSchema(ModelSchema):

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -42,6 +42,44 @@ class DetailedAssetGroupSightingSchema(BaseAssetGroupSightingSchema):
         dump_only = BaseAssetGroupSightingSchema.Meta.dump_only
 
 
+class DetailedAssetGroupSightingAsSightingSchema(BaseAssetGroupSightingSchema):
+    """
+    In order for the frontend to render an AGS with the same code that renders a
+    sighting, we have to pop out all the fields in AGS.config into the top-level
+    of the schema. This is done with AssetGroupSighting.config_field_getter,
+    which creates a getter for a config field of a given name. We can add more
+    fields using the pattern below.
+    """
+
+    assets = base_fields.Function(AssetGroupSighting.get_assets)
+    completion = base_fields.Function(AssetGroupSighting.get_completion)
+    decimalLatitude = base_fields.Function(
+        AssetGroupSighting.config_field_getter('decimalLatitude')
+    )
+    decimalLongitude = base_fields.Function(
+        AssetGroupSighting.config_field_getter('decimalLongitude')
+    )
+    locationId = base_fields.Function(
+        AssetGroupSighting.config_field_getter('locationId')
+    )
+    startTime = base_fields.Function(AssetGroupSighting.config_field_getter('startTime'))
+    encounters = base_fields.Function(
+        AssetGroupSighting.config_field_getter('encounters')
+    )
+
+    class Meta(BaseAssetGroupSightingSchema.Meta):
+        fields = BaseAssetGroupSightingSchema.Meta.fields + (
+            AssetGroupSighting.stage.key,
+            'assets',
+            'completion',
+            'decimalLatitude',
+            'decimalLongitude',
+            'locationId',
+            'startTime',
+            'encounters',
+        )
+
+
 class BaseAssetGroupSchema(ModelSchema):
     """
     Base Asset_group schema exposes only the most general fields.
@@ -69,11 +107,6 @@ class CreateAssetGroupSchema(BaseAssetGroupSchema):
 
     class Meta(BaseAssetGroupSchema.Meta):
         fields = BaseAssetGroupSchema.Meta.fields + (
-            AssetGroup.owner_guid.key,
-            AssetGroup.created.key,
-            AssetGroup.updated.key,
-        )
-        dump_only = BaseAssetGroupSchema.Meta.dump_only + (
             AssetGroup.owner_guid.key,
             AssetGroup.created.key,
             AssetGroup.updated.key,

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -42,7 +42,7 @@ class DetailedAssetGroupSightingSchema(BaseAssetGroupSightingSchema):
         dump_only = BaseAssetGroupSightingSchema.Meta.dump_only
 
 
-class DetailedAssetGroupSightingAsSightingSchema(BaseAssetGroupSightingSchema):
+class AssetGroupSightingAsSightingSchema(BaseAssetGroupSightingSchema):
     """
     In order for the frontend to render an AGS with the same code that renders a
     sighting, we have to pop out all the fields in AGS.config into the top-level

--- a/tests/modules/asset_groups/resources/test_patch_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_patch_asset_group.py
@@ -121,7 +121,7 @@ def test_patch_asset_group(
 
 # similar to the above but against the AGS-as-sighting endpoint
 def test_patch_asset_group_sighting_as_sighting(
-    flask_app_client, researcher_1, regular_user, test_root, db, empty_individual
+    flask_app_client, researcher_1, regular_user, test_root
 ):
     # pylint: disable=invalid-name
     from tests.modules.asset_groups.resources.utils import TestCreationData
@@ -176,9 +176,6 @@ def test_patch_asset_group_sighting_as_sighting(
         )
 
     finally:
-        # with db.session.begin():
-        #     db.session.delete(empty_individual)
-        # Restore original state
         if asset_group_uuid:
             asset_group_utils.delete_asset_group(
                 flask_app_client, regular_user, asset_group_uuid

--- a/tests/modules/asset_groups/resources/test_patch_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_patch_asset_group.py
@@ -1,9 +1,13 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 import uuid
+import copy
 
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.extensions.tus.utils as tus_utils
+
+from tests.modules.asset_groups.resources.utils import TestCreationData
+from tests import utils
 
 
 # Test a bunch of failure scenarios
@@ -11,8 +15,6 @@ def test_patch_asset_group(
     flask_app_client, researcher_1, regular_user, test_root, db, empty_individual
 ):
     # pylint: disable=invalid-name
-    from tests.modules.asset_groups.resources.utils import TestCreationData
-    from tests import utils
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     asset_group_uuid = None
@@ -38,7 +40,6 @@ def test_patch_asset_group(
         assert group_sighting.json['completion'] == 10
         assert 'config' in group_sighting.json
         assert 'assetReferences' in group_sighting.json['config']
-        import copy
 
         new_absent_file = copy.deepcopy(group_sighting.json['config']['assetReferences'])
         new_absent_file.append('absent_file.jpg')
@@ -109,6 +110,76 @@ def test_patch_asset_group(
     finally:
         with db.session.begin():
             db.session.delete(empty_individual)
+        # Restore original state
+        if asset_group_uuid:
+            asset_group_utils.delete_asset_group(
+                flask_app_client, regular_user, asset_group_uuid
+            )
+
+        tus_utils.cleanup_tus_dir(transaction_id)
+
+
+# similar to the above but against the AGS-as-sighting endpoint
+def test_patch_asset_group_sighting_as_sighting(
+    flask_app_client, researcher_1, regular_user, test_root, db, empty_individual
+):
+    # pylint: disable=invalid-name
+    from tests.modules.asset_groups.resources.utils import TestCreationData
+    from tests import utils
+
+    transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
+    asset_group_uuid = None
+    try:
+        data = TestCreationData(transaction_id)
+        data.add_filename(0, test_filename)
+        response = asset_group_utils.create_asset_group(
+            flask_app_client, regular_user, data.get()
+        )
+        asset_group_uuid = response.json['guid']
+        asset_group_sighting_guid = response.json['asset_group_sightings'][0]['guid']
+
+        # Regular user can create it but not read it??????
+        asset_group_utils.read_asset_group_sighting_as_sighting(
+            flask_app_client, regular_user, asset_group_sighting_guid, 403
+        )
+
+        # Researcher should be able to
+        group_sighting = asset_group_utils.read_asset_group_sighting_as_sighting(
+            flask_app_client, researcher_1, asset_group_sighting_guid
+        )
+        from app.modules.asset_groups.schemas import SIGHTING_FIELDS_IN_AGS_CONFIG
+
+        expected_fields = {'guid', 'stage', 'completion', 'assets'}
+        expected_fields.update(SIGHTING_FIELDS_IN_AGS_CONFIG)
+
+        for field in expected_fields:
+            assert field in group_sighting.json
+
+        # Valid patch, adding a new encounter with an existing file
+        new_encounters = copy.deepcopy(group_sighting.json['encounters'])
+        new_encounters.append({})
+        patch_data = [utils.patch_replace_op('encounters', new_encounters)]
+
+        # Should not work as contributor
+        asset_group_utils.patch_asset_group_sighting_as_sighting(
+            flask_app_client, regular_user, asset_group_sighting_guid, patch_data, 403
+        )
+
+        # should work as researcher
+        asset_group_utils.patch_asset_group_sighting_as_sighting(
+            flask_app_client, researcher_1, asset_group_sighting_guid, patch_data
+        )
+
+        # chosen for reasons of incongruity as the naked mole rat is virtually blind
+        # so has no 'sight'
+        add_name_patch = [utils.patch_add_op('name', 'Naked Mole Rat')]
+        asset_group_utils.patch_asset_group_sighting_as_sighting(
+            flask_app_client, researcher_1, asset_group_sighting_guid, add_name_patch
+        )
+
+    finally:
+        # with db.session.begin():
+        #     db.session.delete(empty_individual)
         # Restore original state
         if asset_group_uuid:
             asset_group_utils.delete_asset_group(

--- a/tests/modules/asset_groups/resources/test_patch_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_patch_asset_group.py
@@ -147,12 +147,10 @@ def test_patch_asset_group_sighting_as_sighting(
         group_sighting = asset_group_utils.read_asset_group_sighting_as_sighting(
             flask_app_client, researcher_1, asset_group_sighting_guid
         )
-        from app.modules.asset_groups.schemas import SIGHTING_FIELDS_IN_AGS_CONFIG
 
-        expected_fields = {'guid', 'stage', 'completion', 'assets'}
-        expected_fields.update(SIGHTING_FIELDS_IN_AGS_CONFIG)
-
-        for field in expected_fields:
+        # startTime and locationId are only present in the _as_sighting endpoints,
+        # since they are in the config of a standard AGS
+        for field in {'guid', 'stage', 'completion', 'assets', 'startTime', 'locationId'}:
             assert field in group_sighting.json
 
         # Valid patch, adding a new encounter with an existing file

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -446,9 +446,10 @@ def patch_asset_group_sighting(
             content_type='application/json',
             data=json.dumps(data),
         )
-    # from pprint import pprint
-    # print('patch_asset_group_sighting got response json:')
-    # pprint(response.json)
+    from pprint import pprint
+
+    print('patch_asset_group_sighting got response json:')
+    pprint(response.json)
     if expected_status_code == 200:
         test_utils.validate_dict_response(
             response, 200, EXPECTED_ASSET_GROUP_SIGHTING_FIELDS

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -14,6 +14,17 @@ from tests import utils as test_utils
 from tests import TEST_ASSET_GROUP_UUID, TEST_EMPTY_ASSET_GROUP_UUID
 
 PATH = '/api/v1/asset_groups/'
+EXPECTED_ASSET_GROUP_SIGHTING_FIELDS = {
+    'guid',
+    'stage',
+    'decimalLatitude',
+    'decimalLongitude',
+    'encounters',
+    'locationId',
+    'startTime',
+    'completion',
+    'assets',
+}
 
 ANNOTATION_UUIDS = [
     '1891ca05-5fa5-4e52-bb30-8ee80941c2fc',
@@ -435,9 +446,13 @@ def patch_asset_group_sighting(
             content_type='application/json',
             data=json.dumps(data),
         )
-
+    # from pprint import pprint
+    # print('patch_asset_group_sighting got response json:')
+    # pprint(response.json)
     if expected_status_code == 200:
-        test_utils.validate_dict_response(response, 200, {'guid', 'stage', 'config'})
+        test_utils.validate_dict_response(
+            response, 200, EXPECTED_ASSET_GROUP_SIGHTING_FIELDS
+        )
     elif expected_status_code == 400:
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message', 'passed_message'}
@@ -458,9 +473,12 @@ def read_asset_group_sighting(
             response = flask_app_client.get(f'{PATH}sighting/{asset_group_sighting_guid}')
     else:
         response = flask_app_client.get(f'{PATH}sighting/{asset_group_sighting_guid}')
+    # from pprint import pprint
+    # print('read_asset_group_sighting got response json:')
+    # pprint(response.json)
     if expected_status_code == 200:
         test_utils.validate_dict_response(
-            response, 200, {'guid', 'stage', 'config', 'completion', 'assets'}
+            response, 200, EXPECTED_ASSET_GROUP_SIGHTING_FIELDS
         )
     else:
         test_utils.validate_dict_response(
@@ -480,7 +498,9 @@ def simulate_detection_response(
         )
 
     if expected_status_code == 200:
-        test_utils.validate_dict_response(response, 200, {})
+        test_utils.validate_dict_response(
+            response, 200, EXPECTED_ASSET_GROUP_SIGHTING_FIELDS
+        )
     else:
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message'}
@@ -513,7 +533,7 @@ def patch_in_dummy_annotation(
     group_sighting = read_asset_group_sighting(
         flask_app_client, user, asset_group_sighting_uuid
     )
-    encounter_guid = group_sighting.json['config']['encounters'][encounter_num]['guid']
+    encounter_guid = group_sighting.json['encounters'][encounter_num]['guid']
 
     patch_data = [test_utils.patch_replace_op('annotations', [str(new_annot.guid)])]
     patch_asset_group_sighting(

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -446,11 +446,42 @@ def patch_asset_group_sighting(
             content_type='application/json',
             data=json.dumps(data),
         )
-    from pprint import pprint
-    pprint(response.json)
 
     if expected_status_code == 200:
         test_utils.validate_dict_response(response, 200, {'guid', 'stage', 'config'})
+    elif expected_status_code == 400:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message', 'passed_message'}
+        )
+    else:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+    return response
+
+
+def patch_asset_group_sighting_as_sighting(
+    flask_app_client,
+    user,
+    patch_path,
+    data,
+    expected_status_code=200,
+    expected_resp='',
+):
+    with flask_app_client.login(user, auth_scopes=('asset_group_sightings:write',)):
+        response = flask_app_client.patch(
+            f'{PATH}sighting/as_sighting/{patch_path}',
+            content_type='application/json',
+            data=json.dumps(data),
+        )
+
+    if expected_status_code == 200:
+        from app.modules.asset_groups.schemas import SIGHTING_FIELDS_IN_AGS_CONFIG
+
+        expected_fields = {'guid', 'stage', 'completion', 'assets'}
+        expected_fields.update(SIGHTING_FIELDS_IN_AGS_CONFIG)
+
+        test_utils.validate_dict_response(response, 200, expected_fields)
     elif expected_status_code == 400:
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message', 'passed_message'}
@@ -490,17 +521,11 @@ def read_asset_group_sighting_as_sighting(
         response = flask_app_client.get(get_path)
 
     if expected_status_code == 200:
-        expected_fields = {
-            'guid',
-            'stage',
-            'decimalLatitude',
-            'decimalLongitude',
-            'encounters',
-            'locationId',
-            'startTime',
-            'completion',
-            'assets',
-        }
+        from app.modules.asset_groups.schemas import SIGHTING_FIELDS_IN_AGS_CONFIG
+
+        expected_fields = {'guid', 'stage', 'completion', 'assets'}
+        expected_fields.update(SIGHTING_FIELDS_IN_AGS_CONFIG)
+
         test_utils.validate_dict_response(response, 200, expected_fields)
     else:
         test_utils.validate_dict_response(

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -427,6 +427,7 @@ def delete_asset_group(
         assert response.status_code == 204
         assert not AssetGroup.is_on_remote(asset_group_guid)
     else:
+
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message'}
         )
@@ -477,12 +478,13 @@ def patch_asset_group_sighting_as_sighting(
         )
 
     if expected_status_code == 200:
-        from app.modules.asset_groups.schemas import SIGHTING_FIELDS_IN_AGS_CONFIG
-
-        expected_fields = {'guid', 'stage', 'completion', 'assets'}
-        expected_fields.update(SIGHTING_FIELDS_IN_AGS_CONFIG)
-
-        test_utils.validate_dict_response(response, 200, expected_fields)
+        # startTime and locationId are only present in the _as_sighting endpoints,
+        # since they are in the config of a standard AGS
+        test_utils.validate_dict_response(
+            response,
+            200,
+            {'guid', 'stage', 'completion', 'assets', 'startTime', 'locationId'},
+        )
     elif expected_status_code == 400:
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message', 'passed_message'}
@@ -524,12 +526,13 @@ def read_asset_group_sighting_as_sighting(
         response = flask_app_client.get(get_path)
 
     if expected_status_code == 200:
-        from app.modules.asset_groups.schemas import SIGHTING_FIELDS_IN_AGS_CONFIG
-
-        expected_fields = {'guid', 'stage', 'completion', 'assets'}
-        expected_fields.update(SIGHTING_FIELDS_IN_AGS_CONFIG)
-
-        test_utils.validate_dict_response(response, 200, expected_fields)
+        # startTime and locationId are only present in the _as_sighting endpoints,
+        # since they are in the config of a standard AGS
+        test_utils.validate_dict_response(
+            response,
+            200,
+            {'guid', 'stage', 'completion', 'assets', 'startTime', 'locationId'},
+        )
     else:
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message'}

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -453,6 +453,7 @@ def patch_asset_group_sighting(
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message', 'passed_message'}
         )
+        assert response.json['passed_message'] == expected_resp
     else:
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message'}
@@ -502,7 +503,9 @@ def read_asset_group_sighting(
     else:
         response = flask_app_client.get(f'{PATH}sighting/{asset_group_sighting_guid}')
     if expected_status_code == 200:
-        test_utils.validate_dict_response(response, 200, {'guid', 'stage', 'config'})
+        test_utils.validate_dict_response(
+            response, 200, {'guid', 'stage', 'config', 'completion', 'assets'}
+        )
     else:
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message'}


### PR DESCRIPTION
This adds a new GET and PATCH api endpoint to AssetGroupSightings, at /asset_group/sighting/as_sighting/. The goal is for the frontend to be able to read and modify AGS's using the same calls as it does sightings. This is a new API endpoint so that 1) it doesn't break all our other usage of the AGS api and 2) the standard AGS api endpoints maintain the expected relationship between input parameters, returned schemas, and the objects' actual layout.

The logic that presents an AGS as a Sighting is in a new schema, `AssetGroupSightingAsSightingSchema`. All this really does is pull out the fields from the AGS `config` dict into top-level fields. There is a corresponding new entry in the AGS parameters.py, `PatchAssetGroupSightingAsSightingParameters`. These are both used at the new endpoint defined in the resources `AssetGroupSightingAsSighting` class. These are tested in a new test in test_patch_asset_group.py, `test_patch_asset_group_sighting_as_sighting`, which calls new test utilities from the AssetGroup utils.py. The most recent three commits are most relevant.

Things I felt uncertain about where I welcome feedback (ofc, it's welcomed everywhere):

- I don't see a way to flexibly add fields to the schema besides hard-coding them. This means we return None/null field values rather than not returning those fields, on e.g. decimalLatitude, and we'll have to add more fields here if they are added to the standard AGS.config dict.
- For reference in tests and elsewhere, I define a static set of those AGS.config fields that are present at top-level in sightings in the schema file, named `SIGHTING_FIELDS_IN_AGS_CONFIG`. I welcome other strategies or locations for listing these.