### PR TITLE
DEX-195 part 2

### DIFF
--- a/app/extensions/logging/__init__.py
+++ b/app/extensions/logging/__init__.py
@@ -28,7 +28,6 @@ class Logging(object):
         FrontEndFault = 'Front End Fault'  # Bad message received on API
         BackEndFault = 'Back End Fault'  # Faulty message received from ACM/EDM etc
         HoustonFault = 'Houston Fault'  # Internal Error within Houston
-        SecurityAlert = 'Security Alert'  # Maybe trouble
         Other = 'Other'  # None of the above
 
     def __init__(self, app=None):
@@ -130,15 +129,6 @@ class Logging(object):
             )
         else:
             cls.audit_log(logger, msg, cls.AuditType.HoustonFault, *args, **kwargs)
-
-    @classmethod
-    def security_alert(cls, logger, msg='', obj=None, *args, **kwargs):
-        if obj:
-            cls.audit_log_object(
-                logger, obj, msg, cls.AuditType.SecurityAlert, *args, **kwargs
-            )
-        else:
-            cls.audit_log(logger, msg, cls.AuditType.SecurityAlert, *args, **kwargs)
 
     @classmethod
     def delete_object(cls, logger, obj, msg='', *args, **kwargs):

--- a/app/extensions/logging/__init__.py
+++ b/app/extensions/logging/__init__.py
@@ -122,6 +122,15 @@ class Logging(object):
             cls.audit_log(logger, msg, cls.AuditType.BackEndFault, *args, **kwargs)
 
     @classmethod
+    def frontend_fault(cls, logger, msg='', obj=None, *args, **kwargs):
+        if obj:
+            cls.audit_log_object(
+                logger, obj, msg, cls.AuditType.FrontEndFault, *args, **kwargs
+            )
+        else:
+            cls.audit_log(logger, msg, cls.AuditType.FrontEndFault, *args, **kwargs)
+
+    @classmethod
     def houston_fault(cls, logger, msg='', obj=None, *args, **kwargs):
         if obj:
             cls.audit_log_object(

--- a/app/extensions/logging/__init__.py
+++ b/app/extensions/logging/__init__.py
@@ -28,6 +28,7 @@ class Logging(object):
         FrontEndFault = 'Front End Fault'  # Bad message received on API
         BackEndFault = 'Back End Fault'  # Faulty message received from ACM/EDM etc
         HoustonFault = 'Houston Fault'  # Internal Error within Houston
+        SecurityAlert = 'Security Alert'  # Maybe trouble
         Other = 'Other'  # None of the above
 
     def __init__(self, app=None):
@@ -129,6 +130,15 @@ class Logging(object):
             )
         else:
             cls.audit_log(logger, msg, cls.AuditType.HoustonFault, *args, **kwargs)
+
+    @classmethod
+    def security_alert(cls, logger, msg='', obj=None, *args, **kwargs):
+        if obj:
+            cls.audit_log_object(
+                logger, obj, msg, cls.AuditType.SecurityAlert, *args, **kwargs
+            )
+        else:
+            cls.audit_log(logger, msg, cls.AuditType.SecurityAlert, *args, **kwargs)
 
     @classmethod
     def delete_object(cls, logger, obj, msg='', *args, **kwargs):

--- a/app/modules/encounters/models.py
+++ b/app/modules/encounters/models.py
@@ -99,6 +99,8 @@ class Encounter(db.Model, FeatherModel):
             'guid={self.guid}, '
             'version={self.version}, '
             'owner={self.owner},'
+            'individual={self.individual_guid},'
+            'sighting={self.sighting_guid},'
             ')>'.format(class_name=self.__class__.__name__, self=self)
         )
 

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -70,9 +70,8 @@ class Individual(db.Model, FeatherModel):
 
     # this overrides the one defined in extensions
     def current_user_has_edit_permission(self):
-        if (
-            not self.encounters
-        ):  # we "should never have" an individual without encounters, but....
+        if not self.encounters:
+            # we "should never have" an individual without encounters, but....
             return False
         for enc in self.encounters:
             if enc.current_user_has_edit_permission():  # one is good enough
@@ -252,7 +251,13 @@ class Individual(db.Model, FeatherModel):
     #   and initiates a request including time-out etc
     @classmethod
     def merge_request(cls, *individuals, sex=None, primary_name=None):
-        log.warning('merge_request() NOT YET IMPLEMENTED')
+        if not individuals or not isinstance(individuals, tuple) or len(individuals) < 2:
+            raise ValueError('must be passed a tuple of at least 2 individuals')
+        target_individual = individuals[0]
+        source_individuals = individuals[1:]
+        log.warning(
+            f'merge_request() on {target_individual} from {source_individuals} -- NOT YET IMPLEMENTED'
+        )
         return False
 
     def merge_request_from(self, *individuals):

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -265,30 +265,29 @@ class Individual(db.Model, FeatherModel):
         return Individual.merge_request(*all_indiv)
 
     def _consolidate_social_groups(self, source_individual):
-        return
         if not source_individual.social_groups:
             return
         for source_member in source_individual.social_groups:
             socgrp = source_member.social_group
-            already_member = socgrp.get_member(self.guid)
+            already_member = socgrp.get_member(str(self.guid))
             # source_member = socgrp.get_member(source_individual.guid)
             log.warning(
                 f'*************  {self.guid}/{socgrp} => already=({already_member}) source=({source_member})'
             )
             data = {'roles': source_member.roles}  # roles may be empty, this is fine
             # must remove member first in case roles are singular
-            socgrp.remove_member(source_individual.guid)
+            #########socgrp.remove_member(str(source_individual.guid))
             if already_member:
                 if data.get('roles'):
                     for role in data['roles']:
                         if role not in already_member.roles:
-                            already_member.roles.add(role)
+                            already_member.roles.append(role)
                     # ensure gets in db
                     already_member.roles = already_member.roles
                     with db.session.begin(subtransactions=True):
                         db.session.merge(already_member)
             else:
-                socgrp.add_member(self.guid, data)
+                socgrp.add_member(str(self.guid), data)
             AuditLog.audit_log_object(
                 log,
                 self,

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -68,16 +68,6 @@ class Individual(db.Model, FeatherModel):
     def get_members(self):
         return [encounter.owner for encounter in self.encounters]
 
-    # this overrides the one defined in extensions
-    def current_user_has_edit_permission(self):
-        if not self.encounters:
-            # we "should never have" an individual without encounters, but....
-            return False
-        for enc in self.encounters:
-            if enc.current_user_has_edit_permission():  # one is good enough
-                return True
-        return False
-
     def get_featured_asset_guid(self):
         rt_val = None
         if self.featured_asset_guid is not None:

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -241,6 +241,13 @@ class Individual(db.Model, FeatherModel):
         )
         return False
 
+    def get_blocking_encounters(self):
+        blocking = []
+        for enc in self.encounters:
+            if not enc.current_user_has_edit_permission():
+                blocking.append(enc)
+        return blocking
+
     def _consolidate_social_groups(self, source_individual):
         if not source_individual.social_groups:
             return

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -270,13 +270,11 @@ class Individual(db.Model, FeatherModel):
         for source_member in source_individual.social_groups:
             socgrp = source_member.social_group
             already_member = socgrp.get_member(str(self.guid))
-            # source_member = socgrp.get_member(source_individual.guid)
-            log.warning(
-                f'*************  {self.guid}/{socgrp} => already=({already_member}) source=({source_member})'
-            )
             data = {'roles': source_member.roles}  # roles may be empty, this is fine
-            # must remove member first in case roles are singular
-            #########socgrp.remove_member(str(source_individual.guid))
+            # must blow away source_member roles in case one is singular (as it will get passed to target)
+            source_member.roles = None
+            with db.session.begin(subtransactions=True):
+                db.session.merge(source_member)
             if already_member:
                 if data.get('roles'):
                     for role in data['roles']:

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -260,14 +260,7 @@ class Individual(db.Model, FeatherModel):
             with db.session.begin(subtransactions=True):
                 db.session.merge(source_member)
             if already_member:
-                if data.get('roles'):
-                    for role in data['roles']:
-                        if role not in already_member.roles:
-                            already_member.roles.append(role)
-                    # ensure gets in db
-                    already_member.roles = already_member.roles
-                    with db.session.begin(subtransactions=True):
-                        db.session.merge(already_member)
+                socgrp.add_roles(str(self.guid), data.get('roles'))
             else:
                 socgrp.add_member(str(self.guid), data)
             AuditLog.audit_log_object(

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -68,6 +68,17 @@ class Individual(db.Model, FeatherModel):
     def get_members(self):
         return [encounter.owner for encounter in self.encounters]
 
+    # this overrides the one defined in extensions
+    def current_user_has_edit_permission(self):
+        if (
+            not self.encounters
+        ):  # we "should never have" an individual without encounters, but....
+            return False
+        for enc in self.encounters:
+            if enc.current_user_has_edit_permission():  # one is good enough
+                return True
+        return False
+
     def get_featured_asset_guid(self):
         rt_val = None
         if self.featured_asset_guid is not None:
@@ -236,6 +247,17 @@ class Individual(db.Model, FeatherModel):
     def merge_from(self, *individuals):
         all_indiv = (self,) + individuals
         return Individual.merge(*all_indiv)
+
+    # mimics Individual.merge() in args, but does not immediately executes; rather waits for approval
+    #   and initiates a request including time-out etc
+    @classmethod
+    def merge_request(cls, *individuals, sex=None, primary_name=None):
+        log.warning('merge_request() NOT YET IMPLEMENTED')
+        return False
+
+    def merge_request_from(self, *individuals):
+        all_indiv = (self,) + individuals
+        return Individual.merge_request(*all_indiv)
 
     def delete(self):
         AuditLog.delete_object(log, self)

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -435,7 +435,7 @@ class IndividualByIDMerge(Resource):
         blocking_encounters.extend(blocking)
 
         if not meets_minimum:
-            AuditLog.security_alert(
+            AuditLog.houston_fault(
                 log,
                 f'requested unauthorized merge from {from_individuals}',
                 individual,

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -422,17 +422,17 @@ class IndividualByIDMerge(Resource):
                     message=f'passed from individual id={from_id} is invalid',
                     code=500,
                 )
-            for enc in from_indiv.encounters:
-                if enc.current_user_has_edit_permission():
-                    meets_minimum = True
-                else:
-                    blocking_encounters.append(enc)
-            from_individuals.append(from_indiv)
-        for enc in individual.encounters:
-            if enc.current_user_has_edit_permission():
+            blocking = from_indiv.get_blocking_encounters()
+            if len(blocking) < len(from_indiv.encounters):
+                # means user has edit permission on *at least one* encounter
                 meets_minimum = True
-            else:
-                blocking_encounters.append(enc)
+            blocking_encounters.extend(blocking)
+            from_individuals.append(from_indiv)
+        # now do same for target (passed) individual
+        blocking = individual.get_blocking_encounters()
+        if len(blocking) < len(individual.encounters):
+            meets_minimum = True
+        blocking_encounters.extend(blocking)
 
         if not meets_minimum:
             AuditLog.security_alert(

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -435,7 +435,7 @@ class IndividualByIDMerge(Resource):
         blocking_encounters.extend(blocking)
 
         if not meets_minimum:
-            AuditLog.houston_fault(
+            AuditLog.frontend_fault(
                 log,
                 f'requested unauthorized merge from {from_individuals}',
                 individual,

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -430,11 +430,13 @@ class IndividualByIDMerge(Resource):
                 merge_request = individual.merge_request_from(*from_individuals)
             except Exception as ex:
                 abort(
+                    merge_request=True,
                     message=str(ex),
                     code=500,
                 )
             if not merge_request:
                 abort(
+                    merge_request=True,
                     message='Merge failed',
                     code=500,
                 )

--- a/app/modules/social_groups/models.py
+++ b/app/modules/social_groups/models.py
@@ -180,6 +180,20 @@ class SocialGroup(db.Model, HoustonModel):
         with db.session.begin(subtransactions=True):
             db.session.add(membership)
 
+    def add_roles(self, individual_guid, roles):
+        member = self.get_member(individual_guid)
+        if not member:
+            return
+        if not roles or not isinstance(roles, list):
+            return
+        for role in roles:
+            if role not in member.roles:
+                member.roles.append(role)
+        # ensure gets in db
+        member.roles = member.roles
+        with db.session.begin(subtransactions=True):
+            db.session.merge(member)
+
     def delete(self):
         AuditLog.delete_object(log, self)
 

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -80,12 +80,13 @@ OBJECT_USER_MAP = {
     ('SocialGroup', AccessOperation.DELETE): ['is_researcher'],
 }
 
-# Map of methods (that are passed he current user as a param) on the object.
+# Map of methods (that are passed the current user as a param) on the object.
 # These permissions also granted by collaboration/project/etc so must not be privileged/admin
 OBJECT_USER_METHOD_MAP = {
     ('Sighting', AccessOperation.READ): ['user_is_owner'],
     ('Sighting', AccessOperation.WRITE): ['user_owns_all_encounters'],
     ('Sighting', AccessOperation.DELETE): ['user_can_edit_all_encounters'],
+    ('Individual', AccessOperation.WRITE): ['current_user_has_edit_permission'],
     ('Asset', AccessOperation.READ_PRIVILEGED): ['user_raw_read'],
     ('Asset', AccessOperation.WRITE): ['user_is_owner'],
     ('Annotation', AccessOperation.READ): ['user_is_owner'],

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -86,7 +86,6 @@ OBJECT_USER_METHOD_MAP = {
     ('Sighting', AccessOperation.READ): ['user_is_owner'],
     ('Sighting', AccessOperation.WRITE): ['user_owns_all_encounters'],
     ('Sighting', AccessOperation.DELETE): ['user_can_edit_all_encounters'],
-    ('Individual', AccessOperation.WRITE): ['current_user_has_edit_permission'],
     ('Asset', AccessOperation.READ_PRIVILEGED): ['user_raw_read'],
     ('Asset', AccessOperation.WRITE): ['user_is_owner'],
     ('Annotation', AccessOperation.READ): ['user_is_owner'],

--- a/tests/modules/individuals/resources/test_merge.py
+++ b/tests/modules/individuals/resources/test_merge.py
@@ -3,10 +3,10 @@
 
 from tests.modules.individuals.resources import utils as individual_utils
 from tests.modules.sightings.resources import utils as sighting_utils
+from app.modules.individuals.models import Individual
 import pytest
 import json
-
-from tests.utils import module_unavailable
+from tests import utils as test_utils
 
 increment = 0
 
@@ -49,11 +49,10 @@ def prep_data(db, flask_app_client, user, individual_sex='female'):
 
 
 @pytest.mark.skipif(
-    module_unavailable('individuals', 'encounters', 'sightings'),
+    test_utils.module_unavailable('individuals', 'encounters', 'sightings'),
     reason='Individuals module disabled',
 )
 def test_merge_basics(db, flask_app_client, researcher_1):
-
     individual1_id = None
     sighting1 = None
     encounter1 = None
@@ -67,13 +66,15 @@ def test_merge_basics(db, flask_app_client, researcher_1):
         individual2_id = str(encounter2.individual_guid)
 
         data_in = {}  # first try with bunk data
-        with flask_app_client.login(researcher_1, auth_scopes=('individuals:write',)):
-            response = flask_app_client.post(
-                f'/api/v1/individuals/{individual1_id}/merge',
-                data=json.dumps(data_in),
-                content_type='application/json',
-            )
-        assert response.status_code == 500
+        response = test_utils.post_via_flask(
+            flask_app_client,
+            researcher_1,
+            scopes=('individuals:write',),
+            path=f'/api/v1/individuals/{individual1_id}/merge',
+            data=data_in,
+            expected_status_code=500,
+            response_200={'success'},
+        )
         assert (
             'message' in response.json
             and 'list of individuals' in response.json['message']
@@ -82,13 +83,15 @@ def test_merge_basics(db, flask_app_client, researcher_1):
         # send an invalid guid
         bad_id = '00000000-0000-0000-0000-000000002170'
         data_in = [bad_id]
-        with flask_app_client.login(researcher_1, auth_scopes=('individuals:write',)):
-            response = flask_app_client.post(
-                f'/api/v1/individuals/{individual1_id}/merge',
-                data=json.dumps(data_in),
-                content_type='application/json',
-            )
-        assert response.status_code == 500
+        response = test_utils.post_via_flask(
+            flask_app_client,
+            researcher_1,
+            scopes=('individuals:write',),
+            path=f'/api/v1/individuals/{individual1_id}/merge',
+            data=data_in,
+            expected_status_code=500,
+            response_200={'success'},
+        )
         assert (
             'message' in response.json
             and f'{bad_id} is invalid' in response.json['message']
@@ -100,27 +103,97 @@ def test_merge_basics(db, flask_app_client, researcher_1):
         }
         # data_in = [individual2_id]  # would also be valid
         # note: this tests positive permission case as well (user owns everything)
-        with flask_app_client.login(researcher_1, auth_scopes=('individuals:write',)):
-            response = flask_app_client.post(
-                f'/api/v1/individuals/{individual1_id}/merge',
-                data=json.dumps(data_in),
-                content_type='application/json',
-            )
-        assert response.status_code == 200
-        assert False
+        response = test_utils.post_via_flask(
+            flask_app_client,
+            researcher_1,
+            scopes=('individuals:write',),
+            path=f'/api/v1/individuals/{individual1_id}/merge',
+            data=data_in,
+            expected_status_code=200,
+            response_200={'merged'},
+        )
+        individual2 = Individual.query.get(individual2_id)
+        assert not individual2
 
     finally:
         individual_utils.delete_individual(flask_app_client, researcher_1, individual1_id)
-        individual_utils.delete_individual(flask_app_client, researcher_1, individual2_id)
+        # individual2 is gone now due to successful merge!
         sighting1.delete_cascade()
         sighting2.delete_cascade()
 
 
 @pytest.mark.skipif(
-    module_unavailable('individuals', 'encounters', 'sightings'),
+    test_utils.module_unavailable('individuals', 'encounters', 'sightings'),
     reason='Individuals module disabled',
 )
-def test_merge_permissions(db, flask_app_client, researcher_1, researcher_2):
+def test_merge_permissions(
+    db, flask_app_client, researcher_1, researcher_2, contributor_1
+):
+    individual1_id = None
+    sighting1 = None
+    encounter1 = None
+    individual2_id = None
+    sighting2 = None
+    encounter2 = None
+    try:
+        sighting1, encounter1 = prep_data(db, flask_app_client, researcher_1)
+        individual1_id = str(encounter1.individual_guid)
+        sighting2, encounter2 = prep_data(db, flask_app_client, researcher_2)
+        individual2_id = str(encounter2.individual_guid)
+
+        # this tests as researcher_2, which should trigger a merge-request (owns just 1 encounter)
+        # NOTE: merge_request not yet implmented, so fails accordingly (code 500)
+        data_in = [individual2_id]
+        response = test_utils.post_via_flask(
+            flask_app_client,
+            researcher_2,
+            scopes=('individuals:write',),
+            path=f'/api/v1/individuals/{individual1_id}/merge',
+            data=data_in,
+            expected_status_code=500,
+            response_200={'merged'},
+        )
+        assert response.json['merge_request']
+        assert response.json['message'] == 'Merge failed'
+        assert response.json['blocking_encounters'] == [str(encounter1.guid)]
+
+        # a user who owns none (403 fail, no go)
+        response = test_utils.post_via_flask(
+            flask_app_client,
+            contributor_1,
+            scopes=('individuals:write',),
+            path=f'/api/v1/individuals/{individual1_id}/merge',
+            data=data_in,
+            expected_status_code=403,
+            response_200={'merged'},
+        )
+
+        # anonymous (401)
+        response = test_utils.post_via_flask(
+            flask_app_client,
+            None,
+            scopes=('individuals:write',),
+            path=f'/api/v1/individuals/{individual1_id}/merge',
+            data=data_in,
+            expected_status_code=401,
+            response_200={'merged'},
+        )
+
+    finally:
+        individual_utils.delete_individual(flask_app_client, researcher_1, individual1_id)
+        individual_utils.delete_individual(flask_app_client, researcher_2, individual2_id)
+        sighting1.delete_cascade()
+        sighting2.delete_cascade()
+
+
+@pytest.mark.skipif(
+    test_utils.module_unavailable(
+        'individuals', 'encounters', 'sightings', 'social_groups'
+    ),
+    reason='Individuals module disabled',
+)
+def test_merge_social_groups(db, flask_app_client, researcher_1):
+    from app.modules.social_groups.models import SocialGroup
 
     individual1_id = None
     sighting1 = None
@@ -134,42 +207,62 @@ def test_merge_permissions(db, flask_app_client, researcher_1, researcher_2):
         sighting2, encounter2 = prep_data(db, flask_app_client, researcher_1)
         individual2_id = str(encounter2.individual_guid)
 
-        # this tests as researcher_2, which should trigger a merge-request
-        # NOTE: merge_request not yet implmented, so fails accordingly
+        individual1 = Individual.query.get(individual1_id)
+        individual2 = Individual.query.get(individual2_id)
+
+        # this tests target individual is not in social group
+        groupA_name = 'groupA'
+        groupA_role_from_2 = 'doomed-to-be-merged'
+        members = {individual2_id: {'roles': [groupA_role_from_2]}}
+        social_groupA = SocialGroup(members, groupA_name)
+        with db.session.begin(subtransactions=True):
+            db.session.add(social_groupA)
+
+        # this tests target is in group, but gains new role
+        groupB_name = 'groupB'
+        groupB_role_from_1 = 'roleB1'
+        groupB_role_from_2 = 'roleB2'
+        members = {
+            individual1_id: {'roles': [groupB_role_from_1]},
+            individual2_id: {'roles': [groupB_role_from_2]},
+        }
+        social_groupB = SocialGroup(members, groupB_name)
+        db.session.add(social_groupB)
+
+        # this tests target is in group, but shares a role (and will gain a new one)
+        groupC_name = 'groupC'
+        groupC_shared_role = 'sharedC'
+        groupC_role_from_2 = 'roleC2'
+        members = {
+            individual1_id: {'roles': [groupC_shared_role]},
+            individual2_id: {'roles': [groupC_shared_role, groupC_role_from_2]},
+        }
+        social_groupC = SocialGroup(members, groupC_name)
+        db.session.add(social_groupC)
+
+        db.session.merge(individual1)
+        db.session.merge(individual2)
+        import utool as ut
+
+        ut.embed()
+
+        # now do the merge
         data_in = [individual2_id]
-        with flask_app_client.login(researcher_2, auth_scopes=('individuals:write',)):
+        with flask_app_client.login(researcher_1, auth_scopes=('individuals:write',)):
             response = flask_app_client.post(
                 f'/api/v1/individuals/{individual1_id}/merge',
                 data=json.dumps(data_in),
                 content_type='application/json',
             )
-        assert response.status_code == 500
-        assert response.json['merge_request']
-        assert response.json['message'] == 'Merge failed'
-        assert set(response.json['blocking_encounters']) == set(
-            [str(encounter1.guid), str(encounter2.guid)]
-        )
+        assert response.status_code == 200
 
-        # permission where user owns just one encounter
-        sighting3, encounter3 = prep_data(db, flask_app_client, researcher_2)
-        individual3_id = str(encounter3.individual_guid)
+        import utool as ut
 
-        data_in = [individual3_id]
-        with flask_app_client.login(researcher_2, auth_scopes=('individuals:write',)):
-            response = flask_app_client.post(
-                f'/api/v1/individuals/{individual1_id}/merge',
-                data=json.dumps(data_in),
-                content_type='application/json',
-            )
-        assert response.status_code == 500
-        assert response.json['merge_request']
-        assert response.json['message'] == 'Merge failed'
-        assert response.json['blocking_encounters'] == [str(encounter1.guid)]
+        ut.embed()
+        assert False
 
     finally:
         individual_utils.delete_individual(flask_app_client, researcher_1, individual1_id)
         individual_utils.delete_individual(flask_app_client, researcher_1, individual2_id)
-        individual_utils.delete_individual(flask_app_client, researcher_2, individual3_id)
         sighting1.delete_cascade()
         sighting2.delete_cascade()
-        sighting3.delete_cascade()

--- a/tests/modules/individuals/resources/test_merge.py
+++ b/tests/modules/individuals/resources/test_merge.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-docstring
+
+from tests.modules.individuals.resources import utils as individual_utils
+from tests.modules.sightings.resources import utils as sighting_utils
+import pytest
+import json
+
+from tests.utils import module_unavailable
+
+
+@pytest.mark.skipif(
+    module_unavailable('individuals', 'encounters', 'sightings'),
+    reason='Individuals module disabled',
+)
+def test_merge(db, flask_app_client, researcher_1):
+
+    from app.modules.encounters.models import Encounter
+    from app.modules.sightings.models import Sighting
+
+    sighting_data_in = {
+        'encounters': [
+            {
+                'decimalLatitude': 45.999,
+                'decimalLongitude': 45.999,
+                'verbatimLocality': 'Town Square',
+                'locationId': 'Legoland',
+            }
+        ],
+        'startTime': '2000-01-01T01:01:01Z',
+        'locationId': 'test',
+    }
+    individual_data_in = {
+        'names': {'defaultName': 'Godzilla'},
+        'sex': 'female',
+        'comments': 'Test Individual',
+        'timeOfBirth': '872846040000',
+    }
+
+    try:
+
+        res_sighting, res_individual = sighting_utils.create_sighting_and_individual(
+            flask_app_client, researcher_1, sighting_data_in, individual_data_in
+        )
+        json_sighting1 = res_sighting.json['result']
+        json_individual1 = res_individual.json['result']
+        assert (
+            json_sighting1['encounters'][0]['id']
+            == json_individual1['encounters'][0]['id']
+        )
+
+        individual_data_in['names']['defaultName'] = 'Mothra'
+        sighting_data_in['locationId'] = 'test2'
+        res_sighting, res_individual = sighting_utils.create_sighting_and_individual(
+            flask_app_client, researcher_1, sighting_data_in, individual_data_in
+        )
+        json_sighting2 = res_sighting.json['result']
+        json_individual2 = res_individual.json['result']
+        assert (
+            json_sighting2['encounters'][0]['id']
+            == json_individual2['encounters'][0]['id']
+        )
+
+        sighting1 = Sighting.query.get(json_sighting1['id'])
+        assert sighting1 is not None
+        sighting2 = Sighting.query.get(json_sighting2['id'])
+        assert sighting2 is not None
+        encounter1 = Encounter.query.get(json_sighting1['encounters'][0]['id'])
+        assert encounter1 is not None
+        encounter2 = Encounter.query.get(json_sighting2['encounters'][0]['id'])
+        assert encounter2 is not None
+
+        data_in = {}  # first try with bunk data
+        with flask_app_client.login(researcher_1, auth_scopes=('individuals:write',)):
+            response = flask_app_client.post(
+                f"/api/v1/individuals/{json_individual1['id']}/merge",
+                data=json.dumps(data_in),
+                content_type='application/json',
+            )
+        assert response.status_code == 500
+        assert (
+            'message' in response.json
+            and 'list of individuals' in response.json['message']
+        )
+
+        # send an invalid guid
+        bad_id = '00000000-0000-0000-0000-000000002170'
+        data_in = [bad_id]
+        with flask_app_client.login(researcher_1, auth_scopes=('individuals:write',)):
+            response = flask_app_client.post(
+                f"/api/v1/individuals/{json_individual1['id']}/merge",
+                data=json.dumps(data_in),
+                content_type='application/json',
+            )
+        assert response.status_code == 500
+        assert (
+            'message' in response.json
+            and f'{bad_id} is invalid' in response.json['message']
+        )
+
+        # now with valid list of from-individuals
+        data_in = {
+            'fromIndividualIds': [json_individual2['id']],
+        }
+        # data_in = [json_individual2['id']]  # would also be valid
+        with flask_app_client.login(researcher_1, auth_scopes=('individuals:write',)):
+            response = flask_app_client.post(
+                f"/api/v1/individuals/{json_individual1['id']}/merge",
+                data=json.dumps(data_in),
+                content_type='application/json',
+            )
+        assert response.status_code == 200
+        assert False
+
+    finally:
+        individual_utils.delete_individual(
+            flask_app_client, researcher_1, json_individual1['id']
+        )
+        individual_utils.delete_individual(
+            flask_app_client, researcher_1, json_individual2['id']
+        )
+        sighting1.delete_cascade()
+        sighting2.delete_cascade()
+        # encounter1.delete_cascade()
+        # encounter2.delete_cascade()

--- a/tests/modules/individuals/resources/test_merge.py
+++ b/tests/modules/individuals/resources/test_merge.py
@@ -1,50 +1,11 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
-from tests.modules.individuals.resources import utils as individual_utils
-from tests.modules.sightings.resources import utils as sighting_utils
+from tests.modules.individuals.resources import utils as individual_res_utils
+from tests.modules.individuals import utils as individual_utils
 from app.modules.individuals.models import Individual
 import pytest
 from tests import utils as test_utils
-
-increment = 0
-
-
-def prep_data(db, flask_app_client, user, individual_sex='female'):
-    from app.modules.encounters.models import Encounter
-    from app.modules.sightings.models import Sighting
-
-    global increment
-    sighting_data_in = {
-        'encounters': [
-            {
-                'decimalLatitude': 45.999,
-                'decimalLongitude': 45.999,
-                'verbatimLocality': 'Legoland Town Square',
-                'locationId': f'Location {increment}',
-            }
-        ],
-        'startTime': '2000-01-01T01:01:01Z',
-        'locationId': f'test-{increment}',
-    }
-    individual_data_in = {
-        'names': {'defaultName': f'NAME {increment}'},
-        'sex': individual_sex,
-        'comments': 'Test Individual',
-        'timeOfBirth': '872846040000',
-    }
-    increment += 1
-    res_sighting, res_individual = sighting_utils.create_sighting_and_individual(
-        flask_app_client, user, sighting_data_in, individual_data_in
-    )
-    json_sighting = res_sighting.json['result']
-    json_individual = res_individual.json['result']
-    assert json_sighting['encounters'][0]['id'] == json_individual['encounters'][0]['id']
-    encounter = Encounter.query.get(json_sighting['encounters'][0]['id'])
-    assert encounter is not None
-    sighting = Sighting.query.get(json_sighting['id'])
-    assert sighting is not None
-    return sighting, encounter
 
 
 @pytest.mark.skipif(
@@ -59,9 +20,13 @@ def test_merge_basics(db, flask_app_client, researcher_1):
     sighting2 = None
     encounter2 = None
     try:
-        sighting1, encounter1 = prep_data(db, flask_app_client, researcher_1)
+        sighting1, encounter1 = individual_utils.simple_sighting_encounter(
+            db, flask_app_client, researcher_1
+        )
         individual1_id = str(encounter1.individual_guid)
-        sighting2, encounter2 = prep_data(db, flask_app_client, researcher_1)
+        sighting2, encounter2 = individual_utils.simple_sighting_encounter(
+            db, flask_app_client, researcher_1
+        )
         individual2_id = str(encounter2.individual_guid)
 
         data_in = {}  # first try with bunk data
@@ -115,7 +80,9 @@ def test_merge_basics(db, flask_app_client, researcher_1):
         assert not individual2
 
     finally:
-        individual_utils.delete_individual(flask_app_client, researcher_1, individual1_id)
+        individual_res_utils.delete_individual(
+            flask_app_client, researcher_1, individual1_id
+        )
         # individual2 is gone now due to successful merge!
         sighting1.delete_cascade()
         sighting2.delete_cascade()
@@ -135,9 +102,13 @@ def test_merge_permissions(
     sighting2 = None
     encounter2 = None
     try:
-        sighting1, encounter1 = prep_data(db, flask_app_client, researcher_1)
+        sighting1, encounter1 = individual_utils.simple_sighting_encounter(
+            db, flask_app_client, researcher_1
+        )
         individual1_id = str(encounter1.individual_guid)
-        sighting2, encounter2 = prep_data(db, flask_app_client, researcher_2)
+        sighting2, encounter2 = individual_utils.simple_sighting_encounter(
+            db, flask_app_client, researcher_2
+        )
         individual2_id = str(encounter2.individual_guid)
 
         # this tests as researcher_2, which should trigger a merge-request (owns just 1 encounter)
@@ -179,92 +150,11 @@ def test_merge_permissions(
         )
 
     finally:
-        individual_utils.delete_individual(flask_app_client, researcher_1, individual1_id)
-        individual_utils.delete_individual(flask_app_client, researcher_2, individual2_id)
-        sighting1.delete_cascade()
-        sighting2.delete_cascade()
-
-
-@pytest.mark.skipif(
-    test_utils.module_unavailable(
-        'individuals', 'encounters', 'sightings', 'social_groups'
-    ),
-    reason='Individuals module disabled',
-)
-def test_merge_social_groups(db, flask_app_client, researcher_1):
-    from app.modules.social_groups.models import SocialGroup
-
-    individual1_id = None
-    sighting1 = None
-    encounter1 = None
-    individual2_id = None
-    sighting2 = None
-    encounter2 = None
-    try:
-        sighting1, encounter1 = prep_data(db, flask_app_client, researcher_1)
-        individual1_id = str(encounter1.individual_guid)
-        sighting2, encounter2 = prep_data(db, flask_app_client, researcher_1)
-        individual2_id = str(encounter2.individual_guid)
-
-        individual1 = Individual.query.get(individual1_id)
-        individual2 = Individual.query.get(individual2_id)
-
-        # this tests target individual is not in social group
-        groupA_name = 'groupA'
-        groupA_role_from_2 = 'doomed-to-be-merged'
-        members = {individual2_id: {'roles': [groupA_role_from_2]}}
-        social_groupA = SocialGroup(members, groupA_name)
-        with db.session.begin(subtransactions=True):
-            db.session.add(social_groupA)
-
-        # this tests target is in group, but gains new role
-        groupB_name = 'groupB'
-        groupB_role_from_1 = 'roleB1'
-        groupB_role_from_2 = 'roleB2'
-        members = {
-            individual1_id: {'roles': [groupB_role_from_1]},
-            individual2_id: {'roles': [groupB_role_from_2]},
-        }
-        social_groupB = SocialGroup(members, groupB_name)
-        db.session.add(social_groupB)
-
-        # this tests target is in group, but shares a role (and will gain a new one)
-        groupC_name = 'groupC'
-        groupC_shared_role = 'sharedC'
-        groupC_role_from_2 = 'roleC2'
-        members = {
-            individual1_id: {'roles': [groupC_shared_role]},
-            individual2_id: {'roles': [groupC_shared_role, groupC_role_from_2]},
-        }
-        social_groupC = SocialGroup(members, groupC_name)
-        db.session.add(social_groupC)
-
-        # pre-merge sanity check
-        assert len(social_groupA.members) == 1
-        assert str(social_groupA.members[0].individual_guid) == individual2_id
-        assert len(social_groupB.members) == 2
-        assert social_groupB.get_member(individual1_id).roles == [groupB_role_from_1]
-        assert len(social_groupC.members) == 2
-        assert social_groupC.get_member(individual1_id).roles == [groupC_shared_role]
-
-        # now do the merge
-        merge_from = [individual2]
-        individual1.merge_from(*merge_from)
-        individual2 = Individual.query.get(individual2_id)
-
-        # post-merge changes
-        assert len(social_groupA.members) == 1
-        assert str(social_groupA.members[0].individual_guid) == individual1_id
-        assert len(social_groupB.members) == 1
-        assert set(social_groupB.get_member(individual1_id).roles) == set(
-            [groupB_role_from_1, groupB_role_from_2]
+        individual_res_utils.delete_individual(
+            flask_app_client, researcher_1, individual1_id
         )
-        assert len(social_groupC.members) == 1
-        assert set(social_groupC.get_member(individual1_id).roles) == set(
-            [groupC_shared_role, groupC_role_from_2]
+        individual_res_utils.delete_individual(
+            flask_app_client, researcher_2, individual2_id
         )
-
-    finally:
-        individual_utils.delete_individual(flask_app_client, researcher_1, individual1_id)
         sighting1.delete_cascade()
         sighting2.delete_cascade()

--- a/tests/modules/individuals/resources/test_merge.py
+++ b/tests/modules/individuals/resources/test_merge.py
@@ -121,5 +121,3 @@ def test_merge(db, flask_app_client, researcher_1):
         )
         sighting1.delete_cascade()
         sighting2.delete_cascade()
-        # encounter1.delete_cascade()
-        # encounter2.delete_cascade()

--- a/tests/modules/individuals/resources/test_merge.py
+++ b/tests/modules/individuals/resources/test_merge.py
@@ -146,6 +146,9 @@ def test_merge_permissions(db, flask_app_client, researcher_1, researcher_2):
         assert response.status_code == 500
         assert response.json['merge_request']
         assert response.json['message'] == 'Merge failed'
+        assert set(response.json['blocking_encounters']) == set(
+            [str(encounter1.guid), str(encounter2.guid)]
+        )
 
         # permission where user owns just one encounter
         sighting3, encounter3 = prep_data(db, flask_app_client, researcher_2)
@@ -161,6 +164,7 @@ def test_merge_permissions(db, flask_app_client, researcher_1, researcher_2):
         assert response.status_code == 500
         assert response.json['merge_request']
         assert response.json['message'] == 'Merge failed'
+        assert response.json['blocking_encounters'] == [str(encounter1.guid)]
 
     finally:
         individual_utils.delete_individual(flask_app_client, researcher_1, individual1_id)

--- a/tests/modules/individuals/resources/test_merge.py
+++ b/tests/modules/individuals/resources/test_merge.py
@@ -12,80 +12,70 @@ from tests import utils as test_utils
     test_utils.module_unavailable('individuals', 'encounters', 'sightings'),
     reason='Individuals module disabled',
 )
-def test_merge_basics(db, flask_app_client, researcher_1):
-    individual1_id = None
-    sighting1 = None
-    encounter1 = None
-    individual2_id = None
-    sighting2 = None
-    encounter2 = None
-    try:
-        sighting1, encounter1 = individual_utils.simple_sighting_encounter(
-            db, flask_app_client, researcher_1
-        )
-        individual1_id = str(encounter1.individual_guid)
-        sighting2, encounter2 = individual_utils.simple_sighting_encounter(
-            db, flask_app_client, researcher_1
-        )
-        individual2_id = str(encounter2.individual_guid)
-
-        data_in = {}  # first try with bunk data
-        response = test_utils.post_via_flask(
-            flask_app_client,
-            researcher_1,
-            scopes=('individuals:write',),
-            path=f'/api/v1/individuals/{individual1_id}/merge',
-            data=data_in,
-            expected_status_code=500,
-            response_200={'success'},
-        )
-        assert (
-            'message' in response.json
-            and 'list of individuals' in response.json['message']
-        )
-
-        # send an invalid guid
-        bad_id = '00000000-0000-0000-0000-000000002170'
-        data_in = [bad_id]
-        response = test_utils.post_via_flask(
-            flask_app_client,
-            researcher_1,
-            scopes=('individuals:write',),
-            path=f'/api/v1/individuals/{individual1_id}/merge',
-            data=data_in,
-            expected_status_code=500,
-            response_200={'success'},
-        )
-        assert (
-            'message' in response.json
-            and f'{bad_id} is invalid' in response.json['message']
-        )
-
-        # now with valid list of from-individuals
-        data_in = {
-            'fromIndividualIds': [individual2_id],
-        }
-        # data_in = [individual2_id]  # would also be valid
-        # note: this tests positive permission case as well (user owns everything)
-        response = test_utils.post_via_flask(
-            flask_app_client,
-            researcher_1,
-            scopes=('individuals:write',),
-            path=f'/api/v1/individuals/{individual1_id}/merge',
-            data=data_in,
-            expected_status_code=200,
-            response_200={'merged'},
-        )
-        individual2 = Individual.query.get(individual2_id)
-        assert not individual2
-
-    finally:
-        individual_res_utils.delete_individual(
+def test_merge_basics(db, flask_app_client, researcher_1, request):
+    sighting1, encounter1 = individual_utils.simple_sighting_encounter(
+        db, flask_app_client, researcher_1
+    )
+    request.addfinalizer(sighting1.delete_cascade)
+    individual1_id = str(encounter1.individual_guid)
+    request.addfinalizer(
+        lambda: individual_res_utils.delete_individual(
             flask_app_client, researcher_1, individual1_id
         )
-        # individual2 is gone now due to successful merge!
-        sighting1.delete_cascade()
-        sighting2.delete_cascade()
+    )
+    sighting2, encounter2 = individual_utils.simple_sighting_encounter(
+        db, flask_app_client, researcher_1
+    )
+    request.addfinalizer(sighting2.delete_cascade)
+    individual2_id = str(encounter2.individual_guid)
+
+    data_in = {}  # first try with bunk data
+    response = test_utils.post_via_flask(
+        flask_app_client,
+        researcher_1,
+        scopes=('individuals:write',),
+        path=f'/api/v1/individuals/{individual1_id}/merge',
+        data=data_in,
+        expected_status_code=500,
+        response_200={'success'},
+    )
+    assert (
+        'message' in response.json and 'list of individuals' in response.json['message']
+    )
+
+    # send an invalid guid
+    bad_id = '00000000-0000-0000-0000-000000002170'
+    data_in = [bad_id]
+    response = test_utils.post_via_flask(
+        flask_app_client,
+        researcher_1,
+        scopes=('individuals:write',),
+        path=f'/api/v1/individuals/{individual1_id}/merge',
+        data=data_in,
+        expected_status_code=500,
+        response_200={'success'},
+    )
+    assert (
+        'message' in response.json and f'{bad_id} is invalid' in response.json['message']
+    )
+
+    # now with valid list of from-individuals
+    data_in = {
+        'fromIndividualIds': [individual2_id],
+    }
+    # data_in = [individual2_id]  # would also be valid
+    # note: this tests positive permission case as well (user owns everything)
+    response = test_utils.post_via_flask(
+        flask_app_client,
+        researcher_1,
+        scopes=('individuals:write',),
+        path=f'/api/v1/individuals/{individual1_id}/merge',
+        data=data_in,
+        expected_status_code=200,
+        response_200={'merged'},
+    )
+    individual2 = Individual.query.get(individual2_id)
+    assert not individual2
 
 
 @pytest.mark.skipif(
@@ -93,68 +83,63 @@ def test_merge_basics(db, flask_app_client, researcher_1):
     reason='Individuals module disabled',
 )
 def test_merge_permissions(
-    db, flask_app_client, researcher_1, researcher_2, contributor_1
+    db, flask_app_client, researcher_1, researcher_2, contributor_1, request
 ):
-    individual1_id = None
-    sighting1 = None
-    encounter1 = None
-    individual2_id = None
-    sighting2 = None
-    encounter2 = None
-    try:
-        sighting1, encounter1 = individual_utils.simple_sighting_encounter(
-            db, flask_app_client, researcher_1
-        )
-        individual1_id = str(encounter1.individual_guid)
-        sighting2, encounter2 = individual_utils.simple_sighting_encounter(
-            db, flask_app_client, researcher_2
-        )
-        individual2_id = str(encounter2.individual_guid)
-
-        # this tests as researcher_2, which should trigger a merge-request (owns just 1 encounter)
-        # NOTE: merge_request not yet implmented, so fails accordingly (code 500)
-        data_in = [individual2_id]
-        response = test_utils.post_via_flask(
-            flask_app_client,
-            researcher_2,
-            scopes=('individuals:write',),
-            path=f'/api/v1/individuals/{individual1_id}/merge',
-            data=data_in,
-            expected_status_code=500,
-            response_200={'merged'},
-        )
-        assert response.json['merge_request']
-        assert response.json['message'] == 'Merge failed'
-        assert response.json['blocking_encounters'] == [str(encounter1.guid)]
-
-        # a user who owns none (403 fail, no go)
-        response = test_utils.post_via_flask(
-            flask_app_client,
-            contributor_1,
-            scopes=('individuals:write',),
-            path=f'/api/v1/individuals/{individual1_id}/merge',
-            data=data_in,
-            expected_status_code=403,
-            response_200={'merged'},
-        )
-
-        # anonymous (401)
-        response = test_utils.post_via_flask(
-            flask_app_client,
-            None,
-            scopes=('individuals:write',),
-            path=f'/api/v1/individuals/{individual1_id}/merge',
-            data=data_in,
-            expected_status_code=401,
-            response_200={'merged'},
-        )
-
-    finally:
-        individual_res_utils.delete_individual(
+    sighting1, encounter1 = individual_utils.simple_sighting_encounter(
+        db, flask_app_client, researcher_1
+    )
+    request.addfinalizer(sighting1.delete_cascade)
+    individual1_id = str(encounter1.individual_guid)
+    request.addfinalizer(
+        lambda: individual_res_utils.delete_individual(
             flask_app_client, researcher_1, individual1_id
         )
-        individual_res_utils.delete_individual(
+    )
+    sighting2, encounter2 = individual_utils.simple_sighting_encounter(
+        db, flask_app_client, researcher_2
+    )
+    request.addfinalizer(sighting2.delete_cascade)
+    individual2_id = str(encounter2.individual_guid)
+    request.addfinalizer(
+        lambda: individual_res_utils.delete_individual(
             flask_app_client, researcher_2, individual2_id
         )
-        sighting1.delete_cascade()
-        sighting2.delete_cascade()
+    )
+
+    # this tests as researcher_2, which should trigger a merge-request (owns just 1 encounter)
+    # NOTE: merge_request not yet implmented, so fails accordingly (code 500)
+    data_in = [individual2_id]
+    response = test_utils.post_via_flask(
+        flask_app_client,
+        researcher_2,
+        scopes=('individuals:write',),
+        path=f'/api/v1/individuals/{individual1_id}/merge',
+        data=data_in,
+        expected_status_code=500,
+        response_200={'merged'},
+    )
+    assert response.json['merge_request']
+    assert response.json['message'] == 'Merge failed'
+    assert response.json['blocking_encounters'] == [str(encounter1.guid)]
+
+    # a user who owns none (403 fail, no go)
+    response = test_utils.post_via_flask(
+        flask_app_client,
+        contributor_1,
+        scopes=('individuals:write',),
+        path=f'/api/v1/individuals/{individual1_id}/merge',
+        data=data_in,
+        expected_status_code=403,
+        response_200={'merged'},
+    )
+
+    # anonymous (401)
+    response = test_utils.post_via_flask(
+        flask_app_client,
+        None,
+        scopes=('individuals:write',),
+        path=f'/api/v1/individuals/{individual1_id}/merge',
+        data=data_in,
+        expected_status_code=401,
+        response_200={'merged'},
+    )

--- a/tests/modules/individuals/test_merge.py
+++ b/tests/modules/individuals/test_merge.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
-from tests.modules.individuals.resources import utils as individual_utils
+from tests.modules.individuals.resources import utils as individual_res_utils
+from tests.modules.individuals import utils as individual_utils
 from tests.modules.sightings.resources import utils as sighting_utils
 import pytest
+from tests import utils as test_utils
 
 from tests.utils import module_unavailable
 
@@ -51,7 +53,7 @@ def test_merge(db, flask_app_client, researcher_1):
         ],
         'sex': 'female',
     }
-    individual_response = individual_utils.create_individual(
+    individual_response = individual_res_utils.create_individual(
         flask_app_client, researcher_1, 200, individual_data_in
     )
     indiv1_guid = individual_response.json['result']['id']
@@ -60,7 +62,7 @@ def test_merge(db, flask_app_client, researcher_1):
     individual_data_in['names']['defaultName'] = 'NAME2'
     individual_data_in['encounters'][0]['id'] = enc2_guid
     # both will be set female
-    individual_response = individual_utils.create_individual(
+    individual_response = individual_res_utils.create_individual(
         flask_app_client, researcher_1, 200, individual_data_in
     )
     indiv2_guid = individual_response.json['result']['id']
@@ -87,7 +89,7 @@ def test_merge(db, flask_app_client, researcher_1):
     individual_data_in['sex'] = 'male'
     individual_data_in['names']['defaultName'] = 'NAME3'
     individual_data_in['encounters'][0]['id'] = enc3_guid
-    individual_response = individual_utils.create_individual(
+    individual_response = individual_res_utils.create_individual(
         flask_app_client, researcher_1, 200, individual_data_in
     )
     indiv3_guid = individual_response.json['result']['id']
@@ -104,10 +106,102 @@ def test_merge(db, flask_app_client, researcher_1):
     assert 'errorFields' in json
     assert 'sex' in json['errorFields']
 
-    individual_utils.delete_individual(flask_app_client, researcher_1, indiv1.guid)
-    # individual_utils.delete_individual(flask_app_client, researcher_1, indiv2.guid)  # actually gone by way of merge!
-    individual_utils.delete_individual(flask_app_client, researcher_1, indiv3.guid)
+    individual_res_utils.delete_individual(flask_app_client, researcher_1, indiv1.guid)
+    # individual_res_utils.delete_individual(flask_app_client, researcher_1, indiv2.guid)  # actually gone by way of merge!
+    individual_res_utils.delete_individual(flask_app_client, researcher_1, indiv3.guid)
     sighting.delete_cascade()
     enc1.delete_cascade()
     enc2.delete_cascade()
     enc3.delete_cascade()
+
+
+@pytest.mark.skipif(
+    test_utils.module_unavailable(
+        'individuals', 'encounters', 'sightings', 'social_groups'
+    ),
+    reason='Individuals module disabled',
+)
+def test_merge_social_groups(db, flask_app_client, researcher_1):
+    from app.modules.social_groups.models import SocialGroup
+    from app.modules.individuals.models import Individual
+
+    individual1_id = None
+    sighting1 = None
+    encounter1 = None
+    individual2_id = None
+    sighting2 = None
+    encounter2 = None
+    try:
+        sighting1, encounter1 = individual_utils.simple_sighting_encounter(
+            db, flask_app_client, researcher_1
+        )
+        individual1_id = str(encounter1.individual_guid)
+        sighting2, encounter2 = individual_utils.simple_sighting_encounter(
+            db, flask_app_client, researcher_1
+        )
+        individual2_id = str(encounter2.individual_guid)
+
+        individual1 = Individual.query.get(individual1_id)
+        individual2 = Individual.query.get(individual2_id)
+
+        # this tests target individual is not in social group
+        groupA_name = 'groupA'
+        groupA_role_from_2 = 'doomed-to-be-merged'
+        members = {individual2_id: {'roles': [groupA_role_from_2]}}
+        social_groupA = SocialGroup(members, groupA_name)
+        with db.session.begin(subtransactions=True):
+            db.session.add(social_groupA)
+
+        # this tests target is in group, but gains new role
+        groupB_name = 'groupB'
+        groupB_role_from_1 = 'roleB1'
+        groupB_role_from_2 = 'roleB2'
+        members = {
+            individual1_id: {'roles': [groupB_role_from_1]},
+            individual2_id: {'roles': [groupB_role_from_2]},
+        }
+        social_groupB = SocialGroup(members, groupB_name)
+        db.session.add(social_groupB)
+
+        # this tests target is in group, but shares a role (and will gain a new one)
+        groupC_name = 'groupC'
+        groupC_shared_role = 'sharedC'
+        groupC_role_from_2 = 'roleC2'
+        members = {
+            individual1_id: {'roles': [groupC_shared_role]},
+            individual2_id: {'roles': [groupC_shared_role, groupC_role_from_2]},
+        }
+        social_groupC = SocialGroup(members, groupC_name)
+        db.session.add(social_groupC)
+
+        # pre-merge sanity check
+        assert len(social_groupA.members) == 1
+        assert str(social_groupA.members[0].individual_guid) == individual2_id
+        assert len(social_groupB.members) == 2
+        assert social_groupB.get_member(individual1_id).roles == [groupB_role_from_1]
+        assert len(social_groupC.members) == 2
+        assert social_groupC.get_member(individual1_id).roles == [groupC_shared_role]
+
+        # now do the merge
+        merge_from = [individual2]
+        individual1.merge_from(*merge_from)
+        individual2 = Individual.query.get(individual2_id)
+
+        # post-merge changes
+        assert len(social_groupA.members) == 1
+        assert str(social_groupA.members[0].individual_guid) == individual1_id
+        assert len(social_groupB.members) == 1
+        assert set(social_groupB.get_member(individual1_id).roles) == set(
+            [groupB_role_from_1, groupB_role_from_2]
+        )
+        assert len(social_groupC.members) == 1
+        assert set(social_groupC.get_member(individual1_id).roles) == set(
+            [groupC_shared_role, groupC_role_from_2]
+        )
+
+    finally:
+        individual_res_utils.delete_individual(
+            flask_app_client, researcher_1, individual1_id
+        )
+        sighting1.delete_cascade()
+        sighting2.delete_cascade()

--- a/tests/modules/individuals/test_merge.py
+++ b/tests/modules/individuals/test_merge.py
@@ -75,7 +75,7 @@ def test_merge(db, flask_app_client, researcher_1):
     try:
         indiv1.merge_from()  # fail cuz no source-individuals
     except ValueError as ve:
-        assert 'at least 2' in str(ve)
+        assert 'at least 1' in str(ve)
 
     indiv1.merge_from(indiv2)
 

--- a/tests/modules/individuals/utils.py
+++ b/tests/modules/individuals/utils.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-docstring
+
+from tests.modules.sightings.resources import utils as sighting_utils
+
+increment = 0
+
+
+def simple_sighting_encounter(db, flask_app_client, user, individual_sex='female'):
+    from app.modules.encounters.models import Encounter
+    from app.modules.sightings.models import Sighting
+
+    global increment
+    sighting_data_in = {
+        'encounters': [
+            {
+                'decimalLatitude': 45.999,
+                'decimalLongitude': 45.999,
+                'verbatimLocality': 'Legoland Town Square',
+                'locationId': f'Location {increment}',
+            }
+        ],
+        'startTime': '2000-01-01T01:01:01Z',
+        'locationId': f'test-{increment}',
+    }
+    individual_data_in = {
+        'names': {'defaultName': f'NAME {increment}'},
+        'sex': individual_sex,
+        'comments': 'Test Individual',
+        'timeOfBirth': '872846040000',
+    }
+    increment += 1
+    res_sighting, res_individual = sighting_utils.create_sighting_and_individual(
+        flask_app_client, user, sighting_data_in, individual_data_in
+    )
+    json_sighting = res_sighting.json['result']
+    json_individual = res_individual.json['result']
+    assert json_sighting['encounters'][0]['id'] == json_individual['encounters'][0]['id']
+    encounter = Encounter.query.get(json_sighting['encounters'][0]['id'])
+    assert encounter is not None
+    sighting = Sighting.query.get(json_sighting['id'])
+    assert sighting is not None
+    return sighting, encounter

--- a/tests/modules/sightings/resources/utils.py
+++ b/tests/modules/sightings/resources/utils.py
@@ -195,3 +195,26 @@ def send_sage_identification_response(
             response, expected_status_code, {'status', 'message'}
         )
     return response
+
+
+def create_sighting_and_individual(
+    flask_app_client,
+    user,
+    sighting_data_in={'locationId': 'PYTEST', 'startTime': '2000-01-01T01:01:01Z'},
+    individual_data_in={'sex': 'unknown'},
+):
+    from tests.modules.individuals.resources import utils as individual_utils
+
+    assert 'encounters' in sighting_data_in
+    assert isinstance(sighting_data_in['encounters'], list)
+    assert len(sighting_data_in['encounters']) > 0
+    sighting_response = create_sighting(flask_app_client, user, sighting_data_in)
+    res = sighting_response.json['result']
+    assert 'encounters' in res
+    assert len(res['encounters']) == 1
+
+    individual_data_in['encounters'] = [{'id': res['encounters'][0]['id']}]
+    individual_response = individual_utils.create_individual(
+        flask_app_client, user, data_in=individual_data_in
+    )
+    return sighting_response, individual_response


### PR DESCRIPTION
## Pull Request Overview

- Implements **API endpoints**, including **permissions**
  - Based on permissions, may trigger _immediate merge_ or  _merge request_ (delayed pending approval)
- Adds consolidation/merging of `SocialGroup` membership (including _roles_)

---

**Review Notes**
- _Merge request_ code (`indiv.merge_request()`) only stubbed out, for completion via DEX-513
- _Merge request_ returns list of `blocking_encounters` (those which user does not have edit access to, hence not allowed automatic/instant merge)

**REST API Examples**

Merge "from" Individuals into a _target Individual_.  This will eventually have additional ways it might fail based on **conflicts**, which will be addressed in DEX-514.

```
POST /api/v1/individuals/TARGET_GUID/merge
[
    FROM_INDIV_GUID_1, FROM_INDIV_GUID_2, ...
]
```
or this more complex version, which leaves open potential for future additional parameters for **conflict resolving**
```
POST /api/v1/individuals/TARGET_GUID/merge
{
    "fromIndividualIds": [ FROM_INDIVI_GUID_1, FROM_INDIVI_GUID_2, ... ],
    "potentialFutureArg1": ....
}
```
