### PR TITLE
Use wildme/wildbook-ia:latest instead of nightly

### DIFF
--- a/docker-compose.codex.yml
+++ b/docker-compose.codex.yml
@@ -60,7 +60,7 @@ services:
 
   acm:
     # https://github.com/WildMeOrg/wildbook-ia
-    image: wildme/wildbook-ia:nightly
+    image: wildme/wildbook-ia:latest
     # FIXME: Adjust entrypoint to allow for additive command arguments
     # , "--db-uri", "${WBIA_DB_URI}"
     command: [ "wait-for", "db:5432", "--", "python3.7", "-m", "wbia.dev", "--dbdir", "${WBIA_DB_DIR}", "--logdir", "/data/logs/", "--web", "--port", "5000", "--web-deterministic-ports", "--containerized", "--cpudark", "--production"]


### PR DESCRIPTION
We were using the nightly build because latest wasn't up to date enough
but right now nightly is broken, so change it back to latest for now.

