### PR TITLE
Remove hard coded values for BASE_URL and SENTRY_DSN

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 .git*
 .dockerignore
+.env
 .DS_Store
 
 .github/

--- a/config/codex.py
+++ b/config/codex.py
@@ -107,7 +107,7 @@ class BaseCodexConfig(
 
 
 class ProductionConfig(BaseCodexConfig):
-    BASE_URL = 'https://houston.dyn.wildme.io/'
+    BASE_URL = os.environ.get('HOUSTON_URL')
 
     MAIL_BASE_URL = BASE_URL
     MAIL_OVERRIDE_RECIPIENTS = None

--- a/config/codex.py
+++ b/config/codex.py
@@ -115,7 +115,7 @@ class ProductionConfig(BaseCodexConfig):
         'mail-errors@wildme.org',
     ]
 
-    SENTRY_DSN = 'https://140fc4d010bb43b28417ab57b0e41b44@sentry.dyn.wildme.io/3'
+    SENTRY_DSN = os.getenv('SENTRY_DSN')
 
 
 class DevelopmentConfig(BaseCodexConfig):

--- a/config/mws.py
+++ b/config/mws.py
@@ -83,7 +83,7 @@ class BaseMWSConfig(
 class ProductionConfig(BaseMWSConfig):
     TESTING = False
 
-    BASE_URL = 'https://houston.dyn.wildme.io/'
+    BASE_URL = os.environ.get('HOUSTON_URL')
 
     MAIL_BASE_URL = BASE_URL
     MAIL_OVERRIDE_RECIPIENTS = None

--- a/config/mws.py
+++ b/config/mws.py
@@ -91,7 +91,7 @@ class ProductionConfig(BaseMWSConfig):
         'parham@wildme.org',
     ]
 
-    SENTRY_DSN = 'https://140fc4d010bb43b28417ab57b0e41b44@sentry.dyn.wildme.io/3'
+    SENTRY_DSN = os.getenv('SENTRY_DSN')
 
 
 class DevelopmentConfig(BaseMWSConfig):


### PR DESCRIPTION
This attempts to unhardcode values in the config. 

IMHO this is a temporary workaround. Ideally `BASE_URL` gets removed in favor of Flask's `SERVER_NAME` (see also notes in #342 ).

I'll come back to putting in the ideal fix at a later time. Right now it's my prerogative to simply allow for multiple production like deployments, which means removal of the hard coded production configuration values.

And sneaking in a file ignore for the docker container. This removes the `.env` file from the built container.