### PR TITLE
Fix sage "detected" callback response

### DIFF
--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -228,56 +228,60 @@ def build_sage_detection_response(asset_group_sighting_guid, job_uuid):
 
     # Generate the response back from Sage
     sage_resp = {
-        'response': {
-            'jobid': job_uuid,
-            'json_result': {
-                'has_assignments': False,
-                'image_uuid_list': [
-                    # Image UUID stored in acm (not the same as houston)
-                    {'__UUID__': str(uuid.uuid4())}
-                    for _ in asset_ids
+        'status': 'completed',
+        'jobid': str(job_uuid),
+        'json_result': {
+            'image_uuid_list': [
+                # Image UUID stored in acm (not the same as houston)
+                {'__UUID__': str(uuid.uuid4())}
+                for _ in asset_ids
+            ],
+            'results_list': [
+                [
+                    {
+                        'id': 1,
+                        'uuid': {'__UUID__': ANNOTATION_UUIDS[0]},
+                        'xtl': 459,
+                        'ytl': 126,
+                        'left': 459,
+                        'top': 126,
+                        'width': 531,
+                        'height': 539,
+                        'theta': 0.0,
+                        'confidence': 0.8568,
+                        'class': 'zebra_plains',
+                        'species': 'zebra_plains',
+                        'viewpoint': None,
+                        'quality': None,
+                        'multiple': False,
+                        'interest': False,
+                    },
+                    {
+                        'id': 2,
+                        'uuid': {'__UUID__': ANNOTATION_UUIDS[1]},
+                        'xtl': 26,
+                        'ytl': 145,
+                        'left': 26,
+                        'top': 145,
+                        'width': 471,
+                        'height': 500,
+                        'theta': 0.0,
+                        'confidence': 0.853,
+                        'class': 'zebra_plains',
+                        'species': 'zebra_plains',
+                        'viewpoint': None,
+                        'quality': None,
+                        'multiple': False,
+                        'interest': False,
+                    },
                 ],
-                'results_list': [
-                    [
-                        {
-                            'class': 'whale_orca+fin_dorsal',
-                            'confidence': 0.7909,
-                            'height': 820,
-                            'id': 947505,
-                            'interest': False,
-                            'left': 140,
-                            'multiple': False,
-                            'quality': None,
-                            'species': 'whale_orca+fin_dorsal',
-                            'theta': 0.0,
-                            'top': 0,
-                            'uuid': {'__UUID__': ANNOTATION_UUIDS[0]},
-                            'viewpoint': 'left',
-                            'width': 1063,
-                            'xtl': 140,
-                            'ytl': 0,
-                        },
-                    ],
-                ],
-                'score_list': [
-                    0.0,
-                ],
-            },
-            'status': 'completed',
-        },
-        'status': {
-            'cache': -1,
-            'code': 200,
-            'message': '',
-            'success': True,
+            ],
         },
     }
 
     # Make sure results_list is the same length as the assets (just
     # empty [])
-    sage_resp['response']['json_result']['results_list'] += [
-        [] for _ in range(len(asset_ids) - 1)
-    ]
+    sage_resp['json_result']['results_list'] += [[] for _ in range(len(asset_ids) - 1)]
     return sage_resp
 
 


### PR DESCRIPTION
Revert most of 30271b46 "476 implementing a single handling ofthe
detection response. There were two formats, still not sure which is
correct."

The response added in 28afffd3 in `build_sage_detection_response` in
`tests/modules/asset_groups/resources/utils.py` is an actual response
from sage.

---

I'm working on getting this integration test to work with sage in the CI so we have a way of testing things with sage: (but it doesn't need to be part of this PR)

https://github.com/WildMeOrg/houston/blob/abce34ba4fa7a3adf8a558085747c90632722164/tests/modules/asset_groups/resources/test_create_asset_group.py#L247-L284