### PR TITLE
DEX 518 Individual delete didn't delete social groups

### DIFF
--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -166,6 +166,8 @@ class Individual(db.Model, FeatherModel):
     def delete(self):
         AuditLog.delete_object(log, self)
         with db.session.begin():
+            for group in self.social_groups:
+                db.session.delete(group)
             db.session.delete(self)
 
     def delete_from_edm(self):

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -323,6 +323,7 @@ class IndividualByID(Resource):
         Delete an Individual by ID.
         """
         response = individual.delete_from_edm()
+        response_data = None
         if response.ok:
             response_data = response.json()
         if not response.ok or not response_data.get('success', False):


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Delete of individual now deletes it's social groups, this was an omission in the original social group work
- Found and fixed (but could not replicate) an individuals bug where if the delete failed in edm, response_data was printed when unset

---


