### PR TITLE
DEX-528/529: test of many fields

### DIFF
--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -36,7 +36,7 @@ class EDMManager(RestManager):
     ENDPOINT_PREFIX = 'api'
 
     # this is based on edm date of most recent commit (we must be at or greater than this)
-    MIN_VERSION = '2021-10-26 16:00:00 -0700'
+    MIN_VERSION = '2021-11-08 16:00:00 -0700'
 
     # We use // as a shorthand for prefix
     # fmt: off

--- a/tests/modules/sightings/resources/test_sighting_encounter_fields.py
+++ b/tests/modules/sightings/resources/test_sighting_encounter_fields.py
@@ -8,15 +8,7 @@ import pytest
 import random
 import json
 
-from tests.utils import module_unavailable
-
-
-def _rnd_lat():
-    return random.uniform(-90, 90)
-
-
-def _rnd_lon():
-    return random.uniform(-180, 80)
+from tests.utils import module_unavailable, random_decimal_latitude, random_decimal_longitude
 
 
 @pytest.mark.skipif(
@@ -68,8 +60,8 @@ def test_mega_data(
         'time': encounter_timestamp,
         'locationId': 'enc-test',
         'taxonomy': {'id': tx_guid},
-        'decimalLatitude': _rnd_lat(),
-        'decimalLongitude': _rnd_lon(),
+        'decimalLatitude': random_decimal_latitude(),
+        'decimalLongitude': random_decimal_longitude(),
         'country': 'TEST',
         'sex': 'male',
         'customFields': {
@@ -81,8 +73,8 @@ def test_mega_data(
         'startTime': sighting_timestamp_start,
         'endTime': sighting_timestamp_end,
         'locationId': 'sig-test',
-        'decimalLatitude': _rnd_lat(),
-        'decimalLongitude': _rnd_lon(),
+        'decimalLatitude': random_decimal_latitude(),
+        'decimalLongitude': random_decimal_longitude(),
         'bearing': random.uniform(0, 180),
         'distance': random.uniform(1, 100),
         'customFields': {

--- a/tests/modules/sightings/resources/test_sighting_encounter_fields.py
+++ b/tests/modules/sightings/resources/test_sighting_encounter_fields.py
@@ -1,0 +1,133 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-docstring
+
+from tests.modules.sightings.resources import utils as sighting_utils
+from tests.extensions.edm import utils as edm_utils
+from tests.modules.configuration.resources import utils as conf_utils
+import pytest
+import random
+import json
+
+from tests.utils import module_unavailable
+
+
+def _rnd_lat():
+    return random.uniform(-90, 90)
+
+
+def _rnd_lon():
+    return random.uniform(-180, 80)
+
+
+@pytest.mark.skipif(
+    module_unavailable('encounters', 'sightings'),
+    reason='Encounters and Sightings modules disabled',
+)
+def test_mega_data(
+    db,
+    flask_app_client,
+    researcher_1,
+    admin_user,
+):
+    from app.modules.sightings.models import Sighting
+    import datetime
+
+    # make some customFields in edm
+    sighting_cfd_id = edm_utils.custom_field_create(
+        flask_app_client, admin_user, 'occ_test_cfd'
+    )
+    assert sighting_cfd_id is not None
+    encounter_cfd_id = edm_utils.custom_field_create(
+        flask_app_client, admin_user, 'enc_test_cfd', cls='Encounter'
+    )
+    assert encounter_cfd_id is not None
+
+    # make us a taxonomy to use in edm
+    response = conf_utils.read_configuration(flask_app_client, admin_user, 'site.species')
+    assert 'value' in response.json['response']
+    vals = response.json['response']['value']
+    vals.append({'commonNames': ['Example'], 'scientificName': 'Exempli gratia'})
+    response = conf_utils.modify_configuration(
+        flask_app_client,
+        admin_user,
+        'site.species',
+        {'_value': vals},
+    )
+    response = conf_utils.read_configuration(flask_app_client, admin_user, 'site.species')
+    assert 'response' in response.json and 'value' in response.json['response']
+    tx_guid = response.json['response']['value'][-1]['id']
+
+    sighting_timestamp_start = datetime.datetime.now().isoformat() + 'Z'
+    sighting_timestamp_end = (
+        datetime.datetime.now() + datetime.timedelta(hours=1)
+    ).isoformat() + 'Z'
+    encounter_timestamp = datetime.datetime.now().isoformat() + 'Z'
+    cfd_test_value = 'CFD_TEST_VALUE'
+
+    encounter_data_in = {
+        'time': encounter_timestamp,
+        'locationId': 'enc-test',
+        'taxonomy': {'id': tx_guid},
+        'decimalLatitude': _rnd_lat(),
+        'decimalLongitude': _rnd_lon(),
+        'country': 'TEST',
+        'sex': 'male',
+        'customFields': {
+            encounter_cfd_id: cfd_test_value,
+        },
+    }
+
+    sighting_data_in = {
+        'startTime': sighting_timestamp_start,
+        'endTime': sighting_timestamp_end,
+        'locationId': 'sig-test',
+        'decimalLatitude': _rnd_lat(),
+        'decimalLongitude': _rnd_lon(),
+        'bearing': random.uniform(0, 180),
+        'distance': random.uniform(1, 100),
+        'customFields': {
+            sighting_cfd_id: cfd_test_value,
+        },
+        'encounters': [encounter_data_in],
+        'taxonomies': [{'id': tx_guid}],
+    }
+    response = sighting_utils.create_sighting(
+        flask_app_client,
+        researcher_1,
+        sighting_data_in,
+    )
+
+    sighting_id = response.json['result']['id']
+    sighting = Sighting.query.get(sighting_id)
+    assert sighting is not None
+
+    full_sighting = sighting_utils.read_sighting(
+        flask_app_client,
+        researcher_1,
+        sighting_id,
+    )
+
+    # so we can capture the example if we want, via -s flag on pytest
+    print(json.dumps(full_sighting.json, indent=4, sort_keys=True))
+
+    # some checks on response
+    assert (
+        full_sighting.json['startTime'][0:18] == sighting_timestamp_start[0:18]
+    )  # grr rounding/precision
+    assert full_sighting.json['endTime'][0:18] == sighting_timestamp_end[0:18]
+    assert 'customFields' in full_sighting.json
+    assert sighting_cfd_id in full_sighting.json['customFields']
+    assert full_sighting.json['customFields'][sighting_cfd_id] == cfd_test_value
+    assert (
+        'encounters' in full_sighting.json and len(full_sighting.json['encounters']) == 1
+    )
+    assert full_sighting.json['encounters'][0]['taxonomy']['id'] == tx_guid
+    assert full_sighting.json['encounters'][0]['time'][0:18] == encounter_timestamp[0:18]
+    assert encounter_cfd_id in full_sighting.json['encounters'][0]['customFields']
+    assert (
+        full_sighting.json['encounters'][0]['customFields'][encounter_cfd_id]
+        == cfd_test_value
+    )
+
+    # clean up
+    sighting_utils.delete_sighting(flask_app_client, researcher_1, sighting_id)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,7 +14,7 @@ from flask.testing import FlaskClient
 from werkzeug.utils import cached_property
 from app.extensions.auth import security
 import redis
-
+import random
 import uuid
 import os
 
@@ -456,3 +456,10 @@ def extension_unavailable(*args, **kwargs):
 
 def module_unavailable(*args, **kwargs):
     return not is_module_enabled(*args, **kwargs)
+
+
+def random_decimal_latitude():
+    return random.uniform(-90, 90)
+
+def random_decimal_longitude():
+    return random.uniform(-180, 80)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -461,5 +461,6 @@ def module_unavailable(*args, **kwargs):
 def random_decimal_latitude():
     return random.uniform(-90, 90)
 
+
 def random_decimal_longitude():
     return random.uniform(-180, 80)


### PR DESCRIPTION
## Pull Request Overview

- A test populating many fields on both Sighting and (nested) Encounter, including `customFields`, `taxonomy`, etc.
- Prints output returned from EDM so it can be examined by using `-s` option on `pytest` if desired