### PR TITLE
DEX-481 fix user_manager requesting normal collaboration

### DIFF
--- a/app/modules/collaborations/resources.py
+++ b/app/modules/collaborations/resources.py
@@ -97,17 +97,18 @@ class Collaborations(Resource):
         users = [current_user, other_user]
 
         if current_user.is_user_manager:
-            second_user_guid = req.get('second_user_guid')
-            second_user = User.query.get(second_user_guid)
-            if not second_user:
-                abort(400, f'User with guid {second_user_guid} not found')
-            if not second_user.is_active:
-                abort(400, f'User with guid {second_user_guid} is not active')
 
-            users = [other_user, second_user]
+            second_user_guid = req.get('second_user_guid')
+            if second_user_guid:
+                second_user = User.query.get(second_user_guid)
+                if second_user:
+                    if not second_user.is_active:
+                        abort(400, f'User with guid {second_user_guid} is not active')
+                    users = [other_user, second_user]
+                else:
+                    abort(400, f'User with guid {second_user_guid} not found')
 
         with context:
-
             collaboration = Collaboration(users, current_user)
             db.session.add(collaboration)
 

--- a/app/modules/collaborations/resources.py
+++ b/app/modules/collaborations/resources.py
@@ -103,10 +103,12 @@ class Collaborations(Resource):
                 second_user = User.query.get(second_user_guid)
                 if second_user:
                     if not second_user.is_active:
-                        abort(400, f'User with guid {second_user_guid} is not active')
+                        abort(
+                            400, f'Second user with guid {second_user_guid} is not active'
+                        )
                     users = [other_user, second_user]
                 else:
-                    abort(400, f'User with guid {second_user_guid} not found')
+                    abort(400, f'Second user with guid {second_user_guid} not found')
 
         with context:
             collaboration = Collaboration(users, current_user)

--- a/tests/modules/collaborations/resources/test_collaboration_create.py
+++ b/tests/modules/collaborations/resources/test_collaboration_create.py
@@ -84,7 +84,7 @@ def test_create_approved_collaboration(
         'user_guid': str(researcher_1.guid),
         'second_user_guid': duff_uuid,
     }
-    resp_msg = f'User with guid {duff_uuid} not found'
+    resp_msg = f'Second user with guid {duff_uuid} not found'
     collab_utils.create_collaboration(
         flask_app_client, user_manager_user, data, 400, resp_msg
     )


### PR DESCRIPTION
The collaborations API would assume a POST from a user with the user manager role was always going to have a second guid, and would fail if this user attempted a normal collaboration initiation. Users with the user_manager role should be able to initiate normal collaborations, as they can also be researchers.

This is a wee fix for the above.