### PR TITLE
Allow configuraiton of the full filepath to the SSH key

### DIFF
--- a/config.codex.py
+++ b/config.codex.py
@@ -351,7 +351,7 @@ class AssetGroupConfig(object):
     @property
     def GIT_SSH_KEY_FILEPATH(self):
         # Assuming mixed-in with BaseConfig
-        fp = DATA_ROOT / 'id_ssh_key'
+        fp = Path(os.getenv('GIT_SSH_KEY_FILEPATH', DATA_ROOT / 'id_ssh_key'))
         if self.GIT_SSH_KEY is None:
             # Assume the user knows what they are doing and bail out
             # FIXME: It's possible to get here because parts of the application


### PR DESCRIPTION
In the orchestration scenario the ssh key is mounted on the filesystem
from a [kubernetes] secret. This location needs to reside outside of
the mounted data volume, because a mount can't contain a mount.

This change allows the current practice to continue working when
`GIT_SSH_KEY_FILEPATH` is undefined.

A problem would arrise if both `GIT_SSH_KEY` and
`GIT_SSH_KEY_FILEPATH` are supplied. But if the
permissions are set correctly to read-only on the file at
`GIT_SSH_KEY_FILEPATH`, the operation should fail with an OSError.
