### PR TITLE
Delete objects created in integration tests

### DIFF
--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -144,3 +144,11 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
     # GET sighting
     response = session.get(codex_url(f'/api/v1/sightings/{sighting_guid}'))
     assert response.status_code == 200
+
+    # DELETE asset group
+    response = session.delete(codex_url(f'/api/v1/asset_groups/{asset_group_guid}'))
+    assert response.status_code == 204
+
+    # DELETE sighting
+    response = session.delete(codex_url(f'/api/v1/sightings/{sighting_guid}'))
+    assert response.status_code == 204

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import time
-
 from . import utils
 
 
@@ -63,24 +61,10 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
     assert set(a['filename'] for a in assets) == {'zebra.jpg'}
 
     # Wait for detection
-    timeout = 4 * 60  # timeout after 4 minutes
     ags_url = codex_url(f'/api/v1/asset_groups/sighting/{ags_guids[0]}')
-
-    try:
-        while timeout >= 0:
-            response = session.get(ags_url)
-            assert response.status_code == 200
-            if response.json()['stage'] != 'detection':
-                break
-            time.sleep(15)
-            timeout -= 15
-        if response.json()['stage'] != 'curation':
-            assert (
-                False
-            ), f'{timeout <= 0 and "Timed out: " or ""}stage={response.json()["stage"]}\n{response.json()}'
-    except KeyboardInterrupt:
-        print(f'The last response from {ags_url}:\n{response.json()}')
-        raise
+    utils.wait_for(
+        session.get, ags_url, lambda response: response.json()['stage'] == 'curation'
+    )
 
     # GET asset group sighting as sighting
     response = session.get(

--- a/integration_tests/test_collaborations.py
+++ b/integration_tests/test_collaborations.py
@@ -122,3 +122,9 @@ def test_collaboration(session, codex_url, login, logout, admin_email):
     assert response.json()['members'][my_guid]['editState'] == 'declined'
     assert response.json()['members'][new_user_guid]['viewState'] == 'approved'
     assert response.json()['members'][new_user_guid]['editState'] == 'approved'
+
+    # DELETE new users
+    response = session.delete(codex_url(f'/api/v1/users/{new_user_guid}'))
+    assert response.status_code == 204
+    response = session.delete(codex_url(f'/api/v1/users/{new_user_guid_2}'))
+    assert response.status_code == 204

--- a/integration_tests/test_notifications.py
+++ b/integration_tests/test_notifications.py
@@ -11,6 +11,7 @@ def test_notification_preferences(session, login, logout, codex_url):
     user_guid = create_new_user(session, codex_url, new_email, full_name='My name')
     logout(session)
 
+    # GET user
     login(session, email=new_email)
     response = session.get(codex_url('/api/v1/users/me'))
     assert response.status_code == 200
@@ -23,6 +24,7 @@ def test_notification_preferences(session, login, logout, codex_url):
     }
     user_guid = response.json()['guid']
 
+    # PATCH user notification preferences
     response = session.patch(
         codex_url(f'/api/v1/users/{user_guid}'),
         json=[
@@ -65,3 +67,7 @@ def test_notification_preferences(session, login, logout, codex_url):
             'email': False,
         },
     }
+
+    # DELETE user
+    response = session.delete(codex_url(f'/api/v1/users/{user_guid}'))
+    assert response.status_code == 204

--- a/integration_tests/test_sage_detection.py
+++ b/integration_tests/test_sage_detection.py
@@ -5,6 +5,8 @@ from . import utils
 def test_create_asset_group_detection(session, codex_url, test_root, login):
     login(session)
     me = session.get(codex_url('/api/v1/users/me')).json()
+
+    # Create asset group
     zebra = test_root / 'zebra.jpg'
     transaction_id = utils.upload_to_tus(session, codex_url, [zebra])
     data = {
@@ -49,6 +51,7 @@ def test_create_asset_group_detection(session, codex_url, test_root, login):
         'guid': asset_group['guid'],
     }
 
+    # Wait for sage detection and GET asset group sighting
     ags_url = codex_url(f'/api/v1/asset_groups/sighting/{ags_guids[0]}')
     response = utils.wait_for(
         session.get, ags_url, lambda response: response.json()['stage'] == 'curation'
@@ -118,3 +121,7 @@ def test_create_asset_group_detection(session, codex_url, test_root, login):
         },
         'guid': ags_guids[0],
     }
+
+    # DELETE asset group
+    response = session.delete(codex_url(f'/api/v1/asset_groups/{asset_group["guid"]}'))
+    assert response.status_code == 204

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -250,3 +250,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
         # 6c152f7e-4613-4acc-b44f-2fe278bee9dd
         'transactionId': response.json()['transactionId'],
     }
+
+    # DELETE sighting
+    response = session.delete(codex_url(f'/api/v1/sightings/{sighting_id}'))
+    assert response.status_code == 204

--- a/integration_tests/test_social_groups.py
+++ b/integration_tests/test_social_groups.py
@@ -36,6 +36,7 @@ def test_social_groups(session, login, codex_url):
     }
     response = session.post(codex_url('/api/v1/sightings/'), json=data)
     assert response.status_code == 200
+    sighting_id = response.json()['result']['id']
     result = response.json()['result']
     encounter_ids = [e['id'] for e in result['encounters']]
     encounter_versions = [e['version'] for e in result['encounters']]
@@ -197,3 +198,16 @@ def test_social_groups(session, login, codex_url):
         },
         'guid': social_group_id,
     }
+
+    # DELETE social group
+    response = session.delete(codex_url(f'/api/v1/social-groups/{social_group_id}'))
+    assert response.status_code == 204
+
+    # DELETE individuals
+    for individual_id in individual_ids:
+        response = session.delete(codex_url(f'/api/v1/individuals/{individual_id}'))
+        assert response.status_code == 204
+
+    # DELETE sighting
+    response = session.delete(codex_url(f'/api/v1/sightings/{sighting_id}'))
+    assert response.status_code == 204

--- a/integration_tests/test_users.py
+++ b/integration_tests/test_users.py
@@ -49,3 +49,7 @@ def test_user_deactivation(session, codex_url, login, logout, admin_email):
     assert response.status_code == 200
     assert response.json()['guid'] == new_user_guid
     assert response.json()['email'] == new_email
+
+    # DELETE user
+    response = session.delete(codex_url(f'/api/v1/users/{new_user_guid}'))
+    assert response.status_code == 204


### PR DESCRIPTION
- Add integration_tests.utils.wait_for

  Used to wait for sage detection to be finished.

- Delete objects created in integration tests

  This is especially for deleting asset group sightings because a user can
  only have 10 asset group sightings that are not committed.  The sage
  detection test eventually fails because the admin user has too many
  uncommitted asset group sightings.
