### PR TITLE
DEX-553 collaboration user data in list response

### DIFF
--- a/app/modules/collaborations/schemas.py
+++ b/app/modules/collaborations/schemas.py
@@ -15,12 +15,14 @@ class BaseCollaborationSchema(ModelSchema):
     Base Collaboration schema exposes only the most general fields.
     """
 
+    members = base_fields.Function(Collaboration.get_user_data_as_json)
+
     class Meta:
         # pylint: disable=missing-docstring
         model = Collaboration
         fields = (
             Collaboration.guid.key,
-            Collaboration.user_guids.__name__,
+            'members',
         )
         dump_only = (Collaboration.guid.key,)
 
@@ -30,13 +32,10 @@ class DetailedCollaborationSchema(BaseCollaborationSchema):
     Detailed Collaboration schema exposes all useful fields.
     """
 
-    members = base_fields.Function(Collaboration.get_user_data_as_json)
-
     class Meta(BaseCollaborationSchema.Meta):
         fields = BaseCollaborationSchema.Meta.fields + (
             Collaboration.created.key,
             Collaboration.updated.key,
-            'members',
         )
         dump_only = BaseCollaborationSchema.Meta.dump_only + (
             Collaboration.created.key,

--- a/integration_tests/test_collaborations.py
+++ b/integration_tests/test_collaborations.py
@@ -25,7 +25,6 @@ def test_collaboration(session, codex_url, login, logout, admin_email):
         json={'user_guid': new_user_guid},
     )
     assert response.status_code == 200
-    assert sorted(response.json()['user_guids']) == sorted([new_user_guid, my_guid])
     assert set(response.json()['members'].keys()) == {new_user_guid, my_guid}
     assert response.json()['members'][my_guid]['viewState'] == 'approved'
     assert response.json()['members'][my_guid]['editState'] == 'not_initiated'
@@ -44,8 +43,8 @@ def test_collaboration(session, codex_url, login, logout, admin_email):
         json={'user_guid': new_user_guid, 'second_user_guid': new_user_guid_2},
     )
     assert response.status_code == 200
-    assert sorted(response.json()['user_guids']) == sorted(
-        [new_user_guid, new_user_guid_2]
+    assert set(sorted(response.json()['members'].keys())) == set(
+        {new_user_guid, new_user_guid_2}
     )
     assert response.json()['members'][new_user_guid]['viewState'] == 'approved'
     assert response.json()['members'][new_user_guid]['editState'] == 'not_initiated'

--- a/tests/modules/collaborations/resources/test_collaboration_create.py
+++ b/tests/modules/collaborations/resources/test_collaboration_create.py
@@ -49,7 +49,7 @@ def test_create_collaboration(
 
         # which should contain the same Users
         assert len(all_resp.json) == 2
-        assert set(all_resp.json[0]['user_guids']) == set(
+        assert set(all_resp.json[0]['members'].keys()) == set(
             {str(readonly_user.guid), str(researcher_2.guid)}
         )
 

--- a/tests/modules/collaborations/resources/utils.py
+++ b/tests/modules/collaborations/resources/utils.py
@@ -80,7 +80,7 @@ def read_collaboration(
         scopes='collaborations:read',
         path=f'{PATH}{collaboration_guid}',
         expected_status_code=expected_status_code,
-        response_200={'guid'},
+        response_200={'members', 'guid'},
     )
 
 
@@ -95,7 +95,7 @@ def read_all_collaborations(
         scopes='collaborations:read',
         path=PATH,
         expected_status_code=expected_status_code,
-        expected_fields={'user_guids', 'guid'},
+        expected_fields={'members', 'guid'},
     )
 
 
@@ -121,12 +121,9 @@ def request_edit(
 def validate_expected_states(json_data, expected_states):
     # Check collab is in the state we expect
     members = json_data.get('members')
-    users = json_data.get('user_guids', {})
     assert members
     assert len(members) == len(expected_states)
-    assert len(members) == len(users)
     for expected_user_guid in expected_states.keys():
-        assert str(expected_user_guid) in users
         for expected_state in expected_states[expected_user_guid].keys():
             assert (
                 members[str(expected_user_guid)][expected_state]


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Collaboration member details in the full collaboration list (just promoted members to the base Schema from detailed)
- Removed the user guids from the base class as now superfluous

---


**REST API Updates **
Response to collaborations get is now:

[
    {
	'guid': 'f2eeef5f-963b-46fc-b27e-b263ace961d4',
	'members': {
	    '39fa22ed-8832-42a6-8210-78b06aab7b53':
	    {
		'full_name': 'First Middle Last',
		'guid': '39fa22ed-8832-42a6-8210-78b06aab7b53',
		'email': 'researcher2@localhost',
		'viewState': 'approved',
		'editState': 'not_initiated'
	    },
	    'fcb1dba2-376a-452f-b60a-abc5c8c6b670': 
	    {
		'full_name': 'First Middle Last',
		'guid': 'fcb1dba2-376a-452f-b60a-abc5c8c6b670',
		'email': 'readonly@localhost',
		'viewState': 'pending',
		'editState': 'not_initiated'
	    }
	}
    },
]

and if anyone can show me how to persuade github to not auto-format the above I'd be keen to know
