### PR TITLE
DEX-514: merge conflicts/overrides

### DIFF
--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -36,7 +36,7 @@ class EDMManager(RestManager):
     ENDPOINT_PREFIX = 'api'
 
     # this is based on edm date of most recent commit (we must be at or greater than this)
-    MIN_VERSION = '2021-11-18 00:01:02 -0700'
+    MIN_VERSION = '2021-11-19 12:13:14 -0700'
 
     # We use // as a shorthand for prefix
     # fmt: off

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -556,9 +556,14 @@ class Individual(db.Model, FeatherModel):
     def get_active_merge_requests(cls, user=None):
         from app.utils import get_celery_tasks_scheduled
 
-        reqs = get_celery_tasks_scheduled(
-            'app.modules.individuals.tasks.execute_merge_request'
-        )
+        try:
+            reqs = get_celery_tasks_scheduled(
+                'app.modules.individuals.tasks.execute_merge_request'
+            )
+        except NotImplementedError:
+            AuditLog.backend_fault(log, 'celery failure')
+            return []
+
         if not user:
             return reqs
         user_reqs = []

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -573,6 +573,12 @@ class User(db.Model, FeatherModel, UserEDMMixin):
         preferences = UserNotificationPreferences.get_user_preferences(self)
         return preferences
 
+    def get_individual_merge_requests(self):
+        from app.modules.individuals.models import Individual
+
+        reqs = Individual.get_active_merge_requests(self)
+        return reqs
+
     def unprocessed_asset_groups(self):
         return [
             asset_group.guid

--- a/app/modules/users/schemas.py
+++ b/app/modules/users/schemas.py
@@ -78,6 +78,7 @@ class DetailedUserSchema(UserListSchema):
 
     collaborations = base_fields.Function(User.get_collaborations_as_json)
     notification_preferences = base_fields.Function(User.get_notification_preferences)
+    individual_merge_requests = base_fields.Function(User.get_individual_merge_requests)
 
     class Meta(UserListSchema.Meta):
         fields = UserListSchema.Meta.fields + (
@@ -90,6 +91,7 @@ class DetailedUserSchema(UserListSchema):
             User.website.key,
             'notification_preferences',
             'collaborations',
+            'individual_merge_requests',
         )
 
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -64,6 +64,26 @@ def site_email_hostname():
     return dom.lower()
 
 
+# optionally filter on type
+def get_celery_tasks_scheduled(type=None):
+    from flask import current_app
+
+    inspect = current_app.celery.control.inspect()
+    workers = inspect.ping()
+    if not workers:
+        raise NotImplementedError('there are no celery workers to get data from')
+    scheduled = inspect.scheduled()
+    if not scheduled:
+        return []
+    tasks = []
+    for queue, items in scheduled.items():
+        for item in items:
+            if type and 'request' in item and item['request'].get('type') != type:
+                continue
+            tasks.append(item)
+    return tasks
+
+
 def get_celery_data(task_id):
     from flask import current_app
     from celery.result import AsyncResult

--- a/tests/modules/individuals/resources/test_merge.py
+++ b/tests/modules/individuals/resources/test_merge.py
@@ -274,6 +274,18 @@ def test_get_data_and_voting(
     assert 'request' in response.json
     assert response.json['request'].get('id') == request_id
 
+    # we also make sure the req shows up in /users/me
+    with flask_app_client.login(researcher_1, auth_scopes=('users:read',)):
+        response = flask_app_client.get('/api/v1/users/me')
+    assert response.json
+    assert 'individual_merge_requests' in response.json
+    assert len(response.json['individual_merge_requests']) > 0
+    match = False
+    for req in response.json['individual_merge_requests']:
+        if 'request' in req and req['request'].get('id') == request_id:
+            match = True
+    assert match
+
     # invalid vote (422)
     response = individual_res_utils.vote_merge_request(
         flask_app_client,

--- a/tests/modules/individuals/resources/test_merge_conflicts.py
+++ b/tests/modules/individuals/resources/test_merge_conflicts.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-docstring
+
+from tests.modules.individuals.resources import utils as individual_utils
+from tests.modules.asset_groups.resources import utils as ags_utils
+import pytest
+from tests import utils as test_utils
+import logging
+
+log = logging.getLogger(__name__)
+
+
+@pytest.mark.skipif(
+    test_utils.module_unavailable('individuals', 'encounters', 'sightings'),
+    reason='Individuals module disabled',
+)
+def test_get_conflicts(
+    db,
+    flask_app_client,
+    researcher_1,
+    researcher_2,
+    request,
+    test_root,
+):
+    # make sure anon gets 401
+    res = individual_utils.merge_conflicts(
+        flask_app_client, None, [], expected_status_code=401
+    )
+
+    # set up 2 similar individuals
+    ag, sight, individual1 = ags_utils.create_asset_group_with_sighting_and_individual(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root=test_root,
+    )
+    ag, sight, individual2 = ags_utils.create_asset_group_with_sighting_and_individual(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root=test_root,
+    )
+
+    # bunk individual data
+    res = individual_utils.merge_conflicts(
+        flask_app_client,
+        researcher_2,
+        [],
+        expected_status_code=500,
+    )
+
+    # unknown individual guid
+    res = individual_utils.merge_conflicts(
+        flask_app_client,
+        researcher_2,
+        [str(individual1.guid), '0c898eb4-b913-4080-8dc5-5caefa8a1c82'],
+        expected_status_code=404,
+    )
+
+    # no access to researcher_2
+    res = individual_utils.merge_conflicts(
+        flask_app_client,
+        researcher_2,
+        [str(individual1.guid), str(individual2.guid)],
+        expected_status_code=403,
+    )
+
+    # ok, with no conflicts
+    res = individual_utils.merge_conflicts(
+        flask_app_client,
+        researcher_1,
+        [str(individual1.guid), str(individual2.guid)],
+    )
+    assert not res
+
+    # now one with sex set
+    indiv_data = {'sex': 'male'}
+    ag, sight, individual3 = ags_utils.create_asset_group_with_sighting_and_individual(
+        flask_app_client,
+        researcher_1,
+        request,
+        individual_data=indiv_data,
+        test_root=test_root,
+    )
+    res = individual_utils.merge_conflicts(
+        flask_app_client,
+        researcher_1,
+        [str(individual1.guid), str(individual3.guid)],
+    )
+    assert res == ['sex']
+
+
+@pytest.mark.skipif(
+    test_utils.module_unavailable('individuals', 'encounters', 'sightings'),
+    reason='Individuals module disabled',
+)
+def test_overrides(
+    db,
+    flask_app_client,
+    researcher_1,
+    researcher_2,
+    request,
+    test_root,
+):
+    indiv_data = {'sex': 'male'}
+    ag, sight, individual1 = ags_utils.create_asset_group_with_sighting_and_individual(
+        flask_app_client,
+        researcher_1,
+        request,
+        individual_data=indiv_data,
+        test_root=test_root,
+    )
+    indiv_data = {'sex': 'female'}
+    ag, sight, individual2 = ags_utils.create_asset_group_with_sighting_and_individual(
+        flask_app_client,
+        researcher_1,
+        request,
+        individual_data=indiv_data,
+        test_root=test_root,
+    )
+
+    data = [str(individual2.guid)]
+    res = individual_utils.merge_individuals(
+        flask_app_client,
+        researcher_1,
+        str(individual1.guid),
+        data_in=data,
+    )
+    assert res
+    assert res.get('targetId') == str(individual1.guid)
+    assert res.get('targetSex') == 'male'
+
+    # indiv1 and indiv3 male, but override merge with female
+    indiv_data = {'sex': 'male'}
+    ag, sight, individual3 = ags_utils.create_asset_group_with_sighting_and_individual(
+        flask_app_client,
+        researcher_1,
+        request,
+        individual_data=indiv_data,
+        test_root=test_root,
+    )
+    data = {
+        'fromIndividualIds': [str(individual1.guid)],
+        'parameters': {
+            'override': {'sex': 'female'},
+        },
+    }
+    res = individual_utils.merge_individuals(
+        flask_app_client,
+        researcher_1,
+        str(individual3.guid),
+        data_in=data,
+    )
+    assert res
+    assert res.get('targetId') == str(individual3.guid)
+    assert res.get('targetSex') == 'female'

--- a/tests/modules/individuals/resources/utils.py
+++ b/tests/modules/individuals/resources/utils.py
@@ -185,3 +185,23 @@ def vote_merge_request(
         response_200=set(),
     )
     return resp
+
+
+def merge_conflicts(
+    flask_app_client,
+    user,
+    individuals,
+    auth_scopes=('individuals:write',),
+    expected_status_code=200,
+):
+    resp = test_utils.post_via_flask(
+        flask_app_client,
+        user,
+        scopes=auth_scopes,
+        path='/api/v1/individuals/merge_conflict_check',
+        data=individuals,
+        expected_status_code=expected_status_code,
+        response_200=set(),
+        returns_list=True,
+    )
+    return resp.json

--- a/tests/modules/individuals/test_merge.py
+++ b/tests/modules/individuals/test_merge.py
@@ -40,7 +40,6 @@ def test_merge(db, flask_app_client, researcher_1, request):
     response = sighting_utils.create_sighting(flask_app_client, researcher_1, data_in)
     enc1_guid = response.json['result']['encounters'][0]['id']
     enc2_guid = response.json['result']['encounters'][1]['id']
-    enc3_guid = response.json['result']['encounters'][2]['id']
     enc1 = Encounter.query.get(enc1_guid)
     enc2 = Encounter.query.get(enc1_guid)
     sighting = Sighting.query.get(response.json['result']['id'])
@@ -94,33 +93,6 @@ def test_merge(db, flask_app_client, researcher_1, request):
     assert len(indiv1.encounters) == 2
     indiv2 = Individual.query.get(indiv2_guid)  # should be gone
     assert not indiv2
-
-    # now a 3rd indiv with sex=male
-    individual_data_in['sex'] = 'male'
-    individual_data_in['names']['defaultName'] = 'NAME3'
-    individual_data_in['encounters'][0]['id'] = enc3_guid
-    individual_response = individual_res_utils.create_individual(
-        flask_app_client, researcher_1, 200, individual_data_in
-    )
-    indiv3_guid = individual_response.json['result']['id']
-
-    indiv3 = Individual.query.get(indiv3_guid)
-    assert str(indiv3.encounters[0].guid) == enc3_guid
-    enc3 = Encounter.query.get(enc3_guid)
-    assert enc3.individual_guid == indiv3.guid
-    request.addfinalizer(enc3.delete_cascade)
-    request.addfinalizer(
-        lambda: individual_res_utils.delete_individual(
-            flask_app_client, researcher_1, indiv3.guid
-        )
-    )
-
-    resp = indiv1.merge_from(indiv3)
-    assert not resp.ok
-    assert resp.status_code == 500
-    json = resp.json()
-    assert 'errorFields' in json
-    assert 'sex' in json['errorFields']
 
 
 @pytest.mark.skipif(

--- a/tests/modules/users/resources/test_signup.py
+++ b/tests/modules/users/resources/test_signup.py
@@ -272,6 +272,7 @@ def test_new_user_creation_roles_admin(flask_app_client, admin_user, db):
         'viewed': response.json['viewed'],
         'website': None,
         'collaborations': [],
+        'individual_merge_requests': [],
         'notification_preferences': NOTIFICATION_DEFAULTS,
     }
 

--- a/tests/modules/users/test_schemas.py
+++ b/tests/modules/users/test_schemas.py
@@ -54,6 +54,7 @@ def test_DetailedUserSchema_dump_user_instance(user_instance):
         'forum_id',
         'website',
         'collaborations',
+        'individual_merge_requests',
         'notification_preferences',
     }
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -300,6 +300,7 @@ def post_via_flask(
     expected_status_code,
     response_200,
     expected_error=None,
+    returns_list=False,
 ):
 
     if user:
@@ -316,7 +317,12 @@ def post_via_flask(
             data=json.dumps(data),
         )
 
-    if expected_status_code == 200:
+    if returns_list:
+        if response.status_code == 200:
+            validate_list_response(response, expected_status_code)
+        else:  # this assumes non-200 does *not* return a list
+            assert response.status_code == expected_status_code
+    elif expected_status_code == 200:
         validate_dict_response(response, 200, response_200)
     elif expected_status_code:
         validate_dict_response(response, expected_status_code, {'status', 'message'})


### PR DESCRIPTION
## Pull Request Overview

- Handles **Individual merge** _"conflicts"_ in the following manner:
  - Target Individual will keep values the same as prior to merge (effectively beating out values from other Individuals)...
  - Unless specific **override values** are passed along with the merge
- A new API is provided to query _which fields_ present conflicts between N individuals
- Addition to `/api/v1/users/me` provides `individual_merge_requests: [...]` _(Originally intended for DEX-513)_

---

**Review Notes**
- This behavior is specifically for MVP and only takes into account `sex` and `names` as properties which are considered for conflict resolution
- **Name resolution is currently incomplete**, pending decisions about how names will work in next-gen new world.


**REST API Updates**

When performing a **merge among Individuals** a new format of data will allow for the inclusion _override values_ for properties.  (This is in addition to the previous list of Individual guids, which is still allowed.)

```
POST /api/v1/individuals/TARGET_GUID/merge
{
    "fromIndividualIds": [ FROM_INDIV_GUID_1, FROM_INDIV_GUID_2, ... ],
    "parameters": {
        "override": { "sex": "female" }
    }
}
```

This is the API to query for conflicts among Individuals.  POST a list of Individual guids and a get a list of field names that conflict (or an empty list if none).  This means for the listed properties there is not a single universal value for all Individuals.

```
POST /api/v1/individuals/TARGET_GUID/merge
[ INDIV_GUID_1, INDIV_GUID_2, ... ]

Result:
[ "sex" ]
```
