### PR TITLE
DEX-559: missing comments in AssetGroupSighting GET and PATCH

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -592,6 +592,8 @@ class AssetGroupSighting(db.Model, HoustonModel):
     # Used to build the response to AssetGroupSighting GET
     def get_assets(self):
         assets = []
+        if not self.config.get('assetReferences'):
+            return assets
         for filename in self.config.get('assetReferences'):
             asset = self.asset_group.get_asset_for_file(filename)
             assert asset

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -343,6 +343,8 @@ class AssetGroupSighting(db.Model, HoustonModel):
 
     def check_all_job_status(self):
         jobs = self.jobs
+        if not jobs:
+            return
         for job_id in jobs.keys():
             job = jobs[job_id]
             if job['active']:

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -23,6 +23,7 @@ SIGHTING_FIELDS_IN_AGS_CONFIG = {
     'verbatimLocality',
     'encounterCounts',
     'id',
+    'comments',
     'featuredAssetGuid',
 }
 
@@ -131,11 +132,12 @@ class AssetGroupSightingAsSightingSchema(AugmentedEdmSightingSchema):
         AssetGroupSighting.config_field_getter('featuredAssetGuid')
     )
     sightingGuid = base_fields.Function(AssetGroupSighting.get_sighting_guid)
-
+    comments = base_fields.Function(
+        AssetGroupSighting.config_field_getter('comments', default=None)
+    )
     # These are fields that are in Sighting but don't exist for
     # AssetGroupSighting
     createdEDM = base_fields.DateTime(default=None)
-    comments = base_fields.String(default='None')
     customFields = base_fields.Dict(attribute='get_custom_fields')
     version = base_fields.String(default=None)
 

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -192,6 +192,8 @@ class Sighting(db.Model, FeatherModel):
 
     def check_all_job_status(self):
         jobs = self.jobs
+        if not jobs:
+            return
         for job_id in jobs.keys():
             job = jobs[job_id]
             if job['active']:

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -138,7 +138,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
                 'updated': assets[0]['updated'],
             },
         ],
-        'comments': 'None',
+        'comments': None,
         'completion': 10,
         'createdEDM': None,
         # 2021-11-12T18:28:32.744114+00:00
@@ -243,7 +243,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
                 'updated': assets[0]['updated'],
             },
         ],
-        'comments': 'None',
+        'comments': None,
         'completion': 10,
         'createdEDM': None,
         # 2021-11-12T18:28:32.744114+00:00


### PR DESCRIPTION
## Pull Request Overview

- Small schema change to allow `comments` to be properly processed in PATCH and GET of AssetGroupSighting
- _Bonus_: two small fixes having to do with values which turned out to possibly be `None`