### PR TITLE
491 more collaborations and notifications testing plus bugs fixed

### DIFF
--- a/app/modules/collaborations/models.py
+++ b/app/modules/collaborations/models.py
@@ -194,6 +194,8 @@ class Collaboration(db.Model, HoustonModel):
 
         user_data = {}
         for association in self.collaboration_user_associations:
+            if association.read_approval_state == CollaborationUserState.CREATOR:
+                continue
             assoc_data = BaseUserSchema().dump(association.user).data
             assoc_data['viewState'] = association.read_approval_state
             assoc_data['editState'] = association.edit_approval_state

--- a/tests/modules/collaborations/resources/test_collaboration_create.py
+++ b/tests/modules/collaborations/resources/test_collaboration_create.py
@@ -21,7 +21,7 @@ def test_create_collaboration(
         readonly_user, create_resp.json['guid']
     )
 
-    request.addfinalizer(lambda: readonly_user_collab.delete())
+    request.addfinalizer(readonly_user_collab.delete)
 
     collab = None
     try:
@@ -115,7 +115,7 @@ def test_create_repeat_collaboration(
     )
     collab_guid = create_resp.json['guid']
     collab = collab_utils.get_collab_object_for_user(researcher_1, collab_guid)
-    request.addfinalizer(lambda: collab.delete())
+    request.addfinalizer(collab.delete)
 
     # Should return the first one again
     create_resp = collab_utils.create_simple_collaboration(

--- a/tests/modules/collaborations/resources/test_collaboration_notification.py
+++ b/tests/modules/collaborations/resources/test_collaboration_notification.py
@@ -9,25 +9,13 @@ from tests import utils as test_utils
 # Request edit, validate that notification is received, approve edit.
 def test_edit_collaboration(flask_app_client, researcher_1, researcher_2, db, request):
 
-    create_data = {'user_guid': str(researcher_1.guid)}
-    collab_utils.create_collaboration(flask_app_client, researcher_2, create_data)
-    researcher_1_assocs = [
-        assoc for assoc in researcher_1.user_collaboration_associations
-    ]
-    collab = researcher_1_assocs[0].collaboration
-
-    request.addfinalizer(collab.delete)
-
-    # Check collab is in the state we expect
-    collab_data = collab_utils.read_collaboration(
-        flask_app_client, researcher_1, collab.guid
+    create_resp = collab_utils.create_simple_collaboration(
+        flask_app_client, researcher_2, researcher_1
     )
-    members = collab_data.json.get('members')
-    assert members
-    assert members[str(researcher_1.guid)]['viewState'] == 'pending'
-    assert members[str(researcher_1.guid)]['editState'] == 'not_initiated'
-    assert members[str(researcher_2.guid)]['viewState'] == 'approved'
-    assert members[str(researcher_2.guid)]['editState'] == 'not_initiated'
+    collab_guid = create_resp.json['guid']
+    collab = collab_utils.get_collab_object_for_user(researcher_1, collab_guid)
+
+    request.addfinalizer(lambda: collab.delete())
 
     # Check researcher1 gets the notification
     researcher_1_notifs = notif_utils.read_all_notifications(
@@ -43,36 +31,22 @@ def test_edit_collaboration(flask_app_client, researcher_1, researcher_2, db, re
     collab_utils.request_edit(flask_app_client, collab.guid, researcher_1, 400, resp_msg)
 
     # patch to approve collaboration by researcher1
-    patch_data = [test_utils.patch_replace_op('view_permission', 'approved')]
-
-    collab_utils.patch_collaboration(
-        flask_app_client, collab.guid, researcher_1, patch_data
+    patch_resp = collab_utils.patch_collaboration(
+        flask_app_client,
+        collab.guid,
+        researcher_1,
+        [test_utils.patch_replace_op('view_permission', 'approved')],
     )
-
-    # Check collab is in the state we expect (as researcher 2 for variation)
-    collab_data = collab_utils.read_collaboration(
-        flask_app_client, researcher_2, collab.guid
-    )
-    members = collab_data.json.get('members')
-    assert members
-    assert members[str(researcher_1.guid)]['viewState'] == 'approved'
-    assert members[str(researcher_1.guid)]['editState'] == 'not_initiated'
-    assert members[str(researcher_2.guid)]['viewState'] == 'approved'
-    assert members[str(researcher_2.guid)]['editState'] == 'not_initiated'
+    expected_resp = {
+        researcher_1.guid: {'viewState': 'approved', 'editState': 'not_initiated'},
+        researcher_2.guid: {'viewState': 'approved', 'editState': 'not_initiated'},
+    }
+    collab_utils.validate_expected_states(patch_resp.json, expected_resp)
 
     # Researcher 1 requests that this is escalated to an edit collaboration
-    collab_utils.request_edit(flask_app_client, collab.guid, researcher_1)
-
-    # Check collab is in the state we expect
-    collab_data = collab_utils.read_collaboration(
-        flask_app_client, researcher_1, collab.guid
+    collab_utils.request_edit_simple_collaboration(
+        flask_app_client, researcher_1, researcher_2
     )
-    members = collab_data.json.get('members')
-    assert members
-    assert members[str(researcher_1.guid)]['viewState'] == 'approved'
-    assert members[str(researcher_1.guid)]['editState'] == 'approved'
-    assert members[str(researcher_2.guid)]['viewState'] == 'approved'
-    assert members[str(researcher_2.guid)]['editState'] == 'pending'
 
     # Researcher 2 should now receive a notification
     researcher_2_notifs = notif_utils.read_all_unread_notifications(
@@ -84,19 +58,27 @@ def test_edit_collaboration(flask_app_client, researcher_1, researcher_2, db, re
     assert len(collab_edit_requests_from_res1) == 1
 
     # patch to approve edit collaboration by researcher2
-    patch_data = [test_utils.patch_replace_op('edit_permission', 'approved')]
-
-    collab_utils.patch_collaboration(
-        flask_app_client, collab.guid, researcher_2, patch_data
+    collab_utils.approve_edit_on_collaboration(
+        flask_app_client, researcher_2, researcher_1
     )
 
-    # Check collab is in the state we expect (as researcher 2 for variation)
-    collab_data = collab_utils.read_collaboration(
-        flask_app_client, researcher_2, collab.guid
+    # back to view only TBD move to a separate test, Looks like it's duplicated in patch test
+    patch_resp = collab_utils.patch_collaboration(
+        flask_app_client,
+        collab.guid,
+        researcher_1,
+        [test_utils.patch_replace_op('edit_permission', 'revoked')],
     )
-    members = collab_data.json.get('members')
-    assert members
-    assert members[str(researcher_1.guid)]['viewState'] == 'approved'
-    assert members[str(researcher_1.guid)]['editState'] == 'approved'
-    assert members[str(researcher_2.guid)]['viewState'] == 'approved'
-    assert members[str(researcher_2.guid)]['editState'] == 'approved'
+    expected_resp = {
+        researcher_1.guid: {'viewState': 'approved', 'editState': 'revoked'},
+        researcher_2.guid: {'viewState': 'approved', 'editState': 'approved'},
+    }
+    collab_utils.validate_expected_states(patch_resp.json, expected_resp)
+
+    # Researcher 1 can change their mind and go straight back to edit
+    edit_response = collab_utils.request_edit(flask_app_client, collab.guid, researcher_1)
+    expected_resp = {
+        researcher_1.guid: {'viewState': 'approved', 'editState': 'approved'},
+        researcher_2.guid: {'viewState': 'approved', 'editState': 'approved'},
+    }
+    collab_utils.validate_expected_states(edit_response.json, expected_resp)

--- a/tests/modules/collaborations/resources/test_collaboration_notification.py
+++ b/tests/modules/collaborations/resources/test_collaboration_notification.py
@@ -2,12 +2,15 @@
 # pylint: disable=missing-docstring
 import tests.modules.collaborations.resources.utils as collab_utils
 import tests.modules.notifications.resources.utils as notif_utils
-from tests import utils as test_utils
 
 
 # Full sequence, create the collaboration, validate that the notification is received, approve the view aspect
 # Request edit, validate that notification is received, approve edit.
 def test_edit_collaboration(flask_app_client, researcher_1, researcher_2, db, request):
+
+    # Start with nothing outstanding
+    notif_utils.mark_all_notifications_as_read(flask_app_client, researcher_1)
+    notif_utils.mark_all_notifications_as_read(flask_app_client, researcher_2)
 
     create_resp = collab_utils.create_simple_collaboration(
         flask_app_client, researcher_2, researcher_1
@@ -15,13 +18,13 @@ def test_edit_collaboration(flask_app_client, researcher_1, researcher_2, db, re
     collab_guid = create_resp.json['guid']
     collab = collab_utils.get_collab_object_for_user(researcher_1, collab_guid)
 
-    request.addfinalizer(lambda: collab.delete())
+    request.addfinalizer(collab.delete)
 
     # Check researcher1 gets the notification
     researcher_1_notifs = notif_utils.read_all_notifications(
         flask_app_client, researcher_1
     )
-    collab_requests_from_res2 = notif_utils.get_notifications(
+    collab_requests_from_res2 = notif_utils.get_unread_notifications(
         researcher_1_notifs.json, str(researcher_2.guid), 'collaboration_request'
     )
     assert len(collab_requests_from_res2) >= 1
@@ -31,54 +34,44 @@ def test_edit_collaboration(flask_app_client, researcher_1, researcher_2, db, re
     collab_utils.request_edit(flask_app_client, collab.guid, researcher_1, 400, resp_msg)
 
     # patch to approve collaboration by researcher1
-    patch_resp = collab_utils.patch_collaboration(
-        flask_app_client,
-        collab.guid,
-        researcher_1,
-        [test_utils.patch_replace_op('view_permission', 'approved')],
+    collab_utils.approve_view_on_collaboration(
+        flask_app_client, collab_guid, researcher_1, researcher_2
     )
-    expected_resp = {
-        researcher_1.guid: {'viewState': 'approved', 'editState': 'not_initiated'},
-        researcher_2.guid: {'viewState': 'approved', 'editState': 'not_initiated'},
-    }
-    collab_utils.validate_expected_states(patch_resp.json, expected_resp)
 
     # Researcher 1 requests that this is escalated to an edit collaboration
     collab_utils.request_edit_simple_collaboration(
-        flask_app_client, researcher_1, researcher_2
+        flask_app_client, collab_guid, researcher_1, researcher_2
     )
 
     # Researcher 2 should now receive a notification
     researcher_2_notifs = notif_utils.read_all_unread_notifications(
         flask_app_client, researcher_2
     )
-    collab_edit_requests_from_res1 = notif_utils.get_notifications(
+    collab_edit_requests_from_res1 = notif_utils.get_unread_notifications(
         researcher_2_notifs.json, str(researcher_1.guid), 'collaboration_edit_request'
     )
     assert len(collab_edit_requests_from_res1) == 1
+    notif_utils.mark_all_notifications_as_read(flask_app_client, researcher_2)
 
     # patch to approve edit collaboration by researcher2
     collab_utils.approve_edit_on_collaboration(
-        flask_app_client, researcher_2, researcher_1
+        flask_app_client, collab_guid, researcher_2, researcher_1
     )
 
-    # back to view only TBD move to a separate test, Looks like it's duplicated in patch test
-    patch_resp = collab_utils.patch_collaboration(
-        flask_app_client,
-        collab.guid,
-        researcher_1,
-        [test_utils.patch_replace_op('edit_permission', 'revoked')],
+    # back to view only
+    collab_utils.revoke_edit_on_collaboration(
+        flask_app_client, collab_guid, researcher_1, researcher_2
     )
-    expected_resp = {
-        researcher_1.guid: {'viewState': 'approved', 'editState': 'revoked'},
-        researcher_2.guid: {'viewState': 'approved', 'editState': 'approved'},
-    }
-    collab_utils.validate_expected_states(patch_resp.json, expected_resp)
 
     # Researcher 1 can change their mind and go straight back to edit
-    edit_response = collab_utils.request_edit(flask_app_client, collab.guid, researcher_1)
-    expected_resp = {
-        researcher_1.guid: {'viewState': 'approved', 'editState': 'approved'},
-        researcher_2.guid: {'viewState': 'approved', 'editState': 'approved'},
-    }
-    collab_utils.validate_expected_states(edit_response.json, expected_resp)
+    collab_utils.request_edit(flask_app_client, collab.guid, researcher_1)
+    collab_utils.validate_full_access(collab_guid, researcher_1, researcher_2)
+
+    # Researcher 2 gets no notification of the revoke or the restore
+    researcher_2_notifs = notif_utils.read_all_unread_notifications(
+        flask_app_client, researcher_2
+    )
+    collab_edit_requests_from_res1 = notif_utils.get_unread_notifications(
+        researcher_2_notifs.json, str(researcher_1.guid), 'collaboration_edit_request'
+    )
+    assert len(collab_edit_requests_from_res1) == 0

--- a/tests/modules/collaborations/resources/test_collaboration_patch.py
+++ b/tests/modules/collaborations/resources/test_collaboration_patch.py
@@ -4,135 +4,135 @@ import tests.modules.collaborations.resources.utils as collab_utils
 from tests import utils
 
 
-def test_patch_collaboration(flask_app_client, researcher_1, researcher_2, db):
+def test_patch_collaboration(flask_app_client, researcher_1, researcher_2, request):
 
-    collab = None
-    try:
-        create_resp = collab_utils.create_simple_collaboration(
-            flask_app_client, researcher_1, researcher_2
-        )
-        collab_guid = create_resp.json['guid']
+    create_resp = collab_utils.create_simple_collaboration(
+        flask_app_client, researcher_1, researcher_2
+    )
+    collab_guid = create_resp.json['guid']
+    collab = collab_utils.get_collab_object_for_user(researcher_1, collab_guid)
+    request.addfinalizer(collab.delete)
 
-        # should not work
-        patch_data = [utils.patch_replace_op('view_permission', 'ambivalence')]
-        resp = 'unable to set /view_permission to ambivalence'
-        collab_utils.patch_collaboration(
-            flask_app_client, collab_guid, researcher_2, patch_data, 400, resp
-        )
+    # should not work
+    patch_data = [utils.patch_replace_op('view_permission', 'ambivalence')]
+    resp = 'unable to set /view_permission to ambivalence'
+    collab_utils.patch_collaboration(
+        flask_app_client, collab_guid, researcher_2, patch_data, 400, resp
+    )
 
-        # Should work
-        collab_utils.approve_view_on_collaboration(
-            flask_app_client, collab_guid, researcher_2, researcher_1
-        )
+    # Should work
+    collab_utils.approve_view_on_collaboration(
+        flask_app_client, collab_guid, researcher_2, researcher_1
+    )
 
-        # Researcher 1 requests that this is escalated to an edit collaboration
-        collab_utils.request_edit_simple_collaboration(
-            flask_app_client, researcher_1, researcher_2
-        )
+    # Researcher 1 requests that this is escalated to an edit collaboration
+    collab_utils.request_edit_simple_collaboration(
+        flask_app_client, collab_guid, researcher_1, researcher_2
+    )
 
-        # TBD approve it, then revoke it, then revoke view
-        patch_data = [utils.patch_replace_op('edit_permission', 'revoked')]
-        collab_utils.patch_collaboration(
-            flask_app_client,
-            collab_guid,
-            researcher_1,
-            patch_data,
-        )
-        assert collab.user_has_read_access(researcher_1.guid)
-        assert collab.user_has_read_access(researcher_2.guid)
-        assert not collab.user_has_edit_access(researcher_1.guid)
-        assert not collab.user_has_edit_access(researcher_2.guid)
+    # which is approved
+    collab_utils.approve_edit_on_collaboration(
+        flask_app_client, collab_guid, researcher_2, researcher_1
+    )
 
-        patch_data = [utils.patch_replace_op('view_permission', 'revoked')]
-        collab_utils.patch_collaboration(
-            flask_app_client,
-            collab_guid,
-            researcher_1,
-            patch_data,
-        )
-        assert not collab.user_has_read_access(researcher_1.guid)
-        assert not collab.user_has_read_access(researcher_2.guid)
-        assert not collab.user_has_edit_access(researcher_1.guid)
-        assert not collab.user_has_edit_access(researcher_2.guid)
-    finally:
-        if collab:
-            collab.delete()
+    # remove edit only
+    collab_utils.revoke_edit_on_collaboration(
+        flask_app_client, collab_guid, researcher_1, researcher_2
+    )
+
+    # remove all permissions
+    collab_utils.revoke_view_on_collaboration(
+        flask_app_client, collab_guid, researcher_1, researcher_2, was_edit=True
+    )
+
+
+# As for above but validate that revoking view also revokes edit
+def test_view_revoke(flask_app_client, researcher_1, researcher_2, request):
+    create_resp = collab_utils.create_simple_collaboration(
+        flask_app_client, researcher_1, researcher_2
+    )
+    collab_guid = create_resp.json['guid']
+    collab = collab_utils.get_collab_object_for_user(researcher_1, collab_guid)
+    request.addfinalizer(collab.delete)
+
+    collab_utils.approve_view_on_collaboration(
+        flask_app_client, collab_guid, researcher_2, researcher_1
+    )
+
+    # Researcher 1 requests that this is escalated to an edit collaboration
+    collab_utils.request_edit_simple_collaboration(
+        flask_app_client, collab_guid, researcher_1, researcher_2
+    )
+
+    # which is approved
+    collab_utils.approve_edit_on_collaboration(
+        flask_app_client, collab_guid, researcher_2, researcher_1
+    )
+
+    # remove all permissions
+    collab_utils.revoke_view_on_collaboration(
+        flask_app_client, collab_guid, researcher_1, researcher_2, was_edit=True
+    )
 
 
 # Tests the approved and not approved state transitions for the collaboration.
 # Only on the view as the edit uses exactly the same function
-def test_patch_collaboration_states(flask_app_client, researcher_1, researcher_2, db):
-    from app.modules.collaborations.models import Collaboration
+def test_patch_collaboration_states(
+    flask_app_client, researcher_1, researcher_2, db, request
+):
 
-    collab = None
-    try:
-        # TBD refactor w new utils
-        data = {'user_guid': str(researcher_2.guid)}
-        collab_utils.create_collaboration(flask_app_client, researcher_1, data)
-        collabs = Collaboration.query.all()
-        collab = collabs[0]
-        collab_guid = collab.guid
-        assert not collab.user_has_read_access(researcher_1.guid)
-        assert not collab.user_has_read_access(researcher_2.guid)
+    create_resp = collab_utils.create_simple_collaboration(
+        flask_app_client, researcher_1, researcher_2
+    )
+    collab_guid = create_resp.json['guid']
+    collab = collab_utils.get_collab_object_for_user(researcher_1, collab_guid)
+    request.addfinalizer(collab.delete)
 
-        # should not work
-        patch_data = [utils.patch_replace_op('view_permission', 'creator')]
-        resp = 'unable to set /view_permission to creator'
-        collab_utils.patch_collaboration(
-            flask_app_client, collab_guid, researcher_2, patch_data, 400, resp
-        )
+    # should not work
+    patch_data = [utils.patch_replace_op('view_permission', 'creator')]
+    resp = 'unable to set /view_permission to creator'
+    collab_utils.patch_collaboration(
+        flask_app_client, collab_guid, researcher_2, patch_data, 400, resp
+    )
+    collab_utils.validate_no_access(collab_guid, researcher_1, researcher_2)
 
-        # should not
-        patch_data = [utils.patch_replace_op('view_permission', 'ambivalence')]
-        resp = 'unable to set /view_permission to ambivalence'
-        collab_utils.patch_collaboration(
-            flask_app_client, collab_guid, researcher_2, patch_data, 400, resp
-        )
-        patch_data = [utils.patch_replace_op('view_permission', 'approved')]
-        collab_utils.patch_collaboration(
-            flask_app_client,
-            collab_guid,
-            researcher_2,
-            patch_data,
-        )
+    # also should not
+    patch_data = [utils.patch_replace_op('view_permission', 'ambivalence')]
+    resp = 'unable to set /view_permission to ambivalence'
+    collab_utils.patch_collaboration(
+        flask_app_client, collab_guid, researcher_2, patch_data, 400, resp
+    )
+    collab_utils.validate_no_access(collab_guid, researcher_1, researcher_2)
 
-        patch_data = [utils.patch_replace_op('view_permission', 'pending')]
-        resp = 'unable to set /view_permission to pending'
-        collab_utils.patch_collaboration(
-            flask_app_client, collab_guid, researcher_2, patch_data, 400, resp
-        )
-        assert collab.user_has_read_access(researcher_1.guid)
-        assert collab.user_has_read_access(researcher_2.guid)
+    collab_utils.approve_view_on_collaboration(
+        flask_app_client, collab_guid, researcher_2, researcher_1
+    )
 
-        patch_data = [utils.patch_replace_op('view_permission', 'declined')]
-        resp = 'unable to set /view_permission to declined'
-        collab_utils.patch_collaboration(
-            flask_app_client, collab_guid, researcher_2, patch_data, 400, resp
-        )
-        patch_data = [utils.patch_replace_op('view_permission', 'revoked')]
-        collab_utils.patch_collaboration(
-            flask_app_client,
-            collab_guid,
-            researcher_2,
-            patch_data,
-        )
-        assert not collab.user_has_read_access(researcher_1.guid)
-        assert not collab.user_has_read_access(researcher_2.guid)
+    patch_data = [utils.patch_replace_op('view_permission', 'pending')]
+    resp = 'unable to set /view_permission to pending'
+    collab_utils.patch_collaboration(
+        flask_app_client, collab_guid, researcher_2, patch_data, 400, resp
+    )
+    collab_utils.validate_read_only(collab_guid, researcher_1, researcher_2)
 
-        patch_data = [utils.patch_replace_op('view_permission', 'not_initiated')]
-        resp = 'unable to set /view_permission to not_initiated'
-        collab_utils.patch_collaboration(
-            flask_app_client, collab_guid, researcher_2, patch_data, 400, resp
-        )
-        patch_data = [utils.patch_replace_op('view_permission', 'approved')]
-        collab_utils.patch_collaboration(
-            flask_app_client,
-            collab_guid,
-            researcher_2,
-            patch_data,
-        )
-        assert collab.user_has_read_access(researcher_1.guid)
-        assert collab.user_has_read_access(researcher_2.guid)
-    finally:
-        if collab:
-            collab.delete()
+    patch_data = [utils.patch_replace_op('view_permission', 'declined')]
+    resp = 'unable to set /view_permission to declined'
+    collab_utils.patch_collaboration(
+        flask_app_client, collab_guid, researcher_2, patch_data, 400, resp
+    )
+    collab_utils.validate_read_only(collab_guid, researcher_1, researcher_2)
+
+    collab_utils.revoke_view_on_collaboration(
+        flask_app_client, collab_guid, researcher_2, researcher_1
+    )
+
+    patch_data = [utils.patch_replace_op('view_permission', 'not_initiated')]
+    resp = 'unable to set /view_permission to not_initiated'
+    collab_utils.patch_collaboration(
+        flask_app_client, collab_guid, researcher_2, patch_data, 400, resp
+    )
+    collab_utils.validate_no_access(collab_guid, researcher_1, researcher_2)
+
+    collab_utils.approve_view_on_collaboration(
+        flask_app_client, collab_guid, researcher_2, researcher_1
+    )

--- a/tests/modules/collaborations/resources/utils.py
+++ b/tests/modules/collaborations/resources/utils.py
@@ -122,6 +122,8 @@ def validate_expected_states(json_data, expected_states):
     members = json_data.get('members')
     users = json_data.get('user_guids', {})
     assert members
+    assert len(members) == len(expected_states)
+    assert len(members) == len(users)
     for expected_user_guid in expected_states.keys():
         assert str(expected_user_guid) in users
         for expected_state in expected_states[expected_user_guid].keys():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -260,7 +260,13 @@ def get_dict_via_flask(
 
 
 def get_list_via_flask(
-    flask_app_client, user, scopes, path, expected_status_code, expected_error=None
+    flask_app_client,
+    user,
+    scopes,
+    path,
+    expected_status_code,
+    expected_error=None,
+    expected_fields=None,
 ):
     if user:
         with flask_app_client.login(user, auth_scopes=(scopes,)):
@@ -268,7 +274,11 @@ def get_list_via_flask(
     else:
         response = flask_app_client.get(path)
     if expected_status_code == 200:
-        validate_list_response(response, 200)
+        if expected_fields:
+            validate_list_of_dictionaries_response(
+                response, expected_status_code, expected_fields
+            )
+            validate_list_response(response, 200)
     elif expected_status_code == 404:
         validate_dict_response(response, expected_status_code, {'message'})
     elif expected_status_code:


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Significantly refactored the collaborations and notification test code to enhance the utils, reduct duplication and increase testing 
- Fixed bug in collaborations where the state transitions were not being validated in all places
- Creator is no longer passed back as a member of the collabration. 
- Fixed bug in notifications so that you can now only have one outstanding unread collaboration or collaboration edit request to a user

---


