### PR TITLE
DEX-365 Make GET AssetGroupSighting and Sighting APIs the same

### DIFF
--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -6,6 +6,8 @@ Serialization schemas for Asset_groups resources RESTful API
 
 from flask_marshmallow import base_fields
 from flask_restx_patched import ModelSchema
+from app.modules.assets.schemas import DetailedAssetGroupAssetSchema
+from app.modules.sightings.schemas import AugmentedEdmSightingSchema
 
 from .models import AssetGroup, AssetGroupSighting
 
@@ -42,7 +44,11 @@ class DetailedAssetGroupSightingSchema(BaseAssetGroupSightingSchema):
     Detailed Asset_group_sighting schema exposes all useful fields.
     """
 
-    assets = base_fields.Function(AssetGroupSighting.get_assets)
+    assets = base_fields.Nested(
+        DetailedAssetGroupAssetSchema,
+        attribute='get_assets',
+        many=True,
+    )
 
     completion = base_fields.Function(AssetGroupSighting.get_completion)
 
@@ -60,7 +66,28 @@ class DetailedAssetGroupSightingSchema(BaseAssetGroupSightingSchema):
         )
 
 
-class AssetGroupSightingAsSightingSchema(BaseAssetGroupSightingSchema):
+class AssetGroupSightingEncounterSchema(ModelSchema):
+    country = base_fields.String(default=None)
+    createdHouston = base_fields.DateTime()
+    customFields = base_fields.Dict(default={})
+    decimalLatitude = base_fields.Float(default=None)
+    decimalLongitude = base_fields.Float(default=None)
+    guid = base_fields.UUID()
+    hasEdit = base_fields.Boolean(default=True)
+    hasView = base_fields.Boolean(default=True)
+    id = base_fields.UUID(attribute='guid')
+    individual = base_fields.Dict(default={})
+    locationId = base_fields.String(default=None)
+    owner = base_fields.Dict()
+    sex = base_fields.String(default=None)
+    submitter = base_fields.Dict(default=None)
+    taxonomy = base_fields.Dict(default={})
+    time = base_fields.String(default=None)
+    updatedHouston = base_fields.DateTime()
+    version = base_fields.String(default=None)
+
+
+class AssetGroupSightingAsSightingSchema(AugmentedEdmSightingSchema):
     """
     In order for the frontend to render an AGS with the same code that renders a
     sighting, we have to pop out all the fields in AGS.config into the top-level
@@ -69,14 +96,15 @@ class AssetGroupSightingAsSightingSchema(BaseAssetGroupSightingSchema):
     fields using the pattern below.
     """
 
-    assets = base_fields.Function(AssetGroupSighting.get_assets)
     completion = base_fields.Function(AssetGroupSighting.get_completion)
 
     # Note: these config_field_getter vars should conform to SIGHTING_FIELDS_IN_AGS_CONFIG
     # at the top of this file
     startTime = base_fields.Function(AssetGroupSighting.config_field_getter('startTime'))
-    encounters = base_fields.Function(
-        AssetGroupSighting.config_field_getter('encounters', default=[])
+    encounters = base_fields.Nested(
+        AssetGroupSightingEncounterSchema,
+        attribute='get_encounters',
+        many=True,
     )
     decimalLatitude = base_fields.Function(
         AssetGroupSighting.config_field_getter('decimalLatitude', cast=float)
@@ -90,13 +118,19 @@ class AssetGroupSightingAsSightingSchema(BaseAssetGroupSightingSchema):
     verbatimLocality = base_fields.Function(
         AssetGroupSighting.config_field_getter('verbatimLocality', default='')
     )
-    id = base_fields.Function(AssetGroupSighting.config_field_getter('id', cast=int))
+    id = base_fields.UUID(attribute='guid')
     encounterCounts = base_fields.Function(
         AssetGroupSighting.config_field_getter('encounterCounts', default={})
     )
-    featured_asset_guid = base_fields.Function(
+    featuredAssetGuid = base_fields.Function(
         AssetGroupSighting.config_field_getter('featuredAssetGuid')
     )
+    # These are fields that are in Sighting but don't exist for
+    # AssetGroupSighting
+    createdEDM = base_fields.DateTime(default=None)
+    comments = base_fields.String(default='None')
+    customFields = base_fields.Dict(attribute='get_custom_fields')
+    version = base_fields.String(default=None)
 
     class Meta:
         # adds 'stage' to the fields already defined above

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -429,6 +429,12 @@ class SightingByID(Resource):
 
         schema = AugmentedEdmSightingSchema()
         edm_response = response['result']
+        for encounter in edm_response.get('encounters') or []:
+            # EDM returns strings for decimalLatitude and decimalLongitude
+            if encounter.get('decimalLongitude'):
+                encounter['decimalLongitude'] = float(encounter['decimalLongitude'])
+            if encounter.get('decimalLatitude'):
+                encounter['decimalLatitude'] = float(encounter['decimalLatitude'])
         edm_response.update(schema.dump(sighting).data)
 
         return sighting.augment_edm_json(edm_response)

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -403,22 +403,7 @@ class SightingByID(Resource):
     Manipulations with a specific Sighting.
     """
 
-    @api.login_required(oauth_scopes=['sightings:read'])
-    @api.permission_required(
-        permissions.ObjectAccessPermission,
-        kwargs_on_request=lambda kwargs: {
-            'obj': kwargs['sighting'],
-            'action': AccessOperation.READ,
-        },
-    )
-    def get(self, sighting):
-        """
-        Get Sighting details by ID.
-        """
-
-        # note: should probably _still_ check edm for: stale cache, deletion!
-        #      user.edm_sync(version)
-
+    def _get_sighting(self, sighting):
         response = current_app.edm.get_dict('sighting.data_complete', sighting.guid)
         if not isinstance(response, dict):  # some non-200 thing, incl 404
             return response
@@ -438,6 +423,23 @@ class SightingByID(Resource):
         edm_response.update(schema.dump(sighting).data)
 
         return sighting.augment_edm_json(edm_response)
+
+    @api.login_required(oauth_scopes=['sightings:read'])
+    @api.permission_required(
+        permissions.ObjectAccessPermission,
+        kwargs_on_request=lambda kwargs: {
+            'obj': kwargs['sighting'],
+            'action': AccessOperation.READ,
+        },
+    )
+    def get(self, sighting):
+        """
+        Get Sighting details by ID.
+        """
+
+        # note: should probably _still_ check edm for: stale cache, deletion!
+        #      user.edm_sync(version)
+        return self._get_sighting(sighting)
 
     @api.login_required(oauth_scopes=['sightings:write'])
     @api.permission_required(
@@ -525,40 +527,47 @@ class SightingByID(Resource):
                 response_data['threatened_sighting_id'] = str(sighting.guid)
                 sighting.delete_cascade()  # this will get rid of our encounter(s) as well so no need to rectify_edm_encounters()
                 sighting = None
-            else:
-                sighting.rectify_edm_encounters(result.get('encounters'), current_user)
-                # if we have enc_anns (len=N, N > 0), these should map to the last N encounters in this sighting
-                if len(enc_anns) > 0:
-                    enc_res = result.get('encounters', [])
-                    # enc_res *should* be in order added (e.g. sorted by version)
-                    # note however, i am not 100% sure if sightings.encounters is in same order!  it appears to be in all my testing.
-                    #  in the event it proves not to be, we should trust enc_res order and/or .version on each of sighting.encounters
-                    assert len(enc_res) == len(
-                        sighting.encounters
-                    )  # more just a sanity-check
-                    assert len(enc_anns) <= len(
-                        sighting.encounters
-                    )  # which ones were added, basically
-                    i = 0
-                    offset = len(sighting.encounters) - len(enc_anns)
-                    while i < len(enc_anns):
-                        log.debug(
-                            f'enc_len={len(sighting.encounters)},offset={offset},i={i}: onto encounters[{offset+i}] setting {enc_anns[i]}'
-                        )
-                        sighting.encounters[offset + i].annotations = enc_anns[i]
-                        i += 1
+                return response_data
 
-                new_version = result.get('version', None)
-                if new_version is not None:
-                    sighting.version = new_version
-                    context = api.commit_or_abort(
-                        db.session,
-                        default_error_message='Failed to update Sighting version.',
+            sighting.rectify_edm_encounters(result.get('encounters'), current_user)
+            # if we have enc_anns (len=N, N > 0), these should map to the last N encounters in this sighting
+            if len(enc_anns) > 0:
+                enc_res = result.get('encounters', [])
+                # enc_res *should* be in order added (e.g. sorted by version)
+                # note however, i am not 100% sure if sightings.encounters is in same order!  it appears to be in all my testing.
+                #  in the event it proves not to be, we should trust enc_res order and/or .version on each of sighting.encounters
+                assert len(enc_res) == len(
+                    sighting.encounters
+                )  # more just a sanity-check
+                assert len(enc_anns) <= len(
+                    sighting.encounters
+                )  # which ones were added, basically
+                i = 0
+                offset = len(sighting.encounters) - len(enc_anns)
+                while i < len(enc_anns):
+                    log.debug(
+                        f'enc_len={len(sighting.encounters)},offset={offset},i={i}: onto encounters[{offset+i}] setting {enc_anns[i]}'
                     )
-                    with context:
-                        db.session.merge(sighting)
-                AuditLog.patch_object(log, sighting, args, duration=timer.elapsed())
-            return response_data
+                    sighting.encounters[offset + i].annotations = enc_anns[i]
+                    i += 1
+
+            new_version = result.get('version', None)
+            if new_version is not None:
+                sighting.version = new_version
+                context = api.commit_or_abort(
+                    db.session,
+                    default_error_message='Failed to update Sighting version.',
+                )
+                with context:
+                    db.session.merge(sighting)
+            AuditLog.patch_object(log, sighting, args, duration=timer.elapsed())
+
+            sighting_response = self._get_sighting(sighting)
+            if isinstance(sighting_response, dict):
+                return sighting_response
+            else:
+                # sighting might be deleted, return the original patch response_data
+                return response_data
 
         # no EDM, so fall thru to regular houston-patching
         context = api.commit_or_abort(

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -262,7 +262,11 @@ def browser_failure_handler(browser):
 
 
 def pytest_exception_interact(node, call, report):
-    if 'browser' in node.funcargs and 'session' not in node.funcargs:
+    if (
+        hasattr(node, 'funcargs')
+        and 'browser' in node.funcargs
+        and 'session' not in node.funcargs
+    ):
         # Save screenshot and page source when there's an exception
         browser = node.funcargs['browser']
         browser_failure_handler(browser)

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -10,6 +10,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
 
     response = session.get(codex_url('/api/v1/users/me'))
     my_guid = response.json()['guid']
+    my_name = response.json()['full_name']
 
     # Add an example species and custom fields in edm
     response = utils.add_site_species(
@@ -109,42 +110,91 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
     response = session.get(
         codex_url(f'/api/v1/asset_groups/sighting/as_sighting/{ags_guids[0]}')
     )
-    encounter_guids = [e['guid'] for e in response.json()['encounters']]
+    assets = response.json()['assets']
+    annots_0 = assets[0]['annotations']
+    encounters = response.json()['encounters']
+    encounter_guids = [e['guid'] for e in encounters]
     assert response.status_code == 200
     assert response.json() == {
         'assets': [
             {
+                'annotations': [
+                    {
+                        'asset_guid': assets[0]['guid'],
+                        'bounds': {
+                            'rect': [178, 72, 604, 534],
+                            'theta': 0.0,
+                        },
+                        # 2021-11-09T11:15:09.910872+00:00
+                        'created': annots_0[0]['created'],
+                        'encounter_guid': None,
+                        'guid': annots_0[0]['guid'],
+                        'ia_class': 'zebra_plains',
+                        'keywords': [],
+                        'viewpoint': 'unknown',
+                        'updated': annots_0[0]['updated'],
+                    },
+                ],
+                # 2021-11-09T11:15:08.923895+00:00
+                'created': assets[0]['created'],
+                'dimensions': {'width': 1000, 'height': 664},
+                'filename': 'zebra.jpg',
                 'guid': assets[0]['guid'],
-                'filename': assets[0]['filename'],
                 'src': f'/api/v1/assets/src/{assets[0]["guid"]}',
+                'updated': assets[0]['updated'],
             },
         ],
+        'comments': 'None',
         'completion': 10,
+        'createdEDM': None,
+        # 2021-11-12T18:28:32.744114+00:00
+        'createdHouston': response.json()['createdHouston'],
+        'customFields': {},
         'decimalLatitude': None,
         'decimalLongitude': None,
         'encounterCounts': {},
         'encounters': [
             {
                 'country': 'TEST',
+                # 2021-11-13T16:57:41.937173+00:00
+                'createdHouston': encounters[0]['createdHouston'],
                 'customFields': {
                     enc_test_cfd: 'CFD_TEST_VALUE',
                 },
                 'decimalLatitude': 63.142385,
                 'decimalLongitude': -21.596914,
                 'guid': encounter_guids[0],
+                'hasEdit': True,
+                'hasView': True,
+                'id': encounter_guids[0],
+                'individual': {},
                 'locationId': 'enc-test',
+                'owner': {
+                    'full_name': my_name,
+                    'guid': my_guid,
+                    'profile_fileupload': None,
+                },
                 'sex': 'male',
+                'submitter': None,
                 'taxonomy': {'id': tx_id},
                 'time': encounter_timestamp,
+                # 2021-11-13T16:57:41.937187+00:00
+                'updatedHouston': response.json()['updatedHouston'],
+                'version': None,
             },
         ],
-        'featured_asset_guid': None,
+        'featuredAssetGuid': None,
         'guid': ags_guids[0],
-        'id': None,
+        'hasEdit': True,
+        'hasView': True,
+        'id': ags_guids[0],
         'locationId': 'PYTEST',
         'stage': 'curation',
         'startTime': '2000-01-01T01:01:01Z',
+        # 2021-11-12T18:28:32.744135+00:00
+        'updatedHouston': response.json()['updatedHouston'],
         'verbatimLocality': '',
+        'version': None,
     }
 
     # PATCH asset group sighting as sighting
@@ -167,37 +217,83 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
     assert response.json() == {
         'assets': [
             {
+                'annotations': [
+                    {
+                        'asset_guid': assets[0]['guid'],
+                        'bounds': {
+                            'rect': [178, 72, 604, 534],
+                            'theta': 0.0,
+                        },
+                        # 2021-11-09T11:15:09.910872+00:00
+                        'created': annots_0[0]['created'],
+                        'encounter_guid': None,
+                        'guid': annots_0[0]['guid'],
+                        'ia_class': 'zebra_plains',
+                        'keywords': [],
+                        'viewpoint': 'unknown',
+                        'updated': annots_0[0]['updated'],
+                    },
+                ],
+                # 2021-11-09T11:15:08.923895+00:00
+                'created': assets[0]['created'],
+                'dimensions': {'width': 1000, 'height': 664},
                 'filename': 'zebra.jpg',
-                'src': f'/api/v1/assets/src/{assets[0]["guid"]}',
                 'guid': assets[0]['guid'],
+                'src': f'/api/v1/assets/src/{assets[0]["guid"]}',
+                'updated': assets[0]['updated'],
             },
         ],
+        'comments': 'None',
         'completion': 10,
+        'createdEDM': None,
+        # 2021-11-12T18:28:32.744114+00:00
+        'createdHouston': response.json()['createdHouston'],
+        'customFields': {},
         'decimalLatitude': 52.152029,
         'decimalLongitude': 2.318116,
+        'encounterCounts': {},
         'encounters': [
             {
                 'country': 'TEST',
+                # 2021-11-13T16:57:41.937173+00:00
+                'createdHouston': encounters[0]['createdHouston'],
                 'customFields': {
                     enc_test_cfd: 'CFD_TEST_VALUE',
                 },
                 'decimalLatitude': 63.142385,
                 'decimalLongitude': -21.596914,
                 'guid': encounter_guids[0],
+                'hasEdit': True,
+                'hasView': True,
+                'id': encounter_guids[0],
+                'individual': {},
                 'locationId': 'enc-test',
+                'owner': {
+                    'full_name': my_name,
+                    'guid': my_guid,
+                    'profile_fileupload': None,
+                },
                 'sex': 'male',
+                'submitter': None,
                 'taxonomy': {'id': tx_id},
                 'time': encounter_timestamp,
+                # 2021-11-13T16:57:41.937187+00:00
+                'updatedHouston': response.json()['updatedHouston'],
+                'version': None,
             },
         ],
-        'encounterCounts': {},
-        'featured_asset_guid': None,
+        'featuredAssetGuid': None,
         'guid': ags_guids[0],
-        'id': None,
+        'hasEdit': True,
+        'hasView': True,
+        'id': ags_guids[0],
         'locationId': 'PYTEST',
         'stage': 'curation',
         'startTime': '2000-01-01T01:01:01Z',
+        # 2021-11-12T18:28:32.744135+00:00
+        'updatedHouston': response.json()['updatedHouston'],
         'verbatimLocality': '',
+        'version': None,
     }
 
     # Commit asset group sighting (becomes sighting)

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -102,19 +102,19 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
             {
                 'annotations': [
                     {
-                        # 2021-11-09T11:15:09.910872+00:00
-                        'created': annots_0[0]['created'],
-                        'keywords': [],
-                        'ia_class': 'zebra_plains',
                         'asset_guid': assets[0]['guid'],
-                        'viewpoint': 'unknown',
-                        'updated': annots_0[0]['updated'],
-                        'encounter_guid': None,
                         'bounds': {
                             'rect': [178, 72, 604, 534],
                             'theta': 0.0,
                         },
+                        # 2021-11-09T11:15:09.910872+00:00
+                        'created': annots_0[0]['created'],
+                        'encounter_guid': None,
                         'guid': annots_0[0]['guid'],
+                        'ia_class': 'zebra_plains',
+                        'keywords': [],
+                        'viewpoint': 'unknown',
+                        'updated': annots_0[0]['updated'],
                     },
                 ],
                 # 2021-11-09T11:15:08.923895+00:00
@@ -144,8 +144,8 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
                 'customFields': {
                     enc_test_cfd: 'CFD_TEST_VALUE',
                 },
-                'decimalLatitude': '63.142385',
-                'decimalLongitude': '-21.596914',
+                'decimalLatitude': 63.142385,
+                'decimalLongitude': -21.596914,
                 'guid': encounters[0]['guid'],
                 'hasEdit': True,
                 'hasView': True,

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -203,37 +203,89 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
         ],
     )
     assert response.status_code == 200
-    assert response.json()['result']['version'] > sighting_version
-    sighting_version = response.json()['result']['version']
+    assert response.json()['version'] > sighting_version
+    sighting_version = response.json()['version']
     assert response.json() == {
-        'result': {
-            'comments': 'None',
-            'createdEDM': response.json()['result']['createdEDM'],
-            'encounters': [
-                {
-                    'id': encounters[0]['id'],
-                    'version': encounters[0]['version'],
-                },
-            ],
-            'id': sighting_id,
-            'startTime': '2000-01-01T01:01:01Z',
-            'version': sighting_version,
-        },
-        'patchResults': [
+        'assets': [
             {
-                'op': 'add',
-                'path': 'decimalLatitude',
-                'value': 52.152029,
-            },
-            {
-                'op': 'add',
-                'path': 'decimalLongitude',
-                'value': 2.318116,
+                'annotations': [
+                    {
+                        'asset_guid': assets[0]['guid'],
+                        'bounds': {
+                            'rect': [178, 72, 604, 534],
+                            'theta': 0.0,
+                        },
+                        'created': annots_0[0]['created'],
+                        'encounter_guid': None,
+                        'guid': annots_0[0]['guid'],
+                        'ia_class': 'zebra_plains',
+                        'keywords': [],
+                        'updated': annots_0[0]['updated'],
+                        'viewpoint': 'unknown',
+                    },
+                ],
+                'created': assets[0]['created'],
+                'dimensions': {'width': 1000, 'height': 664},
+                'filename': 'zebra.jpg',
+                'guid': assets[0]['guid'],
+                'src': f'/api/v1/assets/src/{assets[0]["guid"]}',
+                'updated': assets[0]['updated'],
             },
         ],
-        'success': True,
-        # 6c152f7e-4613-4acc-b44f-2fe278bee9dd
-        'transactionId': response.json()['transactionId'],
+        'comments': 'None',
+        'createdEDM': response.json()['createdEDM'],  # 2021-11-16 09:45:26
+        # 2021-11-16T09:45:26.717326+00:00
+        'createdHouston': response.json()['createdHouston'],
+        'customFields': {},
+        'decimalLatitude': 52.152029,
+        'decimalLongitude': 2.318116,
+        'encounters': [
+            {
+                'country': 'TEST',
+                'createdHouston': encounters[0]['createdHouston'],
+                'customFields': {
+                    enc_test_cfd: 'CFD_TEST_VALUE',
+                },
+                'decimalLatitude': 63.142385,
+                'decimalLongitude': -21.596914,
+                'guid': encounters[0]['guid'],
+                'hasEdit': True,
+                'hasView': True,
+                'id': encounters[0]['guid'],
+                'individual': {},
+                'locationId': 'enc-test',
+                'owner': {
+                    'full_name': my_name,
+                    'guid': my_guid,
+                    'profile_fileupload': None,
+                },
+                'sex': 'male',
+                'submitter': None,
+                'taxonomy': {
+                    'commonNames': ['Example'],
+                    'scientificName': 'Exempli gratia',
+                    'id': tx_id,
+                },
+                'time': encounter_timestamp,
+                'updatedHouston': encounters[0]['updatedHouston'],
+                'version': encounters[0]['version'],
+            },
+        ],
+        'encounterCounts': {
+            'lifeStage': {},
+            'sex': {'male': 1},
+            'individuals': 0,
+        },
+        'featuredAssetGuid': assets[0]['guid'],
+        'guid': sighting_id,
+        'hasEdit': True,
+        'hasView': True,
+        'id': sighting_id,
+        'locationId': 'PYTEST',
+        'startTime': '2000-01-01T01:01:01Z',
+        # 2021-11-16T09:45:26.717432+00:00
+        'updatedHouston': response.json()['updatedHouston'],
+        'version': sighting_version,
     }
 
     # DELETE asset group

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -80,7 +80,10 @@ def add_site_species(session, codex_url, data):
     site_species_url = codex_url('/api/v1/configuration/default/site.species')
     response = session.get(site_species_url)
     values = response.json()['response']['value']
-    if not [v for v in values if v == data]:
+    for v in values:
+        if all(v.get(k) == data[k] for k in data):
+            break
+    else:
         values.append(data)
         response = session.post(site_species_url, json={'_value': values})
         assert response.status_code == 200

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -385,8 +385,8 @@ def test_annotations_within_sightings(
             }
         ],
     )
-    assert len(response.json['result']['encounters']) == 3
-    enc_guid = response.json['result']['encounters'][2]['id']
+    assert len(response.json['encounters']) == 3
+    enc_guid = response.json['encounters'][2]['id']
     enc = Encounter.query.get(enc_guid)
     assert enc is not None
     assert len(enc.annotations) == 1

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -441,8 +441,8 @@ def test_edm_and_houston_encounter_data_within_sightings(
         assert json['encounters'][0]['verbatimLocality'] == 'Saturn'
         assert json['encounters'][0]['locationId'] == 'Saturn'
         assert json['encounters'][0]['time'] == '2010-01-01T01:01:01Z'
-        assert json['encounters'][0]['decimalLatitude'] == '25.9999'
-        assert json['encounters'][0]['decimalLongitude'] == '25.9999'
+        assert json['encounters'][0]['decimalLatitude'] == 25.9999
+        assert json['encounters'][0]['decimalLongitude'] == 25.9999
 
         # houston stuff
         assert json['encounters'][0]['id'] is not None

--- a/tests/modules/sightings/resources/utils.py
+++ b/tests/modules/sightings/resources/utils.py
@@ -125,11 +125,15 @@ def patch_sighting(
         '%s%s' % (PATH, sighting_guid),
         patch_data,
         expected_status_code,
-        {'result', 'success'},
+        set(),
         headers=headers,
     )
     if expected_status_code == 200:
-        assert response.json['success']
+        if 'version' in response.json.keys():
+            assert response.json.keys() >= {'version', 'guid', 'id'}
+        else:
+            assert response.json.keys() >= {'result', 'success'}
+            assert response.json['success']
     elif expected_status_code != 401:
         assert not response.json['success']
 


### PR DESCRIPTION
- Fix integration test exception handler attribute error

  When there's a syntax error, this is shown instead of the syntax error:
  
  ```
  INTERNALERROR>   File "/home/karen/src/wildme/houston/integration_tests/conftest.py", line 265, in pytest_exception_interact
  INTERNALERROR>     if 'browser' in node.funcargs and 'session' not in node.funcargs:
  INTERNALERROR> AttributeError: 'Module' object has no attribute 'funcargs'
  ```

- Fix integration tests utils add_site_species adding duplicates

  `add_site_species` was adding a species to EDM even when it already
  existed.  The reason is because it was checking:
  
  ```
  {'commonNames': ['Example'],
   'scientificName': 'Exempli gratia',
   'id': 'fd4533c1-ce43-4826-a841-205d3f62098f'}
  == {'commonNames': ['Example'], 'scientificName': 'Exempli gratia'}
  ```
  
  which was failing because of the extra `id` field.

- Make GET AssetGroupSighting and Sighting APIs the same

  Change `AssetGroupSightingAsSightingSchema` to inherit from
  `AugmentedEdmSightingSchema` so the schema is the same as the GET
  sighting API.
  
  Add `AssetGroupSightingEncounterSchema` which is used for `encounters`
  within `AssetGroupSightingAsSightingSchema` and has the same fields as
  the GET sighting API.
  
  Add custom json encoder for decimal fields (for encounters latitude and
  longitude fields) in `config.codex.py`.

---

After this PR, the only difference between the GET sighting (red -) and asset group sighting (green +) APIs:

```diff
--- sighting_get.json   2021-11-15 15:32:57.022457152 +0000
+++ asset_group_sighting_get.json       2021-11-15 15:34:56.647491746 +0000
@@ -34,18 +34,13 @@                        
     }                                     
   ],                                      
   "comments": "None",                     
-  "createdEDM": "2021-11-15 15:32:56",    
+  "completion": 10,                       
+  "createdEDM": null,                     
   "createdHouston": "2021-11-15T15:32:56.897991+00:00",
   "customFields": {},                     
   "decimalLatitude": 63.142385,           
   "decimalLongitude": -21.596914,         
-  "encounterCounts": {                    
-    "individuals": 0,                     
-    "lifeStage": {},                      
-    "sex": {
-      "male": 1
-    }
-  },
+  "encounterCounts": {},
   "encounters": [
     {
       "country": "TEST",
@@ -69,24 +64,22 @@                        
       "sex": "male",                      
       "submitter": null,                  
       "taxonomy": {                       
-        "commonNames": [                  
-          "Example"                       
-        ],                                
-        "id": "c6439356-b02d-4edf-8059-d5d6fe1067bf",
-        "scientificName": "Exempli gratia"
+        "id": "c6439356-b02d-4edf-8059-d5d6fe1067bf"
       },                                  
       "time": "2021-11-15T15:32:41.227Z", 
       "updatedHouston": "2021-11-15T15:32:56.932337+00:00",
-      "version": 1636990376865            
+      "version": null                     
     }                                     
   ],                                      
-  "featuredAssetGuid": "d514f638-bd51-4826-a50a-94f973ccb62e",
+  "featuredAssetGuid": null,              
   "guid": "a26d9133-973d-41ec-9a4e-948700d914a4",
   "hasEdit": true,                        
   "hasView": true,                        
   "id": "a26d9133-973d-41ec-9a4e-948700d914a4",
   "locationId": "PYTEST",                 
+  "stage": "curation",                    
   "startTime": "2000-01-01T01:01:01Z",    
   "updatedHouston": "2021-11-15T15:32:56.898012+00:00",
-  "version": 1636990376865                
-}                                         
\ No newline at end of file                
+  "verbatimLocality": "",                 
+  "version": null                         
+}                                         
```