### PR TITLE
Add integration tests for approving, declining collaborations and fix collaborations created by user managers

### DIFF
--- a/app/modules/collaborations/models.py
+++ b/app/modules/collaborations/models.py
@@ -104,7 +104,7 @@ class Collaboration(db.Model, HoustonModel):
 
         for user in members:
             if not hasattr(user, 'is_user_manager'):
-                raise ValueError(f'User {user} is not a user')
+                raise ValueError(f'User {user} is not a user manager')
 
             collab_user_assoc = CollaborationUserAssociations(
                 collaboration=self, user=user

--- a/app/modules/collaborations/models.py
+++ b/app/modules/collaborations/models.py
@@ -245,7 +245,11 @@ class Collaboration(db.Model, HoustonModel):
 
     def set_read_approval_state_for_user(self, user_guid, state):
         success = False
-        if user_guid is not None and state in CollaborationUserState.ALLOWED_STATES:
+        if state not in CollaborationUserState.ALLOWED_STATES:
+            raise ValueError(
+                f'State "{state}" not in allowed states: {", ".join(CollaborationUserState.ALLOWED_STATES)}'
+            )
+        if user_guid is not None:
             assert isinstance(user_guid, uuid.UUID)
             for association in self.collaboration_user_associations:
                 if association.user_guid == user_guid:
@@ -298,7 +302,11 @@ class Collaboration(db.Model, HoustonModel):
 
     def set_edit_approval_state_for_user(self, user_guid, state):
         success = False
-        if user_guid is not None and state in CollaborationUserState.ALLOWED_STATES:
+        if state not in CollaborationUserState.ALLOWED_STATES:
+            raise ValueError(
+                f'State "{state}" not in allowed states: {", ".join(CollaborationUserState.ALLOWED_STATES)}'
+            )
+        if user_guid is not None:
             assert isinstance(user_guid, uuid.UUID)
             for association in self.collaboration_user_associations:
                 if association.user_guid == user_guid:

--- a/integration_tests/test_collaboration.py
+++ b/integration_tests/test_collaboration.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import uuid
 
+from .utils import create_new_user
+
 
 def test_collaboration(session, codex_url, login, admin_email):
     login(session)
@@ -11,13 +13,7 @@ def test_collaboration(session, codex_url, login, admin_email):
 
     # Create a new user
     new_email = f'{uuid.uuid4()}@localhost'
-    response = session.post(
-        codex_url('/api/v1/users/'),
-        json={'email': new_email, 'password': 'password'},
-    )
-    assert response.status_code == 200
-    assert response.json()['email'] == new_email
-    new_user_guid = response.json()['guid']
+    new_user_guid = create_new_user(session, codex_url, new_email)
 
     # Create a collaboration with the new user
     response = session.post(

--- a/integration_tests/test_collaboration.py
+++ b/integration_tests/test_collaboration.py
@@ -4,7 +4,7 @@ import uuid
 from .utils import create_new_user
 
 
-def test_collaboration(session, codex_url, login, admin_email):
+def test_collaboration(session, codex_url, login, logout, admin_email):
     login(session)
     response = session.get(codex_url('/api/v1/users/me'))
     assert response.status_code == 200
@@ -21,10 +21,58 @@ def test_collaboration(session, codex_url, login, admin_email):
         json={'user_guid': new_user_guid},
     )
     assert response.status_code == 200
+    assert sorted(response.json()['user_guids']) == sorted([new_user_guid, my_guid])
     assert set(response.json()['members'].keys()) == {new_user_guid, my_guid}
+    assert response.json()['members'][my_guid]['viewState'] == 'approved'
+    assert response.json()['members'][my_guid]['editState'] == 'not_initiated'
+    assert response.json()['members'][new_user_guid]['viewState'] == 'pending'
+    assert response.json()['members'][new_user_guid]['editState'] == 'not_initiated'
     collaboration_guid = response.json()['guid']
 
     # Check collaboration is in /users/me
     response = session.get(codex_url('/api/v1/users/me'))
     assert response.status_code == 200
     assert collaboration_guid in [c['guid'] for c in response.json()['collaborations']]
+    logout(session)
+
+    # Log in as new user and check collaboration request
+    login(session, new_email)
+    response = session.get(codex_url('/api/v1/users/me'))
+    assert response.status_code == 200
+    assert collaboration_guid in [c['guid'] for c in response.json()['collaborations']]
+    response = session.get(codex_url(f'/api/v1/collaborations/{collaboration_guid}'))
+    assert response.status_code == 200
+
+    # Approve collaboration
+    response = session.patch(
+        codex_url(f'/api/v1/collaborations/{collaboration_guid}'),
+        json=[{'op': 'replace', 'path': '/view_permission', 'value': 'approved'}],
+    )
+    assert response.status_code == 200
+    assert response.json()['members'][my_guid]['viewState'] == 'approved'
+    assert response.json()['members'][my_guid]['editState'] == 'not_initiated'
+    assert response.json()['members'][new_user_guid]['viewState'] == 'approved'
+    assert response.json()['members'][new_user_guid]['editState'] == 'not_initiated'
+
+    # Create edit request
+    response = session.post(
+        codex_url(f'/api/v1/collaborations/edit_request/{collaboration_guid}'),
+    )
+    assert response.status_code == 200
+    assert response.json()['members'][my_guid]['viewState'] == 'approved'
+    assert response.json()['members'][my_guid]['editState'] == 'pending'
+    assert response.json()['members'][new_user_guid]['viewState'] == 'approved'
+    assert response.json()['members'][new_user_guid]['editState'] == 'approved'
+    logout(session)
+
+    # Reject collaboration for edit
+    login(session)
+    response = session.patch(
+        codex_url(f'/api/v1/collaborations/{collaboration_guid}'),
+        json=[{'op': 'replace', 'path': '/edit_permission', 'value': 'declined'}],
+    )
+    assert response.status_code == 200
+    assert response.json()['members'][my_guid]['viewState'] == 'approved'
+    assert response.json()['members'][my_guid]['editState'] == 'declined'
+    assert response.json()['members'][new_user_guid]['viewState'] == 'approved'
+    assert response.json()['members'][new_user_guid]['editState'] == 'approved'

--- a/integration_tests/test_notifications.py
+++ b/integration_tests/test_notifications.py
@@ -1,21 +1,14 @@
 # -*- coding: utf-8 -*-
 import uuid
 
+from .utils import create_new_user
+
 
 def test_notification_preferences(session, login, logout, codex_url):
     # Create new user
     login(session)
     new_email = f'{uuid.uuid4()}@localhost'
-    new_user = {
-        'email': new_email,
-        'password': 'password',
-        'full_name': 'My name',
-    }
-    response = session.post(
-        codex_url('/api/v1/users/'),
-        json=new_user,
-    )
-    user_guid = response.json()['guid']
+    user_guid = create_new_user(session, codex_url, new_email, full_name='My name')
     logout(session)
 
     login(session, email=new_email)

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -38,3 +38,12 @@ def upload_to_tus(session, codex_url, file_path, transaction_id=None):
     )
     assert response.status_code == 204
     return transaction_id
+
+
+def create_new_user(session, codex_url, email, password='password', **kwargs):
+    data = {'email': email, 'password': password}
+    data.update(kwargs)
+    response = session.post(codex_url('/api/v1/users/'), json=data)
+    assert response.status_code == 200
+    assert response.json()['email'] == email
+    return response.json()['guid']

--- a/tests/modules/collaborations/resources/test_collaboration_patch.py
+++ b/tests/modules/collaborations/resources/test_collaboration_patch.py
@@ -21,9 +21,9 @@ def test_patch_collaboration(flask_app_client, researcher_1, researcher_2, reque
 
     # should not work
     patch_data = [utils.patch_replace_op('view_permission', 'ambivalence')]
-    resp = 'unable to set /view_permission to ambivalence'
+    resp = 'State "ambivalence" not in allowed states: declined, approved, pending, not_initiated, revoked, creator'
     collab_utils.patch_collaboration(
-        flask_app_client, collab_guid, researcher_2, patch_data, 400, resp
+        flask_app_client, collab_guid, researcher_2, patch_data, 409, resp
     )
 
     # Should work
@@ -110,9 +110,9 @@ def test_patch_collaboration_states(
 
     # also should not
     patch_data = [utils.patch_replace_op('view_permission', 'ambivalence')]
-    resp = 'unable to set /view_permission to ambivalence'
+    resp = 'State "ambivalence" not in allowed states: declined, approved, pending, not_initiated, revoked, creator'
     collab_utils.patch_collaboration(
-        flask_app_client, collab_guid, researcher_2, patch_data, 400, resp
+        flask_app_client, collab_guid, researcher_2, patch_data, 409, resp
     )
     collab_utils.validate_no_access(collab_guid, researcher_1, researcher_2)
 


### PR DESCRIPTION
- Add create_new_user to integration_tests/utils.py

  Change integration tests that create a new user to use this new util
  function.

- Add integration tests for approving, declining collaborations


- Add valid view/edit permissions when patching collaborations fail

  Change error 400:
  
  ```
  unable to set /view_permission to ambivalence
  ```
  
  to error 409:
  
  ```
  State "ambivalence" not in allowed states: declined, approved, pending, not_initiated, revoked, creator
  ```
  
  So it's easier for development.

- Fix collaborations created by user managers

  If a user manager creates a collaboration between user1 and user2 and
  the user manager already has a collaboration with user1, houston
  responds with
  "User <user-manager> attempted repeated collaboration with <user1>" and
  returns the collaboration between user manager and user1.
  
  The reason is because the code first checks whether there's a
  collaboration between logged in user and user1, even if the
  collaboration is for user1 and user2.


---

**Note:** This PR is created to check whether the additional database commits in #349 were necessary and it looks like they are not...?