### PR TITLE
remove double delete of encounter in tests

### DIFF
--- a/tests/modules/encounters/resources/test_modify_encounter.py
+++ b/tests/modules/encounters/resources/test_modify_encounter.py
@@ -141,7 +141,6 @@ def test_modify_encounter(
     assert enc.json['customFields'][cfd_id] == new_cfd_test_value
 
     new_encounter_1.sighting.delete_cascade()
-    new_encounter_1.delete()
 
 
 @pytest.mark.skipif(module_unavailable('encounters'), reason='Encounters module disabled')

--- a/tests/modules/individuals/resources/test_individual_featured_asset_guid.py
+++ b/tests/modules/individuals/resources/test_individual_featured_asset_guid.py
@@ -126,7 +126,6 @@ def test_patch_featured_asset_guid_on_individual(db, flask_app_client, researche
             flask_app_client, researcher_1, str(individual.guid)
         )
         sighting.delete_cascade()
-        enc.delete_cascade()
         ann_1.delete()
         ann_2.delete()
         delete_remote(str(new_asset_group.guid))


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- delete of encounter in tests after sightinig delete_cascade was resulting in a double delete causing a warning
- Now test runs are 100% green

---

