### PR TITLE
DEX 519 Collaboration associations need writing to DB on creation

### DIFF
--- a/app/modules/collaborations/models.py
+++ b/app/modules/collaborations/models.py
@@ -112,6 +112,8 @@ class Collaboration(db.Model, HoustonModel):
             collab_user_assoc.initiator = user == initiator_user
             # Edit not enabled on creation
             collab_user_assoc.edit_approval_state = CollaborationUserState.NOT_INITIATED
+            with db.session.begin(subtransactions=True):
+                db.session.add(collab_user_assoc)
 
             # If you initiate, then you approve read. Manager created are also read approved
             if user == initiator_user or manager_created:
@@ -127,6 +129,8 @@ class Collaboration(db.Model, HoustonModel):
 
             collab_creator.read_approval_state = CollaborationUserState.CREATOR
             collab_creator.edit_approval_state = CollaborationUserState.CREATOR
+            with db.session.begin(subtransactions=True):
+                db.session.add(collab_creator)
 
     def _get_association_for_user(self, user_guid):
         assoc = None
@@ -258,6 +262,8 @@ class Collaboration(db.Model, HoustonModel):
                         ):
 
                             association.edit_approval_state = state
+                        with db.session.begin(subtransactions=True):
+                            db.session.merge(association)
                         success = True
         return success
 
@@ -300,6 +306,8 @@ class Collaboration(db.Model, HoustonModel):
                         association.edit_approval_state, state
                     ):
                         association.edit_approval_state = state
+                        with db.session.begin(subtransactions=True):
+                            db.session.merge(association)
                         success = True
         return success
 
@@ -315,10 +323,14 @@ class Collaboration(db.Model, HoustonModel):
                 my_assoc.read_approval_state, CollaborationUserState.APPROVED
             ):
                 my_assoc.edit_approval_state = CollaborationUserState.APPROVED
+                with db.session.begin(subtransactions=True):
+                    db.session.merge(my_assoc)
             if self._is_approval_state_transition_valid(
                 other_assoc.edit_approval_state, CollaborationUserState.PENDING
             ):
                 other_assoc.edit_approval_state = CollaborationUserState.PENDING
+                with db.session.begin(subtransactions=True):
+                    db.session.merge(other_assoc)
         else:
             raise HoustonException(
                 log, 'Unable to start edit on unapproved collaboration'

--- a/app/modules/collaborations/models.py
+++ b/app/modules/collaborations/models.py
@@ -109,7 +109,7 @@ class Collaboration(db.Model, HoustonModel):
             collab_user_assoc = CollaborationUserAssociations(
                 collaboration=self, user=user
             )
-            collab_user_assoc.initiator = user == initiator_user
+
             # Edit not enabled on creation
             collab_user_assoc.edit_approval_state = CollaborationUserState.NOT_INITIATED
             with db.session.begin(subtransactions=True):

--- a/tests/modules/collaborations/test_models.py
+++ b/tests/modules/collaborations/test_models.py
@@ -27,13 +27,13 @@ def test_collaboration_create_with_members(
     request.addfinalizer(basic_collab.delete)
 
     assert len(basic_collab.get_users()) == 2
+    assert basic_collab.initiator_guid == collab_user_a.guid
+
     for association in basic_collab.collaboration_user_associations:
         assert association.edit_approval_state == 'not_initiated'
         if association.user == collab_user_a:
-            assert association.initiator is True
             assert association.read_approval_state == 'approved'
         else:
-            assert association.initiator is False
             assert association.read_approval_state == 'pending'
 
     manager_collab = Collaboration(members, user_manager_user)


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Collaboration associations written to DB explicitly upon change
- Test updated to no longer validate a member that had been removed a long time ago

---

**Review Notes**
- If anyone can explain to me how that unit test was passing beforehand and how these changes made it fail (as it should have) I'll be really interested to know


