### PR TITLE
DEX-515 Change social-groups PATCH to only use /members

### DIFF
--- a/app/modules/social_groups/resources.py
+++ b/app/modules/social_groups/resources.py
@@ -5,7 +5,9 @@ RESTful API Social Groups resources
 --------------------------
 """
 
+import json
 import logging
+import uuid
 
 from flask import request
 from flask_restx_patched import Resource
@@ -20,7 +22,6 @@ import app.extensions.logging as AuditLog
 
 from . import parameters, schemas
 from .models import SocialGroup
-import json
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace(
@@ -39,6 +40,13 @@ def validate_members(input_data):
 
     current_roles = {}
     for member_guid, data in input_data.items():
+        try:
+            uuid.UUID(member_guid)
+        except (AttributeError, ValueError):
+            # AttributeError for int, ValueError for string
+            raise HoustonException(
+                log, f'Social Group member {member_guid} needs to be a valid uuid'
+            )
         individual = Individual.query.get(member_guid)
         if not individual:
             raise HoustonException(

--- a/integration_tests/test_social_groups.py
+++ b/integration_tests/test_social_groups.py
@@ -124,8 +124,8 @@ def test_social_groups(session, login, codex_url):
     data = [
         {
             'op': 'remove',
-            'path': '/member',
-            'value': individual_ids[1],
+            'path': '/members',
+            'value': [individual_ids[1]],
         },
     ]
     response = session.patch(
@@ -148,10 +148,9 @@ def test_social_groups(session, login, codex_url):
     data = [
         {
             'op': 'add',
-            'path': '/member',
+            'path': '/members',
             'value': {
-                'guid': individual_ids[1],
-                'roles': None,
+                individual_ids[1]: {'roles': None},
             },
         },
     ]

--- a/integration_tests/test_social_groups.py
+++ b/integration_tests/test_social_groups.py
@@ -1,0 +1,200 @@
+# -*- coding: utf-8 -*-
+def test_social_groups(session, login, codex_url):
+    # Create social group roles
+    login(session)
+    data = {
+        'key': 'social_group_roles',
+        'data': {
+            'Matriarch': {'multipleInGroup': False},
+            'Patriarch': {'multipleInGroup': True},
+        },
+    }
+    response = session.post(codex_url('/api/v1/site-settings/'), json=data)
+    assert response.status_code == 200
+    assert response.json() == {
+        'key': 'social_group_roles',
+        'data': {
+            'Matriarch': {'multipleInGroup': False},
+            'Patriarch': {'multipleInGroup': True},
+        },
+        'created': response.json()['created'],  # 2021-10-29T20:17:46.585288+00:00
+        'string': response.json()['string'],  # '' or None
+        'file_upload_guid': None,
+        'public': True,
+        'updated': response.json()['updated'],
+    }
+
+    # Create encounters
+    data = {
+        'locationId': 'PYTEST-SIGHTING',
+        'startTime': '2000-01-01T01:01:01Z',
+        'encounters': [
+            {'locationId': 'PYTEST-ENCOUNTER-0'},
+            {'locationId': 'PYTEST-ENCOUNTER-1'},
+            {'locationId': 'PYTEST-ENCOUNTER-2'},
+        ],
+    }
+    response = session.post(codex_url('/api/v1/sightings/'), json=data)
+    assert response.status_code == 200
+    result = response.json()['result']
+    encounter_ids = [e['id'] for e in result['encounters']]
+    encounter_versions = [e['version'] for e in result['encounters']]
+    assert response.json() == {
+        'success': True,
+        'result': {
+            'id': result['id'],  # 7934b1db-6d5f-405a-9502-88f754fa9179
+            'version': result['version'],  # 1635538733340,
+            'encounters': [
+                {
+                    # 06292cf1-1168-43ac-b6a0-40972afb9af3
+                    'id': encounter_ids[0],
+                    'version': encounter_versions[0],  # 1635538733339
+                },
+                {
+                    'id': encounter_ids[1],
+                    'version': encounter_versions[1],
+                },
+                {
+                    'id': encounter_ids[2],
+                    'version': encounter_versions[2],
+                },
+            ],
+            'assets': {},
+        },
+    }
+
+    # Create individuals
+    responses = []
+    for i in range(3):
+        data = {'encounters': [{'id': encounter_ids[i]}]}
+        responses.append(session.post(codex_url('/api/v1/individuals/'), json=data))
+        assert responses[-1].status_code == 200
+    result = responses[0].json()['result']
+    individual_ids = [r.json()['result']['id'] for r in responses]
+    assert responses[0].json() == {
+        'success': True,
+        'result': {
+            'id': individual_ids[0],  # 7934b1db-6d5f-405a-9502-88f754fa9179
+            'version': None,
+            'encounters': [
+                {
+                    'id': encounter_ids[0],
+                    'version': encounter_versions[0],
+                }
+            ],
+        },
+    }
+
+    # Create social group
+    data = {
+        'name': 'Family',
+        'members': {
+            individual_ids[0]: {'roles': ['Matriarch']},
+            individual_ids[1]: {},
+            individual_ids[2]: {'roles': ['Patriarch']},
+        },
+    }
+    response = session.post(codex_url('/api/v1/social-groups/'), json=data)
+    assert response.status_code == 200
+    social_group = response.json()
+    social_group_id = social_group['guid']
+    assert response.json() == {
+        'created': social_group['created'],
+        'updated': social_group['updated'],
+        'name': 'Family',
+        'members': {
+            individual_ids[0]: {'roles': ['Matriarch']},
+            individual_ids[1]: {'roles': None},
+            individual_ids[2]: {'roles': ['Patriarch']},
+        },
+        'guid': social_group_id,
+    }
+
+    # GET social group
+    response = session.get(codex_url(f'/api/v1/social-groups/{social_group_id}'))
+    assert response.status_code == 200
+    assert response.json() == social_group
+
+    response = session.get(codex_url('/api/v1/social-groups/'))
+    assert response.status_code == 200
+    assert len(response.json()) >= 1
+    assert {'name': 'Family', 'guid': social_group_id} in response.json()
+
+    # PATCH social group: remove member
+    data = [
+        {
+            'op': 'remove',
+            'path': '/member',
+            'value': individual_ids[1],
+        },
+    ]
+    response = session.patch(
+        codex_url(f'/api/v1/social-groups/{social_group_id}'),
+        json=data,
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        'created': social_group['created'],
+        'updated': social_group['updated'],
+        'name': 'Family',
+        'members': {
+            individual_ids[0]: {'roles': ['Matriarch']},
+            individual_ids[2]: {'roles': ['Patriarch']},
+        },
+        'guid': social_group_id,
+    }
+
+    # PATCH social group: add member
+    data = [
+        {
+            'op': 'add',
+            'path': '/member',
+            'value': {
+                'guid': individual_ids[1],
+                'roles': None,
+            },
+        },
+    ]
+    response = session.patch(
+        codex_url(f'/api/v1/social-groups/{social_group_id}'),
+        json=data,
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        'created': social_group['created'],
+        'updated': social_group['updated'],
+        'name': 'Family',
+        'members': {
+            individual_ids[0]: {'roles': ['Matriarch']},
+            individual_ids[1]: {'roles': None},
+            individual_ids[2]: {'roles': ['Patriarch']},
+        },
+        'guid': social_group_id,
+    }
+
+    # PATCH social group: replace members
+    data = [
+        {
+            'op': 'replace',
+            'path': '/members',
+            'value': {
+                individual_ids[0]: {'roles': ['Matriarch']},
+                individual_ids[1]: {'roles': None},
+            },
+        },
+    ]
+    response = session.patch(
+        codex_url(f'/api/v1/social-groups/{social_group_id}'),
+        json=data,
+    )
+    assert response.status_code == 200
+    assert response.json() == {
+        'created': social_group['created'],
+        'updated': social_group['updated'],
+        'name': 'Family',
+        'members': {
+            individual_ids[0]: {'roles': ['Matriarch']},
+            individual_ids[1]: {'roles': None},
+        },
+        'guid': social_group_id,
+    }

--- a/tests/modules/social_groups/resources/test_social_group.py
+++ b/tests/modules/social_groups/resources/test_social_group.py
@@ -345,7 +345,7 @@ def test_patch(
     # can't patch in member as regular_user
     patch_add_matriarch = [
         test_utils.patch_add_op(
-            'member', {'guid': individuals[2]['id'], 'roles': ['Matriarch']}
+            'members', {individuals[2]['id']: {'roles': ['Matriarch']}}
         )
     ]
     soc_group_utils.patch_social_group(
@@ -358,7 +358,7 @@ def test_patch(
     )
 
     # remove the existing matriarch, any researcher can do that
-    patch_remove_matriarch = [test_utils.patch_remove_op('member', individuals[1]['id'])]
+    patch_remove_matriarch = [test_utils.patch_remove_op('members', individuals[1]['id'])]
     soc_group_utils.patch_social_group(
         flask_app_client, researcher_2, group_guid, patch_remove_matriarch
     )
@@ -382,8 +382,8 @@ def test_patch(
 
     patch_make_irritating = [
         test_utils.patch_replace_op(
-            'member',
-            {'guid': individuals[2]['id'], 'roles': ['Matriarch', 'IrritatingGit']},
+            'members',
+            {individuals[2]['id']: {'roles': ['Matriarch', 'IrritatingGit']}},
         )
     ]
     soc_group_utils.patch_social_group(

--- a/tests/modules/social_groups/resources/test_social_group.py
+++ b/tests/modules/social_groups/resources/test_social_group.py
@@ -357,6 +357,23 @@ def test_patch(
         flask_app_client, researcher_1, group_guid, patch_add_matriarch, 400, error
     )
 
+    # Patch with a non-uuid individual guid
+    patch_add_error = [
+        test_utils.patch_add_op(
+            'members',
+            {'4037': {'roles': ['Matriarch']}},
+        ),
+    ]
+    invalid_uuid_error = 'Social Group member 4037 needs to be a valid uuid'
+    soc_group_utils.patch_social_group(
+        flask_app_client,
+        researcher_2,
+        group_guid,
+        patch_add_error,
+        400,
+        invalid_uuid_error,
+    )
+
     # remove the existing matriarch, any researcher can do that
     patch_remove_matriarch = [test_utils.patch_remove_op('members', individuals[1]['id'])]
     soc_group_utils.patch_social_group(


### PR DESCRIPTION
- Add social group integration test


- Change social-groups PATCH to only use /members

  Remove `/member` PATCH path and instead use `/members` to be consistent.
  When op is "add", the members are added (or replaced if they already
  existed).  When the op is "removed", the member or list of members are
  removed.  When the op is "replaced", the members are set to exactly what
  the user provides.

- Fix error when social group member is not valid uuid

  ```
  E               sqlalchemy.exc.StatementError: (builtins.ValueError) badly formed hexadecimal UUID string
  E               [SQL: SELECT individual.created AS individual_created, individual.updated AS individual_updated, individual.viewed AS individual_viewed, individual.guid AS individual_guid, individual.featured_asset_guid AS individual_featured_asset_guid, individual.version AS individual_version
  E               FROM individual
  E               WHERE individual.guid = %(param_1)s]
  E               [parameters: [{'%(140645722029696 param)s': '4037'}]]
  ```
