### PR TITLE
Fix sighting fields in asset group POST integration test

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,7 +73,7 @@ jobs:
         run: |
           set -ex
           # Need -c integration_tests/conftest.py otherwise it tries to use tests/conftest.py
-          pytest -s -x -c integration_tests/conftest.py integration_tests/
+          pytest -s -vv -c integration_tests/conftest.py integration_tests/
 
       - name: Show docker-compose logs if failed
         if: failure()

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -39,15 +39,15 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
     response = session.post(
         codex_url('/api/v1/asset_groups/'),
         json={
-            'bearing': bearing,
-            'customFields': {occ_test_cfd: 'OCC_TEST_CFD'},
             'description': 'This is a test asset group, please ignore',
-            'decimalLatitude': -39.063228,
-            'decimalLongitude': 21.832598,
-            'distance': distance,
             'sightings': [
                 {
                     'assetReferences': ['zebra.jpg'],
+                    'bearing': bearing,
+                    'customFields': {occ_test_cfd: 'OCC_TEST_CFD'},
+                    'decimalLatitude': -39.063228,
+                    'decimalLongitude': 21.832598,
+                    'distance': distance,
                     'encounters': [
                         {
                             'country': 'TEST',
@@ -144,14 +144,16 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
                 'updated': assets[0]['updated'],
             },
         ],
+        # missing 'bearing': bearing,
         'comments': 'None',
         'completion': 10,
         'createdEDM': None,
         # 2021-11-12T18:28:32.744114+00:00
         'createdHouston': response.json()['createdHouston'],
-        'customFields': {},
-        'decimalLatitude': None,
-        'decimalLongitude': None,
+        'customFields': {occ_test_cfd: 'OCC_TEST_CFD'},
+        'decimalLatitude': -39.063228,
+        'decimalLongitude': 21.832598,
+        # missing 'distance': distance,
         'encounterCounts': {},
         'encounters': [
             {
@@ -248,7 +250,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
         'createdEDM': None,
         # 2021-11-12T18:28:32.744114+00:00
         'createdHouston': response.json()['createdHouston'],
-        'customFields': {},
+        'customFields': {occ_test_cfd: 'OCC_TEST_CFD'},
         'decimalLatitude': 52.152029,
         'decimalLongitude': 2.318116,
         'encounterCounts': {},

--- a/integration_tests/test_sage_detection.py
+++ b/integration_tests/test_sage_detection.py
@@ -61,9 +61,8 @@ def test_create_asset_group_detection(session, codex_url, test_root, login):
     job_id = list(response_json['jobs'].keys())[0]
     first_job = response_json['jobs'][job_id]
     job_start = first_job['start']
-    annotation_uuids = [
-        annot['uuid']['__UUID__'] for annot in first_job['json_result']['results_list'][0]
-    ]
+    annotations = first_job['json_result']['results_list'][0]
+    annotation_uuids = [annot['uuid']['__UUID__'] for annot in annotations]
     assert response_json == {
         'assets': [
             {
@@ -89,7 +88,7 @@ def test_create_asset_group_detection(session, codex_url, test_root, login):
                     'results_list': [
                         [
                             {
-                                'id': 1,
+                                'id': annotations[0]['id'],
                                 'uuid': {'__UUID__': annotation_uuids[0]},
                                 'xtl': 178,
                                 'ytl': 72,

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -39,15 +39,15 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
     response = session.post(
         codex_url('/api/v1/asset_groups/'),
         json={
-            'bearing': bearing,
-            'customFields': {occ_test_cfd: 'OCC_TEST_CFD'},
             'description': 'This is a test asset group, please ignore',
-            'decimalLatitude': -39.063228,
-            'decimalLongitude': 21.832598,
-            'distance': distance,
             'sightings': [
                 {
                     'assetReferences': ['zebra.jpg'],
+                    'bearing': bearing,
+                    'customFields': {occ_test_cfd: 'OCC_TEST_CFD'},
+                    'decimalLatitude': -39.063228,
+                    'decimalLongitude': 21.832598,
+                    'distance': distance,
                     'encounters': [
                         {
                             'country': 'TEST',
@@ -126,20 +126,18 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
                 'updated': assets[0]['updated'],
             },
         ],
-        # FIXME missing 'bearing': bearing,
+        # REMOVED 'bearing': bearing,
         'comments': 'None',
         'createdEDM': response.json()['createdEDM'],  # 2021-11-09 11:15:24
         # 2021-11-09T11:15:24.316645+00:00
         'createdHouston': response.json()['createdHouston'],
-        # FIXME should be 'customFields': {occ_test_cfd: 'OCC_TEST_CFD'},
-        'customFields': {},
-        'decimalLatitude': 63.142385,
-        'decimalLongitude': -21.596914,
-        # FIXME missing 'distance': distance,
-        'stage': 'un_reviewed',
+        'customFields': {occ_test_cfd: 'OCC_TEST_CFD'},
+        'decimalLatitude': -39.063228,
+        'decimalLongitude': 21.832598,
+        # REMOVED 'distance': distance,
         'encounters': [
             {
-                'country': 'TEST',
+                # REMOVED 'country': 'TEST',
                 # 2021-11-09T11:15:24.343018+00:00
                 'createdHouston': encounters[0]['createdHouston'],
                 'customFields': {
@@ -171,7 +169,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
             },
         ],
         'encounterCounts': {
-            'lifeStage': {},
+            # REMOVED 'lifeStage': {},
             'sex': {'male': 1},
             'individuals': 0,
         },
@@ -182,6 +180,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
         'id': sighting_id,
         'locationId': 'PYTEST',
         'startTime': '2000-01-01T01:01:01Z',
+        'stage': 'un_reviewed',
         # FIXME missing taxonomies: [{'id': tx_id}],
         'updatedHouston': response.json()['updatedHouston'],
         'version': response.json()['version'],  # 1636456524261
@@ -233,16 +232,18 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
                 'updated': assets[0]['updated'],
             },
         ],
+        # REMOVED 'bearing': bearing,
         'comments': 'None',
         'createdEDM': response.json()['createdEDM'],  # 2021-11-16 09:45:26
         # 2021-11-16T09:45:26.717326+00:00
         'createdHouston': response.json()['createdHouston'],
-        'customFields': {},
+        'customFields': {occ_test_cfd: 'OCC_TEST_CFD'},
         'decimalLatitude': 52.152029,
         'decimalLongitude': 2.318116,
+        # REMOVED 'distance': distance,
         'encounters': [
             {
-                'country': 'TEST',
+                # REMOVED 'country': 'TEST',
                 'createdHouston': encounters[0]['createdHouston'],
                 'customFields': {
                     enc_test_cfd: 'CFD_TEST_VALUE',
@@ -273,7 +274,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
             },
         ],
         'encounterCounts': {
-            'lifeStage': {},
+            # REMOVED 'lifeStage': {},
             'sex': {'male': 1},
             'individuals': 0,
         },


### PR DESCRIPTION
`bearing`, `customFields`, `decimalLatitude`, `decimalLongitude` and
`distance` are fields in sighting instead of asset group.

This caused the values to not go through and not returned in GET.  These
are now returned in the sightings GET API.

