### PR TITLE
Dex 460 more fields for individual API

### DIFF
--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -36,7 +36,7 @@ class EDMManager(RestManager):
     ENDPOINT_PREFIX = 'api'
 
     # this is based on edm date of most recent commit (we must be at or greater than this)
-    MIN_VERSION = '2021-09-09 00:00:01 -0700'
+    MIN_VERSION = '2021-09-16 17:39:00 -0700'
 
     # We use // as a shorthand for prefix
     # fmt: off

--- a/app/modules/encounters/schemas.py
+++ b/app/modules/encounters/schemas.py
@@ -71,8 +71,10 @@ class AugmentedEdmEncounterSchema(BaseEncounterSchema):
 
 class AugmentedIndividualApiEncounterSchema(BaseEncounterSchema):
 
-    submitter = base_fields.Nested('BaseUserSchema', many=False, exclude='email')
-    owner = base_fields.Nested('BaseUserSchema', many=False, exclude='email')
+    submitter = base_fields.Nested(
+        'BaseUserSchema', many=False, only=('full_name', 'guid')
+    )
+    owner = base_fields.Nested('BaseUserSchema', many=False, only=('full_name', 'guid'))
 
     class Meta(BaseEncounterSchema.Meta):
         fields = BaseEncounterSchema.Meta.fields + (
@@ -81,6 +83,5 @@ class AugmentedIndividualApiEncounterSchema(BaseEncounterSchema):
             'owner',
             'hasView',
             'hasEdit',
-            'asset_group_sighting_encounter_guid'
+            'asset_group_sighting_encounter_guid',
         )
-

--- a/app/modules/encounters/schemas.py
+++ b/app/modules/encounters/schemas.py
@@ -67,3 +67,20 @@ class AugmentedEdmEncounterSchema(BaseEncounterSchema):
             'hasEdit',
             'annotations',
         )
+
+
+class AugmentedIndividualApiEncounterSchema(BaseEncounterSchema):
+
+    submitter = base_fields.Nested('BaseUserSchema', many=False, exclude='email')
+    owner = base_fields.Nested('BaseUserSchema', many=False, exclude='email')
+
+    class Meta(BaseEncounterSchema.Meta):
+        fields = BaseEncounterSchema.Meta.fields + (
+            Encounter.sighting.key,
+            'submitter',
+            'owner',
+            'hasView',
+            'hasEdit',
+            'asset_group_sighting_encounter_guid'
+        )
+

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -44,4 +44,5 @@ class DetailedIndividualSchema(BaseIndividualSchema):
         dump_only = BaseIndividualSchema.Meta.dump_only + (
             Individual.created.key,
             Individual.updated.key,
+            'encounters',
         )

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -30,6 +30,7 @@ class DetailedIndividualSchema(BaseIndividualSchema):
     hasView = base_fields.Function(Individual.current_user_has_view_permission)
     hasEdit = base_fields.Function(Individual.current_user_has_edit_permission)
     featuredAssetGuid = base_fields.Function(Individual.get_featured_asset_guid)
+    encounters = base_fields.Nested('AugmentedIndividualApiEncounterSchema', many=True)
 
     class Meta(BaseIndividualSchema.Meta):
         fields = BaseIndividualSchema.Meta.fields + (
@@ -38,6 +39,7 @@ class DetailedIndividualSchema(BaseIndividualSchema):
             'featuredAssetGuid',
             'hasView',
             'hasEdit',
+            'encounters'
         )
         dump_only = BaseIndividualSchema.Meta.dump_only + (
             Individual.created.key,

--- a/tests/modules/individuals/resources/test_individual_crud.py
+++ b/tests/modules/individuals/resources/test_individual_crud.py
@@ -270,8 +270,11 @@ def test_individual_has_detailed_encounter_from_edm(db, flask_app_client, resear
         sighting = Sighting.query.get(sighting_id)
         assert sighting is not None
 
+        encounter = Encounter.query.get(enc.guid)
+        encounter.asset_group_sighting_encounter_guid = uuid.uuid4()
+
         individual_data_in = {
-            'names': {'primaryName': 'Wilbur'},
+            'names': {'defaultName': 'Wilbur'},
             'encounters': [{'id': str(enc.guid)}],
         }
 


### PR DESCRIPTION
Small PR to add a few fields to the Individual API response per @brmscheiner 's request. New response should look a little something like this: 

```javascript
{
	'comments': 'None',
	'encounters': [{
		'individual': {
			'names': {
				'nickname': 'Meatloaf',
				'defaultName': 'Micheal Aday'
			},
			'id': 'fc35b212-3d96-4071-b290-6ab22df4ec0b'
		},
		'customFields': {},
		'locationId': 'Saturn',
		'decimalLongitude': '25.9999',
		'decimalLatitude': '25.9999',
		'verbatimLocality': 'Saturn',
		'id': 'f9aabbd7-56c6-4a68-a097-46fc5a9e8697',
		'time': '2010-01-01T01:01:01Z',
		'version': 1633473655066,
		'hasView': True,
		'createdHouston': '2021-10-05T22:40:55.091886+00:00',
		'guid': 'f9aabbd7-56c6-4a68-a097-46fc5a9e8697',
		'submitter': {
			'guid': 'e5435041-b65d-41d7-9a5a-a3168d30ce28',
			'full_name': 'First Middle Last',
			'profile_fileupload': None
		},
		'owner': {
			'guid': 'e5435041-b65d-41d7-9a5a-a3168d30ce28',
			'full_name': 'First Middle Last',
			'profile_fileupload': None
		},
		'hasEdit': True,
		'updatedHouston': '2021-10-05T22:40:55.091905+00:00'
	}],
	'createdEDM': '2021-10-05 22:40:55',
	'customFields': {},
	'locationId': 'test',
	'decimalLongitude': 25.9999,
	'startTime': '2021-10-05T22:40:44.692Z',
	'decimalLatitude': 25.9999,
	'verbatimLocality': 'Saturn',
	'id': 'c3c11028-991c-43aa-be38-45f0dd922415',
	'encounterCounts': {
		'lifeStage': {},
		'sex': {},
		'individuals': 1
	},
	'version': 1633473655066,
	'featuredAssetGuid': None,
	'hasView': True,
	'createdHouston': '2021-10-05T22:40:55.084494+00:00',
	'guid': 'c3c11028-991c-43aa-be38-45f0dd922415',
	'assets': [],
	'hasEdit': True,
	'updatedHouston': '2021-10-05T22:40:55.084518+00:00'
}
```