### PR TITLE
Make names the same in GET and PATCH notification preferences

### DIFF
--- a/app/modules/notifications/schemas.py
+++ b/app/modules/notifications/schemas.py
@@ -8,18 +8,23 @@ from flask_restx_patched import ModelSchema
 from flask_marshmallow import base_fields
 
 from app.extensions import ExtraValidationSchema
-from .models import Notification
+from .models import Notification, NotificationType, NotificationChannel
+
+
+class NotificationChannelSchema(ExtraValidationSchema):
+    def __new__(cls, *args, **kwargs):
+        for notification_channel in NotificationChannel.__members__.values():
+            cls._declared_fields[notification_channel] = base_fields.Bool()
+        return super().__new__(cls)
 
 
 class NotificationPreferenceSchema(ExtraValidationSchema):
-    class NotificationChannelSchema(ExtraValidationSchema):
-        restAPI = base_fields.Bool()
-        email = base_fields.Bool()
-
-    all = base_fields.Nested(NotificationChannelSchema)
-    raw = base_fields.Nested(NotificationChannelSchema)
-    collaboration_request = base_fields.Nested(NotificationChannelSchema)
-    merge_request = base_fields.Nested(NotificationChannelSchema)
+    def __new__(cls, *args, **kwargs):
+        for notification_type in NotificationType.__members__.values():
+            cls._declared_fields[notification_type] = base_fields.Nested(
+                NotificationChannelSchema
+            )
+        return super().__new__(cls)
 
 
 class BaseNotificationSchema(ModelSchema):

--- a/integration_tests/test_notifications.py
+++ b/integration_tests/test_notifications.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+import uuid
+
+
+def test_notification_preferences(session, login, logout, codex_url):
+    # Create new user
+    login(session)
+    new_email = f'{uuid.uuid4()}@localhost'
+    new_user = {
+        'email': new_email,
+        'password': 'password',
+        'full_name': 'My name',
+    }
+    response = session.post(
+        codex_url('/api/v1/users/'),
+        json=new_user,
+    )
+    user_guid = response.json()['guid']
+    logout(session)
+
+    login(session, email=new_email)
+    response = session.get(codex_url('/api/v1/users/me'))
+    assert response.status_code == 200
+    assert response.json()['notification_preferences'] == {
+        'all': {'restAPI': True, 'email': False},
+        'raw': {'restAPI': True, 'email': True},
+        'collaboration_request': {'restAPI': True, 'email': False},
+        'collaboration_edit_request': {'restAPI': True, 'email': False},
+        'individual_merge_request': {'restAPI': True, 'email': False},
+    }
+    user_guid = response.json()['guid']
+
+    response = session.patch(
+        codex_url(f'/api/v1/users/{user_guid}'),
+        json=[
+            {
+                'op': 'replace',
+                'path': '/notification_preferences',
+                'value': {
+                    'collaboration_request': {'restAPI': True, 'email': True},
+                },
+            },
+            {
+                'op': 'replace',
+                'path': '/notification_preferences',
+                'value': {
+                    'individual_merge_request': {'restAPI': False, 'email': False},
+                },
+            },
+        ],
+    )
+    assert response.status_code == 200
+    assert response.json()['notification_preferences'] == {
+        'all': {
+            'restAPI': True,
+            'email': False,
+        },
+        'raw': {
+            'restAPI': True,
+            'email': True,
+        },
+        'collaboration_request': {
+            'restAPI': True,
+            'email': False,
+        },
+        'collaboration_edit_request': {
+            'restAPI': True,
+            'email': False,
+        },
+        'individual_merge_request': {
+            'restAPI': False,
+            'email': False,
+        },
+    }

--- a/tests/modules/notifications/test_models.py
+++ b/tests/modules/notifications/test_models.py
@@ -88,7 +88,11 @@ def test_notification_message(db, researcher_1, researcher_2, flask_app):
 
 
 def test_validate_preferences():
-    from app.modules.notifications.models import NotificationPreferences
+    from app.modules.notifications.models import (
+        NotificationPreferences,
+        NotificationType,
+        NotificationChannel,
+    )
 
     with pytest.raises(HoustonException) as exc:
         NotificationPreferences.validate_preferences([])
@@ -96,15 +100,19 @@ def test_validate_preferences():
 
     with pytest.raises(HoustonException) as exc:
         NotificationPreferences.validate_preferences({'random': 'value'})
+
+    valid_options = sorted([i.value for i in NotificationType.__members__.values()])
     assert (
         str(exc.value)
-        == 'Unknown field(s): random, options are all, collaboration_request, merge_request, raw.'
+        == f'Unknown field(s): random, options are {", ".join(valid_options)}.'
     )
 
     with pytest.raises(HoustonException) as exc:
         NotificationPreferences.validate_preferences({'all': {'random': True}})
+    valid_channels = sorted([i.value for i in NotificationChannel.__members__.values()])
     assert (
-        str(exc.value) == '"all": Unknown field(s): random, options are email, restAPI.'
+        str(exc.value)
+        == f'"all": Unknown field(s): random, options are {", ".join(valid_channels)}.'
     )
 
     with pytest.raises(HoustonException) as exc:
@@ -117,7 +125,7 @@ def test_validate_preferences():
         )
     assert (
         str(exc.value)
-        == '"all.restAPI": Not a valid boolean. Unknown field(s): random, options are all, collaboration_request, merge_request, raw.'
+        == f'"all.restAPI": Not a valid boolean. Unknown field(s): random, options are {", ".join(valid_options)}.'
     )
 
     # Valid examples


### PR DESCRIPTION
Dynamically generate notification preference schema for PATCH

There was a difference in the names used in GET notification preferences
and PATCH.  Change the code to generate notification preference schema
for PATCH using the enums defined in models.py

