### PR TITLE
Change log.error to log.exception so traceback is shown

### DIFF
--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -251,7 +251,7 @@ class EDMObjectMixin(object):
                 model_obj._sync_item(model_obj.guid, version)
                 updated_items.append(model_obj)
             except sqlalchemy.exc.IntegrityError:
-                log.error(f'Error updating {cls.EDM_NAME} {model_obj}')
+                log.exception(f'Error updating {cls.EDM_NAME} {model_obj}')
 
                 failed_items.append(model_obj)
 

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -995,7 +995,7 @@ class AssetGroup(db.Model, HoustonModel):
                     transaction_id=metadata.tus_transaction_id, paths=metadata.files
                 )
             except Exception:
-                log.error(
+                log.exception(
                     'create_from_tus() had problems with import_tus_files(); deleting from db and fs %r'
                     % asset_group
                 )
@@ -1033,7 +1033,7 @@ class AssetGroup(db.Model, HoustonModel):
                 transaction_id=transaction_id, paths=paths
             )
         except Exception:
-            log.error(
+            log.exception(
                 'create_from_tus() had problems with import_tus_files(); deleting from db and fs %r'
                 % asset_group
             )
@@ -1505,12 +1505,12 @@ class AssetGroup(db.Model, HoustonModel):
         try:
             return current_app.git_backend.get_project(str(guid))
         except (GitlabInitializationError, requests.exceptions.RequestException):
-            log.error(f'Error when calling AssetGroup.get_remote({guid})')
+            log.exception(f'Error when calling AssetGroup.get_remote({guid})')
 
     @classmethod
     def is_on_remote(cls, guid):
         try:
             return current_app.git_backend.is_project_on_remote(str(guid))
         except (GitlabInitializationError, requests.exceptions.RequestException):
-            log.error(f'Error when calling AssetGroup.is_on_remote({guid})')
+            log.exception(f'Error when calling AssetGroup.is_on_remote({guid})')
             return False

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -104,7 +104,7 @@ def _validate_asset_references(asset_references):
             try:
                 sz = os.path.getsize(file_path)  # 2for1
             except OSError as err:
-                log.error(
+                log.exception(
                     'Sighting.post OSError %r assetReferences data: %r / %r'
                     % (err, tid, path)
                 )

--- a/tasks/codex/consistency.py
+++ b/tasks/codex/consistency.py
@@ -168,7 +168,7 @@ def all(context, skip_on_failure=False):
         user_staff_permissions(context)
     except AssertionError as exception:
         if not skip_on_failure:
-            log.error('%s', exception)
+            log.exception('Consistency checks failed.')
         else:
             log.debug(
                 'The following error was ignored due to the `skip_on_failure` flag: %s',

--- a/tasks/codex/initialize.py
+++ b/tasks/codex/initialize.py
@@ -52,7 +52,7 @@ def all(context, edm_authentication=None, skip_on_failure=False):
         initialize_orgs_from_edm(context, edm_authentication=edm_authentication)
     except AssertionError as exception:
         if not skip_on_failure:
-            log.error('%s', exception)
+            log.exception('Initialize tasks failed.')
         else:
             log.debug(
                 'The following error was ignored due to the `skip_on_failure` flag: %s',

--- a/tasks/mws/consistency.py
+++ b/tasks/mws/consistency.py
@@ -19,7 +19,7 @@ def all(context, skip_on_failure=False):
         pass
     except AssertionError as exception:
         if not skip_on_failure:
-            log.error('%s', exception)
+            log.exception('Consistency checks failed.')
         else:
             log.debug(
                 'The following error was ignored due to the `skip_on_failure` flag: %s',

--- a/tasks/mws/initialize.py
+++ b/tasks/mws/initialize.py
@@ -20,7 +20,7 @@ def all(context, edm_authentication=None, skip_on_failure=False):
         pass
     except AssertionError as exception:
         if not skip_on_failure:
-            log.error('%s', exception)
+            log.exception('Initialize tasks failed.')
         else:
             log.debug(
                 'The following error was ignored due to the `skip_on_failure` flag: %s',


### PR DESCRIPTION
The difference between `log.error` and `log.exception` is that traceback
is not shown so it's harder to debug:

```
2021-09-07 09:47:32,976 [ERROR] [app.modules.asset_groups.models] create_from_tus() had problems with import_tus_files(); deleting from db and fs <AssetGroup(guid=c2ddfc7f-9738-4624-837c-fa111eb37ba0, )>
2021-09-07 09:47:32,990 [AUDIT] [app.extensions.logging] 400 Bad Request: The browser (or proxy) sent a request that this server could not understand. executed by user :1fe85998-1a3e-492c-bf0c-10a62e6e4e52 root@example.org
```

vs

```
2021-09-07 10:05:50,285 [ERROR] [app.modules.asset_groups.models] create_from_tus() had problems with import_tus_files(); deleting from db and fs <AssetGroup(guid=ecb3450e-80cc-44e3-9205-f5c352004d7f, )>
Traceback (most recent call last):
  File "/code/app/modules/asset_groups/models.py", line 887, in create_from_metadata
    added = asset_group.import_tus_files(
  File "/code/app/modules/asset_groups/models.py", line 957, in import_tus_files
    os.rename(path, os.path.join(asset_group_path, name))
PermissionError: [Errno 13] Permission denied: '/data/var/uploads/trans-9a2185f9-5bf5-487e-a19c-0a4baed43b1e/zebra.jpg' -> '/data/var/asset_group/ecb3450e-80cc-44e3-9205-f5c352004d7f/_asset_group/zebra.jpg'
2021-09-07 10:05:50,483 [AUDIT] [app.extensions.logging] 400 Bad Request: The browser (or proxy) sent a request that this server could not understand. executed by user :1fe85998-1a3e-492c-bf0c-10a62e6e4e52 root@example.org
```

