### PR TITLE
DEX 560 add upload type to unprocessed asset group list in users/me

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -784,6 +784,9 @@ class AssetGroup(db.Model, HoustonModel):
                     mime_type_file.write(json.dumps(mime_type_whitelist_dict))
         return self._mime_type_whitelist_guid
 
+    def get_config_field(self, field):
+        return self.config.get(field) if isinstance(self.config, dict) else None
+
     def _ensure_repository_files(self):
         group_path = self.get_absolute_path()
 

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -581,7 +581,10 @@ class User(db.Model, FeatherModel, UserEDMMixin):
 
     def unprocessed_asset_groups(self):
         return [
-            asset_group.guid
+            {
+                'uuid': str(asset_group.guid),
+                'uploadType': asset_group.get_config_field('uploadType'),
+            }
             for asset_group in self.asset_groups
             if not asset_group.is_processed()
         ]

--- a/tests/modules/asset_groups/resources/test_create_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_create_asset_group.py
@@ -529,10 +529,17 @@ def test_create_bulk_asset_group(flask_app_client, researcher_1, test_root, db, 
 
         # Make sure that the user has the group and it's in the correct state
         user_resp = user_utils.read_user(flask_app_client, researcher_1, 'me')
+
         assert 'unprocessed_asset_groups' in user_resp.json
         # Not being too rigid in the validation as sporadically '00000000-0000-0000-0000-000000000003'
         # is also in there
-        assert asset_group_uuid in user_resp.json['unprocessed_asset_groups']
+        group_data = [
+            group
+            for group in user_resp.json['unprocessed_asset_groups']
+            if group['uuid'] == asset_group_uuid
+        ]
+        assert len(group_data) == 1
+        assert group_data[0]['uploadType'] == 'bulk'
 
     finally:
         if asset_group_uuid:


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- As requested in DEX 560, unprocessed_asset_group_sightings now contains the type as well 
example below
---
[{'uuid': '67adee5d-cc81-413f-8d32-275e661a1c80', 'uploadType': 'bulk'}]

