### PR TITLE
DEX-501: Co-Occurrence methods and API

### DIFF
--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -357,6 +357,12 @@ class FeatherModel(GhostModel, TimestampViewed):
         rule = ObjectActionRule(obj=self, action=AccessOperation.WRITE)
         return rule.check()
 
+    @classmethod
+    def get_multiple(cls, guids):
+        if not guids or not isinstance(guids, list) or len(guids) < 1:
+            return []
+        return cls.query.filter(cls.guid.in_(guids)).all()
+
 
 class HoustonModel(FeatherModel):
     """

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -77,6 +77,71 @@ class Individual(db.Model, FeatherModel):
                 rt_val = self.encounters[0].annotations[0].asset_guid
         return rt_val
 
+    # returns Individuals
+    def get_cooccurring_individuals(self):
+        return Individual.get_multiple(self.get_cooccurring_individual_guids())
+
+    # returns guids
+    def get_cooccurring_individual_guids(self):
+        return Individual.get_cooccurring_individual_guids_for_individual_guid(self.guid)
+
+    # arbitrary individual_guid
+    @classmethod
+    def get_cooccurring_individual_guids_for_individual_guid(cls, individual_guid):
+        from app.modules.sightings.models import Sighting
+        from app.modules.encounters.models import Encounter
+        from sqlalchemy.orm import aliased
+
+        enc1 = aliased(Encounter, name='enc1')
+        enc2 = aliased(Encounter, name='enc2')
+        res = (
+            db.session.query(enc1.individual_guid)
+            .join(Sighting)
+            .join(enc2)
+            .filter(enc2.individual_guid == individual_guid)
+            .filter(enc1.individual_guid != individual_guid)
+            .group_by(enc1.individual_guid)
+        )
+        return [row.individual_guid for row in res]
+
+    # returns Sightings
+    def get_shared_sightings(self, individual_guids):
+        from app.modules.sightings.models import Sighting
+
+        return Sighting.get_multiple(self.get_shared_sighting_guids(individual_guids))
+
+    # returns guids
+    def get_shared_sighting_guids(self, individual_guids):
+        if (
+            not individual_guids
+            or not isinstance(individual_guids, list)
+            or len(individual_guids) < 1
+        ):
+            raise ValueError('must be passed a list of at least 1 individual guid')
+        individual_guids.append(self.guid)
+        return Individual.get_shared_sighting_guids_for_individual_guids(individual_guids)
+
+    @classmethod
+    def get_shared_sighting_guids_for_individual_guids(self, individual_guids):
+        if (
+            not individual_guids
+            or not isinstance(individual_guids, list)
+            or len(individual_guids) < 2
+        ):
+            raise ValueError('must be passed a list of at least 2 individual guids')
+        from app.modules.sightings.models import Sighting
+        from app.modules.encounters.models import Encounter
+        from sqlalchemy.orm import aliased
+
+        alias = []
+        res = db.session.query(Sighting.guid)
+        for i in range(len(individual_guids)):
+            alias[i] = aliased(Encounter, name=f'enc{i}')
+            res = res.join(alias[i])
+        for i in range(len(individual_guids)):
+            res = res.filter(alias[i].individual_guid == individual_guids[i])
+        return [row.guid for row in res]
+
     def set_featured_asset_guid(self, asset_guid):
         if self._ensure_asset_individual_association(asset_guid):
             self.featured_asset_guid = asset_guid

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -136,7 +136,7 @@ class Individual(db.Model, FeatherModel):
         alias = []
         res = db.session.query(Sighting.guid)
         for i in range(len(individual_guids)):
-            alias[i] = aliased(Encounter, name=f'enc{i}')
+            alias.append(aliased(Encounter, name=f'enc{i}'))
             res = res.join(alias[i])
         for i in range(len(individual_guids)):
             res = res.filter(alias[i].individual_guid == individual_guids[i])

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -331,3 +331,28 @@ class IndividualByID(Resource):
             )
 
         return None
+
+
+@api.route('/<uuid:individual_guid>/cooccurrence')
+@api.response(
+    code=HTTPStatus.NOT_FOUND,
+    description='Individual not found.',
+)
+@api.resolve_object_by_model(Individual, 'individual')
+@api.response(schemas.BaseIndividualSchema(many=True))
+class IndividualByIDCoOccurence(Resource):
+    """
+    List co-occurring individuals
+    """
+
+    @api.permission_required(
+        permissions.ObjectAccessPermission,
+        kwargs_on_request=lambda kwargs: {
+            'obj': kwargs['individual'],
+            'action': AccessOperation.READ,
+        },
+    )
+    def get(self, individual):
+        if individual is not None:
+            others = individual.get_cooccurring_individuals()
+            return others

--- a/tests/modules/individuals/test_cooccurrence.py
+++ b/tests/modules/individuals/test_cooccurrence.py
@@ -5,7 +5,7 @@ from app.modules.users.models import User
 import tests.utils as test_utils
 
 
-def test_cooccurrence(db):
+def test_cooccurrence(db, flask_app_client, researcher_1):
     from app.modules.sightings.models import Sighting, SightingStage
     from app.modules.individuals.models import Individual
 
@@ -40,6 +40,15 @@ def test_cooccurrence(db):
 
     pals = individual_1.get_cooccurring_individuals()
     assert pals == [individual_2, individual_3]
+
+    # since its all set up, lets test api as well
+    with flask_app_client.login(researcher_1, auth_scopes=('individuals:read',)):
+        response = flask_app_client.get(
+            f'/api/v1/individuals/{str(individual_1.guid)}/cooccurrence'
+        )
+    assert len(response.json) == 2
+    assert response.json[0]['guid'] == str(individual_2.guid)
+    assert response.json[1]['guid'] == str(individual_3.guid)
 
     # tests indiv.get_shared_sightings(list_individual_guids)
     individual_4 = Individual()

--- a/tests/modules/individuals/test_cooccurrence.py
+++ b/tests/modules/individuals/test_cooccurrence.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,missing-docstring
+
+from app.modules.users.models import User
+import tests.utils as test_utils
+
+
+def test_cooccurrence(db):
+    from app.modules.sightings.models import Sighting, SightingStage
+    from app.modules.individuals.models import Individual
+
+    sighting = Sighting(stage=SightingStage.processed)
+    owner = User.get_public_user()
+
+    encounter_a = test_utils.generate_owned_encounter(owner)
+    individual_1 = Individual()
+    individual_1.add_encounter(encounter_a)
+    sighting.add_encounter(encounter_a)
+
+    encounter_b = test_utils.generate_owned_encounter(owner)
+    individual_2 = Individual()
+    individual_2.add_encounter(encounter_b)
+    sighting.add_encounter(encounter_b)
+
+    encounter_c = test_utils.generate_owned_encounter(owner)
+    individual_3 = Individual()
+    individual_3.add_encounter(encounter_c)
+    sighting.add_encounter(encounter_c)
+
+    assert len(sighting.get_encounters()) == 3
+
+    with db.session.begin():
+        db.session.add(sighting)
+        db.session.add(encounter_a)
+        db.session.add(encounter_b)
+        db.session.add(encounter_c)
+        db.session.add(individual_1)
+        db.session.add(individual_2)
+        db.session.add(individual_3)
+
+    pals = individual_1.get_cooccurring_individuals()
+    assert pals == [individual_2, individual_3]
+
+    # tests indiv.get_shared_sightings(list_individual_guids)
+    individual_4 = Individual()
+    sighting_two = Sighting(stage=SightingStage.processed)
+    encounter_d = test_utils.generate_owned_encounter(owner)
+    individual_1.add_encounter(encounter_d)
+    encounter_e = test_utils.generate_owned_encounter(owner)
+    individual_2.add_encounter(encounter_e)
+    encounter_f = test_utils.generate_owned_encounter(owner)
+    individual_4.add_encounter(encounter_f)
+    sighting_two.add_encounter(encounter_d)
+    sighting_two.add_encounter(encounter_e)
+    sighting_two.add_encounter(encounter_f)
+
+    with db.session.begin():
+        db.session.add(individual_4)
+        db.session.add(sighting_two)
+        db.session.add(encounter_d)
+        db.session.add(encounter_e)
+
+    with_2 = individual_1.get_shared_sightings([individual_2.guid])
+    assert with_2 == [sighting, sighting_two]
+    with_3 = individual_1.get_shared_sightings([individual_3.guid])
+    assert with_3 == [sighting]
+    empty = individual_4.get_shared_sightings([individual_3.guid])
+    assert len(empty) == 0
+    with_2_3 = individual_1.get_shared_sightings([individual_2.guid, individual_3.guid])
+    assert with_2_3 == [sighting]
+
+    db.session.delete(individual_1)
+    db.session.delete(individual_2)
+    db.session.delete(individual_3)
+    db.session.delete(individual_4)
+    db.session.delete(encounter_a)
+    db.session.delete(encounter_b)
+    db.session.delete(encounter_c)
+    db.session.delete(encounter_d)
+    db.session.delete(encounter_e)
+    db.session.delete(encounter_f)
+    db.session.delete(sighting)
+    db.session.delete(sighting_two)

--- a/tests/modules/individuals/test_cooccurrence.py
+++ b/tests/modules/individuals/test_cooccurrence.py
@@ -70,13 +70,13 @@ def test_cooccurrence(db, flask_app_client, researcher_1):
         db.session.add(encounter_d)
         db.session.add(encounter_e)
 
-    with_2 = individual_1.get_shared_sightings([individual_2.guid])
+    with_2 = individual_1.get_shared_sightings(individual_2)
     assert set(with_2) == set([sighting, sighting_two])
-    with_3 = individual_1.get_shared_sightings([individual_3.guid])
+    with_3 = individual_1.get_shared_sightings(individual_3)
     assert with_3 == [sighting]
-    empty = individual_4.get_shared_sightings([individual_3.guid])
+    empty = individual_4.get_shared_sightings(individual_3)
     assert len(empty) == 0
-    with_2_3 = individual_1.get_shared_sightings([individual_2.guid, individual_3.guid])
+    with_2_3 = individual_1.get_shared_sightings(individual_2, individual_3)
     assert with_2_3 == [sighting]
 
     db.session.delete(individual_1)

--- a/tests/modules/individuals/test_cooccurrence.py
+++ b/tests/modules/individuals/test_cooccurrence.py
@@ -39,7 +39,7 @@ def test_cooccurrence(db, flask_app_client, researcher_1):
         db.session.add(individual_3)
 
     pals = individual_1.get_cooccurring_individuals()
-    assert pals == [individual_2, individual_3]
+    assert set(pals) == set([individual_2, individual_3])
 
     # since its all set up, lets test api as well
     with flask_app_client.login(researcher_1, auth_scopes=('individuals:read',)):
@@ -47,8 +47,9 @@ def test_cooccurrence(db, flask_app_client, researcher_1):
             f'/api/v1/individuals/{str(individual_1.guid)}/cooccurrence'
         )
     assert len(response.json) == 2
-    assert response.json[0]['guid'] == str(individual_2.guid)
-    assert response.json[1]['guid'] == str(individual_3.guid)
+    assert set([response.json[0]['guid'], response.json[1]['guid']]) == set(
+        [str(individual_2.guid), str(individual_3.guid)]
+    )
 
     # tests indiv.get_shared_sightings(list_individual_guids)
     individual_4 = Individual()
@@ -70,7 +71,7 @@ def test_cooccurrence(db, flask_app_client, researcher_1):
         db.session.add(encounter_e)
 
     with_2 = individual_1.get_shared_sightings([individual_2.guid])
-    assert with_2 == [sighting, sighting_two]
+    assert set(with_2) == set([sighting, sighting_two])
     with_3 = individual_1.get_shared_sightings([individual_3.guid])
     assert with_3 == [sighting]
     empty = individual_4.get_shared_sightings([individual_3.guid])


### PR DESCRIPTION

## Pull Request Overview

- Adds API and methods for listing _Individuals_ who co-occur with a specified _Individual_
- `indiv.get_cooccurring_individuals()` (and some helper variations on same) returns list of _Individuals_
- `GET /api/v1/individuals/GUID/cooccurrence` does same, via API

### Additional methods
- Added `indiv.get_shared_sightings([indiv1, indiv2, ...])` (and helper variations) which returns _Sightings_ common to all _Individuals_, as I stumbled on the join statement to find this.  **No API made for this.**