### PR TITLE
365 more ags fields and defaults

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -291,9 +291,16 @@ class AssetGroupSighting(db.Model, HoustonModel):
         # calculation generates a floating point value, reporting that would be claiming precision without accuracy
         return round(completion)
 
-    # returns a None-safe getter for a given config field
-    def config_field_getter(field_name):
-        return lambda self: self.config and self.config.get(field_name)
+    # returns a getter for a given config field, allowing for casting and default vals
+    @staticmethod
+    def config_field_getter(field_name, default=None, cast=None):
+        def getter(self):
+            value = self.config and self.config.get(field_name)
+            if cast is not None and value:
+                value = cast(value)
+            return value or default
+
+        return getter
 
     @classmethod
     def check_jobs(cls):

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -6,7 +6,6 @@ Serialization schemas for Asset_groups resources RESTful API
 
 from flask_marshmallow import base_fields
 from flask_restx_patched import ModelSchema
-from marshmallow import post_dump
 
 from .models import AssetGroup, AssetGroupSighting
 
@@ -14,11 +13,15 @@ from .models import AssetGroup, AssetGroupSighting
 # Sighting endpoints to standardize frontend interactions. For that reason we need
 # to know which sighting fields to expect in an AssetGroupSighting.config dict
 SIGHTING_FIELDS_IN_AGS_CONFIG = {
+    'startTime',
     'decimalLatitude',
     'decimalLongitude',
     'encounters',
     'locationId',
-    'startTime',
+    'verbatimLocality',
+    'encounterCounts',
+    'id',
+    'featuredAssetGuid',
 }
 
 
@@ -71,32 +74,34 @@ class AssetGroupSightingAsSightingSchema(BaseAssetGroupSightingSchema):
 
     # Note: these config_field_getter vars should conform to SIGHTING_FIELDS_IN_AGS_CONFIG
     # at the top of this file
-    decimalLatitude = base_fields.Function(
-        AssetGroupSighting.config_field_getter('decimalLatitude')
-    )
-    decimalLongitude = base_fields.Function(
-        AssetGroupSighting.config_field_getter('decimalLongitude')
-    )
-    locationId = base_fields.Function(
-        AssetGroupSighting.config_field_getter('locationId')
-    )
     startTime = base_fields.Function(AssetGroupSighting.config_field_getter('startTime'))
     encounters = base_fields.Function(
-        AssetGroupSighting.config_field_getter('encounters')
+        AssetGroupSighting.config_field_getter('encounters', default=[])
+    )
+    decimalLatitude = base_fields.Function(
+        AssetGroupSighting.config_field_getter('decimalLatitude', cast=float)
+    )
+    decimalLongitude = base_fields.Function(
+        AssetGroupSighting.config_field_getter('decimalLongitude', cast=float)
+    )
+    locationId = base_fields.Function(
+        AssetGroupSighting.config_field_getter('locationId', default='')
+    )
+    verbatimLocality = base_fields.Function(
+        AssetGroupSighting.config_field_getter('verbatimLocality', default='')
+    )
+    id = base_fields.Function(AssetGroupSighting.config_field_getter('id', cast=int))
+    encounterCounts = base_fields.Function(
+        AssetGroupSighting.config_field_getter('encounterCounts', default={})
+    )
+    featured_asset_guid = base_fields.Function(
+        AssetGroupSighting.config_field_getter('featuredAssetGuid')
     )
 
     class Meta:
         # adds 'stage' to the fields already defined above
         additional = ('stage',)
         dump_only = BaseAssetGroupSightingSchema.Meta.dump_only
-
-    # Ensures we don't return fields with None values
-    @post_dump
-    def remove_none_fields(self, data):
-        for field in SIGHTING_FIELDS_IN_AGS_CONFIG:
-            if data[field] is None:
-                del data[field]
-        return data
 
 
 class BaseAssetGroupSchema(ModelSchema):

--- a/tests/modules/asset_groups/test_models.py
+++ b/tests/modules/asset_groups/test_models.py
@@ -184,3 +184,36 @@ def test_asset_group_sighting_get_completion(
 
     asset_group_sighting.stage = AssetGroupSightingStage.failed
     assert asset_group_sighting.get_completion() == 100
+
+
+def test_asset_group_sighting_config_field_getter(researcher_1, request):
+    from app.modules.asset_groups.models import AssetGroupSighting, AssetGroup
+
+    asset_group = AssetGroup(owner=researcher_1)
+    request.addfinalizer(asset_group.delete)
+    ags = AssetGroupSighting(asset_group=asset_group)
+    request.addfinalizer(ags.delete)
+
+    config_field_getter = AssetGroupSighting.config_field_getter
+
+    ags.config = None
+    assert config_field_getter('name')(ags) is None
+    assert config_field_getter('name', default='value')(ags) == 'value'
+    assert config_field_getter('name', default=1, cast=int)(ags) == 1
+    assert config_field_getter('name', cast=int)(ags) is None
+
+    ags.config = {'id': '10', 'decimalLatitude': None}
+    assert config_field_getter('id')(ags) == '10'
+    assert config_field_getter('id', default=1)(ags) == '10'
+    assert config_field_getter('id', default=1, cast=int)(ags) == 10
+    assert config_field_getter('id', cast=int)(ags) == 10
+
+    assert config_field_getter('decimalLatitude')(ags) is None
+    assert config_field_getter('decimalLatitude', default=1.0)(ags) == 1.0
+    assert config_field_getter('decimalLatitude', default=1.0, cast=float)(ags) == 1.0
+    assert config_field_getter('decimalLatitude', cast=float)(ags) is None
+
+    assert config_field_getter('name')(ags) is None
+    assert config_field_getter('name', default='value')(ags) == 'value'
+    assert config_field_getter('name', default=1, cast=int)(ags) == 1
+    assert config_field_getter('name', cast=int)(ags) is None


### PR DESCRIPTION
A few changes to the AGS-as-sighting as requested by Ben. Adds default values and typing to the config-dict fields on an AGS. The docker-compose test is currently failing (not sure why) hence draft PR

