### PR TITLE
578 asset group rework

### DIFF
--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -64,14 +64,14 @@ def create_asset_group(session, codex_url, data):
     assert set(json_resp.keys()) >= set(
         {'guid', 'assets', 'asset_group_sightings', 'major_type', 'description'}
     )
-    asset_guid = json_resp['guid']
+    group_guid = json_resp['guid']
     asset_guids = [asset['guid'] for asset in json_resp['assets']]
     ags_guids = [ags['guid'] for ags in json_resp['asset_group_sightings']]
     assert len(ags_guids) == len(data['sightings'])
 
     assert json_resp['major_type'] == 'filesystem'
     assert json_resp['description'] == data['description']
-    return asset_guid, ags_guids, asset_guids
+    return group_guid, ags_guids, asset_guids
 
 
 def wait_for(

--- a/tests/modules/asset_groups/resources/test_commit_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_commit_asset_group.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 import tests.modules.asset_groups.resources.utils as asset_group_utils
-import tests.extensions.tus.utils as tus_utils
 from tests import utils as test_utils
 import pytest
 
@@ -12,70 +11,59 @@ from tests.utils import module_unavailable
 @pytest.mark.skipif(
     module_unavailable('asset_groups'), reason='AssetGroups module disabled'
 )
-def test_commit_asset_group(flask_app_client, researcher_1, regular_user, test_root, db):
+def test_commit_asset_group(
+    flask_app_client, researcher_1, regular_user, test_root, request, db
+):
     # pylint: disable=invalid-name
-    from tests.modules.asset_groups.resources.utils import AssetGroupCreationData
     from app.modules.sightings.models import Sighting, SightingStage
 
-    transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
-    asset_group_uuid = None
-    try:
-        data = AssetGroupCreationData(transaction_id)
-        data.add_filename(0, test_filename)
-        response = asset_group_utils.create_asset_group(
-            flask_app_client, regular_user, data.get()
-        )
-        asset_group_uuid = response.json['guid']
-        asset_group_sighting_guid = response.json['asset_group_sightings'][0]['guid']
-        asset_uuid = response.json['assets'][0]['guid']
-        asset_group_utils.patch_in_dummy_annotation(
-            flask_app_client, db, researcher_1, asset_group_sighting_guid, asset_uuid
-        )
+    (
+        asset_group_uuid,
+        asset_group_sighting_guid,
+        asset_uuid,
+    ) = asset_group_utils.create_simple_asset_group(
+        flask_app_client, regular_user, request, test_root
+    )
 
-        # Should not be able to commit as contributor
-        asset_group_utils.commit_asset_group_sighting(
-            flask_app_client, regular_user, asset_group_sighting_guid, 403
-        )
-        # researcher should though
-        response = asset_group_utils.commit_asset_group_sighting(
-            flask_app_client, researcher_1, asset_group_sighting_guid
-        )
+    asset_group_utils.patch_in_dummy_annotation(
+        flask_app_client, db, researcher_1, asset_group_sighting_guid, asset_uuid
+    )
 
-        sighting_uuid = response.json['guid']
-        sighting = Sighting.query.get(sighting_uuid)
-        assert sighting.stage == SightingStage.un_reviewed
-        assert len(sighting.get_encounters()) == 1
-        assert len(sighting.get_assets()) == 1
-        assert sighting.get_owner() == regular_user
-        group_sighting = asset_group_utils.read_asset_group_sighting(
-            flask_app_client, researcher_1, asset_group_sighting_guid
-        )
-        assert set(group_sighting.json.keys()) >= set(
-            {
-                'completion',
-                'asset_group_guid',
-                'assets',
-                'stage',
-                'creator',
-                'jobs',
-                'config',
-                'guid',
-                'sighting_guid',
-            }
-        )
-        assert group_sighting.json['completion'] == 76
-        assert group_sighting.json['asset_group_guid'] == asset_group_uuid
-        assert group_sighting.json['creator']['guid'] == str(regular_user.guid)
-        assert group_sighting.json['sighting_guid'] == sighting_uuid
+    # Should not be able to commit as contributor
+    asset_group_utils.commit_asset_group_sighting(
+        flask_app_client, regular_user, asset_group_sighting_guid, 403
+    )
+    # researcher should though
+    response = asset_group_utils.commit_asset_group_sighting(
+        flask_app_client, researcher_1, asset_group_sighting_guid
+    )
 
-    finally:
-        # Restore original state
-        if asset_group_uuid:
-            asset_group_utils.delete_asset_group(
-                flask_app_client, regular_user, asset_group_uuid
-            )
-
-        tus_utils.cleanup_tus_dir(transaction_id)
+    sighting_uuid = response.json['guid']
+    sighting = Sighting.query.get(sighting_uuid)
+    assert sighting.stage == SightingStage.un_reviewed
+    assert len(sighting.get_encounters()) == 1
+    assert len(sighting.get_assets()) == 1
+    assert sighting.get_owner() == regular_user
+    group_sighting = asset_group_utils.read_asset_group_sighting(
+        flask_app_client, researcher_1, asset_group_sighting_guid
+    )
+    assert set(group_sighting.json.keys()) >= set(
+        {
+            'completion',
+            'asset_group_guid',
+            'assets',
+            'stage',
+            'creator',
+            'jobs',
+            'config',
+            'guid',
+            'sighting_guid',
+        }
+    )
+    assert group_sighting.json['completion'] == 76
+    assert group_sighting.json['asset_group_guid'] == asset_group_uuid
+    assert group_sighting.json['creator']['guid'] == str(regular_user.guid)
+    assert group_sighting.json['sighting_guid'] == sighting_uuid
 
 
 @pytest.mark.skipif(
@@ -128,75 +116,67 @@ def test_commit_owner_asset_group(
     module_unavailable('asset_groups'), reason='AssetGroups module disabled'
 )
 def test_commit_asset_group_ia(
-    flask_app_client, researcher_1, regular_user, test_root, db
+    flask_app_client, researcher_1, regular_user, test_root, db, request
 ):
     # pylint: disable=invalid-name
-    from tests.modules.asset_groups.resources.utils import AssetGroupCreationData
     from app.modules.sightings.models import Sighting, SightingStage
 
-    transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
-    asset_group_uuid = None
-    try:
-        data = AssetGroupCreationData(transaction_id)
-        data.add_filename(0, test_filename)
-        response = asset_group_utils.create_asset_group(
-            flask_app_client, regular_user, data.get()
-        )
-        asset_group_uuid = response.json['guid']
-        asset_group_sighting_guid = response.json['asset_group_sightings'][0]['guid']
-        asset_uuid = response.json['assets'][0]['guid']
-        asset_group_utils.patch_in_dummy_annotation(
-            flask_app_client, db, researcher_1, asset_group_sighting_guid, asset_uuid
-        )
+    (
+        asset_group_uuid,
+        asset_group_sighting_guid,
+        asset_uuid,
+    ) = asset_group_utils.create_simple_asset_group(
+        flask_app_client, regular_user, request, test_root
+    )
 
-        ia_configs = [
-            {
-                'algorithms': [
-                    'hotspotter_nosv',
-                ],
-            }
-        ]
-        patch_data = [test_utils.patch_replace_op('idConfigs', ia_configs)]
-        resp = f'matchingSetDataOwners field missing from Sighting {asset_group_sighting_guid}'
-        asset_group_utils.patch_asset_group_sighting(
-            flask_app_client,
-            researcher_1,
-            asset_group_sighting_guid,
-            patch_data,
-            400,
-            resp,
-        )
-        ia_configs[0]['matchingSetDataOwners'] = 'someone_elses'
-        patch_data = [test_utils.patch_replace_op('idConfigs', ia_configs)]
-        resp = "dataOwners someone_elses not supported, only support ['mine', 'extended', 'all']"
-        asset_group_utils.patch_asset_group_sighting(
-            flask_app_client,
-            researcher_1,
-            asset_group_sighting_guid,
-            patch_data,
-            400,
-            resp,
-        )
-        ia_configs[0]['matchingSetDataOwners'] = 'mine'
-        patch_data = [test_utils.patch_replace_op('idConfigs', ia_configs)]
-        asset_group_utils.patch_asset_group_sighting(
-            flask_app_client, researcher_1, asset_group_sighting_guid, patch_data, 200
-        )
+    asset_group_utils.patch_in_dummy_annotation(
+        flask_app_client, db, researcher_1, asset_group_sighting_guid, asset_uuid
+    )
 
-        response = asset_group_utils.commit_asset_group_sighting(
-            flask_app_client, researcher_1, asset_group_sighting_guid
-        )
-        sighting_uuid = response.json['guid']
-        sighting = Sighting.query.get(sighting_uuid)
-        assert sighting.stage == SightingStage.un_reviewed
-    finally:
-        # Restore original state
-        if asset_group_uuid:
-            asset_group_utils.delete_asset_group(
-                flask_app_client, regular_user, asset_group_uuid
-            )
+    ia_configs = [
+        {
+            'algorithms': [
+                'hotspotter_nosv',
+            ],
+        }
+    ]
+    patch_data = [test_utils.patch_replace_op('idConfigs', ia_configs)]
+    resp = (
+        f'matchingSetDataOwners field missing from Sighting {asset_group_sighting_guid}'
+    )
+    asset_group_utils.patch_asset_group_sighting(
+        flask_app_client,
+        researcher_1,
+        asset_group_sighting_guid,
+        patch_data,
+        400,
+        resp,
+    )
+    ia_configs[0]['matchingSetDataOwners'] = 'someone_elses'
+    patch_data = [test_utils.patch_replace_op('idConfigs', ia_configs)]
+    resp = (
+        "dataOwners someone_elses not supported, only support ['mine', 'extended', 'all']"
+    )
+    asset_group_utils.patch_asset_group_sighting(
+        flask_app_client,
+        researcher_1,
+        asset_group_sighting_guid,
+        patch_data,
+        400,
+        resp,
+    )
+    ia_configs[0]['matchingSetDataOwners'] = 'mine'
+    patch_data = [test_utils.patch_replace_op('idConfigs', ia_configs)]
+    asset_group_utils.patch_asset_group_sighting(
+        flask_app_client, researcher_1, asset_group_sighting_guid, patch_data, 200
+    )
 
-        tus_utils.cleanup_tus_dir(transaction_id)
+    response = asset_group_utils.commit_asset_group_sighting(
+        flask_app_client, researcher_1, asset_group_sighting_guid
+    )
+    sighting_uuid = response.json['guid']
+    sighting = Sighting.query.get(sighting_uuid)
+    assert sighting.stage == SightingStage.un_reviewed
 
 
 @pytest.mark.skipif(

--- a/tests/modules/asset_groups/resources/test_create_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_create_asset_group.py
@@ -22,7 +22,7 @@ def test_create_asset_group(flask_app_client, researcher_1, readonly_user, test_
     asset_group_uuid = None
 
     try:
-        data = AssetGroupCreationData(transaction_id, False)
+        data = AssetGroupCreationData(transaction_id, populate_default=False)
         data.set_field('uploadType', 'form')
         data.set_field('description', 'This is a test asset_group, please ignore')
 
@@ -140,8 +140,7 @@ def test_create_asset_group_2_assets(flask_app_client, researcher_1, test_root, 
     tus_utils.prep_tus_dir(test_root, filename='coelacanth.png')
     asset_group_uuid = None
     try:
-        data = AssetGroupCreationData(transaction_id)
-        data.add_filename(0, test_filename)
+        data = AssetGroupCreationData(transaction_id, test_filename)
         data.add_filename(0, 'coelacanth.png')
         resp = asset_group_utils.create_asset_group(
             flask_app_client, researcher_1, data.get()
@@ -215,7 +214,7 @@ def test_create_asset_group_anonymous(
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     asset_group_uuid = None
     try:
-        data = AssetGroupCreationData(transaction_id)
+        data = AssetGroupCreationData(transaction_id, test_filename)
         data.add_filename(0, test_filename)
         data.set_field('submitterEmail', researcher_1.email)
         resp_msg = 'Invalid submitter data'
@@ -266,8 +265,7 @@ def no_test_create_asset_group_detection(
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
 
-    data = AssetGroupCreationData(transaction_id)
-    data.add_filename(0, test_filename)
+    data = AssetGroupCreationData(transaction_id, test_filename)
     data.set_field('speciesDetectionModel', ['african_terrestrial'])
     resp = asset_group_utils.create_asset_group(
         flask_app_client, researcher_1, data.get()
@@ -309,8 +307,7 @@ def test_create_asset_group_sim_detection(
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     asset_group_uuid = None
     try:
-        data = AssetGroupCreationData(transaction_id)
-        data.add_filename(0, test_filename)
+        data = AssetGroupCreationData(transaction_id, test_filename)
         data.set_field('speciesDetectionModel', ['african_terrestrial'])
 
         # Simulate a valid response from Sage but don't actually send the request to Sage
@@ -560,8 +557,7 @@ def test_create_asset_group_individual(
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     asset_group_uuid = None
     try:
-        data = AssetGroupCreationData(transaction_id)
-        data.add_filename(0, test_filename)
+        data = AssetGroupCreationData(transaction_id, test_filename)
         dummy_uuid = str(uuid.uuid4())
         data.set_encounter_field(0, 0, 'individualUuid', dummy_uuid)
         resp_msg = f'Encounter 1.1 individual {dummy_uuid} not found'

--- a/tests/modules/asset_groups/resources/test_patch_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_patch_asset_group.py
@@ -4,9 +4,6 @@ import uuid
 import copy
 
 import tests.modules.asset_groups.resources.utils as asset_group_utils
-import tests.extensions.tus.utils as tus_utils
-
-from tests.modules.asset_groups.resources.utils import AssetGroupCreationData
 from tests import utils
 import pytest
 
@@ -18,111 +15,100 @@ from tests.utils import module_unavailable
     module_unavailable('asset_groups'), reason='AssetGroups module disabled'
 )
 def test_patch_asset_group(
-    flask_app_client, researcher_1, regular_user, test_root, db, empty_individual
+    flask_app_client, researcher_1, regular_user, test_root, db, empty_individual, request
 ):
     # pylint: disable=invalid-name
 
-    transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
-    asset_group_uuid = None
-    try:
-        data = AssetGroupCreationData(transaction_id)
-        data.add_filename(0, test_filename)
-        response = asset_group_utils.create_asset_group(
-            flask_app_client, regular_user, data.get()
-        )
-        asset_group_uuid = response.json['guid']
-        asset_group_sighting_guid = response.json['asset_group_sightings'][0]['guid']
+    (
+        asset_group_guid,
+        asset_group_sighting_guid,
+        asset_guid,
+    ) = asset_group_utils.create_simple_asset_group(
+        flask_app_client, regular_user, request, test_root
+    )
 
-        # Regular user can create it but not read it??????
-        asset_group_utils.read_asset_group_sighting(
-            flask_app_client, regular_user, asset_group_sighting_guid, 403
-        )
+    # Regular user can create it but not read it??????
+    asset_group_utils.read_asset_group_sighting(
+        flask_app_client, regular_user, asset_group_sighting_guid, 403
+    )
 
-        # Researcher should be able to
-        group_sighting = asset_group_utils.read_asset_group_sighting(
-            flask_app_client, researcher_1, asset_group_sighting_guid
-        )
-        assert 'completion' in group_sighting.json
-        assert group_sighting.json['completion'] == 10
-        assert 'config' in group_sighting.json
-        assert 'assetReferences' in group_sighting.json['config']
+    # Researcher should be able to
+    group_sighting = asset_group_utils.read_asset_group_sighting(
+        flask_app_client, researcher_1, asset_group_sighting_guid
+    )
+    assert 'completion' in group_sighting.json
+    assert group_sighting.json['completion'] == 10
+    assert 'config' in group_sighting.json
+    assert 'assetReferences' in group_sighting.json['config']
 
-        new_absent_file = copy.deepcopy(group_sighting.json['config']['assetReferences'])
-        new_absent_file.append('absent_file.jpg')
-        patch_data = [utils.patch_replace_op('assetReferences', new_absent_file)]
-        expected_resp = f'absent_file.jpg not in Group for assetGroupSighting {asset_group_sighting_guid}'
-        asset_group_utils.patch_asset_group_sighting(
-            flask_app_client,
-            researcher_1,
-            asset_group_sighting_guid,
-            patch_data,
-            400,
-            expected_resp,
-        )
+    new_absent_file = copy.deepcopy(group_sighting.json['config']['assetReferences'])
+    new_absent_file.append('absent_file.jpg')
+    patch_data = [utils.patch_replace_op('assetReferences', new_absent_file)]
+    expected_resp = (
+        f'absent_file.jpg not in Group for assetGroupSighting {asset_group_sighting_guid}'
+    )
+    asset_group_utils.patch_asset_group_sighting(
+        flask_app_client,
+        researcher_1,
+        asset_group_sighting_guid,
+        patch_data,
+        400,
+        expected_resp,
+    )
 
-        # Valid patch, adding a new encounter with an existing file
-        new_encounters = copy.deepcopy(group_sighting.json['config']['encounters'])
-        new_encounters.append({})
-        patch_data = [utils.patch_replace_op('encounters', new_encounters)]
+    # Valid patch, adding a new encounter with an existing file
+    new_encounters = copy.deepcopy(group_sighting.json['config']['encounters'])
+    new_encounters.append({})
+    patch_data = [utils.patch_replace_op('encounters', new_encounters)]
 
-        # Should not work as contributor
-        asset_group_utils.patch_asset_group_sighting(
-            flask_app_client, regular_user, asset_group_sighting_guid, patch_data, 403
-        )
+    # Should not work as contributor
+    asset_group_utils.patch_asset_group_sighting(
+        flask_app_client, regular_user, asset_group_sighting_guid, patch_data, 403
+    )
 
-        # should work as researcher
-        asset_group_utils.patch_asset_group_sighting(
-            flask_app_client, researcher_1, asset_group_sighting_guid, patch_data
-        )
+    # should work as researcher
+    asset_group_utils.patch_asset_group_sighting(
+        flask_app_client, researcher_1, asset_group_sighting_guid, patch_data
+    )
 
-        # chosen for reasons of incongruity as the naked mole rat is virtually blind
-        # so has no 'sight'
-        add_name_patch = [utils.patch_add_op('name', 'Naked Mole Rat')]
-        asset_group_utils.patch_asset_group_sighting(
-            flask_app_client, researcher_1, asset_group_sighting_guid, add_name_patch
-        )
+    # chosen for reasons of incongruity as the naked mole rat is virtually blind
+    # so has no 'sight'
+    add_name_patch = [utils.patch_add_op('name', 'Naked Mole Rat')]
+    asset_group_utils.patch_asset_group_sighting(
+        flask_app_client, researcher_1, asset_group_sighting_guid, add_name_patch
+    )
 
-        # invalid patch, encounter has individualuuid of nonsense
-        encounter_guid = group_sighting.json['config']['encounters'][0]['guid']
-        patch_data = [utils.patch_add_op('individualUuid', '8037460')]
-        expected_resp = f'Encounter {encounter_guid} individual 8037460 not valid'
-        path = f'{asset_group_sighting_guid}/encounter/{encounter_guid}'
-        asset_group_utils.patch_asset_group_sighting(
-            flask_app_client, researcher_1, path, patch_data, 400, expected_resp
-        )
+    # invalid patch, encounter has individualuuid of nonsense
+    encounter_guid = group_sighting.json['config']['encounters'][0]['guid']
+    patch_data = [utils.patch_add_op('individualUuid', '8037460')]
+    expected_resp = f'Encounter {encounter_guid} individual 8037460 not valid'
+    path = f'{asset_group_sighting_guid}/encounter/{encounter_guid}'
+    asset_group_utils.patch_asset_group_sighting(
+        flask_app_client, researcher_1, path, patch_data, 400, expected_resp
+    )
 
-        # invalid patch, encounter has invalid individualuuid
-        invalid_uuid = str(uuid.uuid4())
+    # invalid patch, encounter has invalid individualuuid
+    invalid_uuid = str(uuid.uuid4())
 
-        patch_data = [utils.patch_add_op('individualUuid', invalid_uuid)]
-        expected_resp = f'Encounter {encounter_guid} individual {invalid_uuid} not found'
-        path = f'{asset_group_sighting_guid}/encounter/{encounter_guid}'
-        asset_group_utils.patch_asset_group_sighting(
-            flask_app_client, researcher_1, path, patch_data, 400, expected_resp
-        )
+    patch_data = [utils.patch_add_op('individualUuid', invalid_uuid)]
+    expected_resp = f'Encounter {encounter_guid} individual {invalid_uuid} not found'
+    path = f'{asset_group_sighting_guid}/encounter/{encounter_guid}'
+    asset_group_utils.patch_asset_group_sighting(
+        flask_app_client, researcher_1, path, patch_data, 400, expected_resp
+    )
 
-        # valid patch, real individual
-        with db.session.begin():
-            db.session.add(empty_individual)
-        patch_data = [utils.patch_add_op('individualUuid', str(empty_individual.guid))]
-        path = f'{asset_group_sighting_guid}/encounter/{encounter_guid}'
-        asset_group_utils.patch_asset_group_sighting(
-            flask_app_client,
-            researcher_1,
-            path,
-            patch_data,
-        )
-
-    finally:
-        with db.session.begin():
-            db.session.delete(empty_individual)
-        # Restore original state
-        if asset_group_uuid:
-            asset_group_utils.delete_asset_group(
-                flask_app_client, regular_user, asset_group_uuid
-            )
-
-        tus_utils.cleanup_tus_dir(transaction_id)
+    # valid patch, real individual
+    with db.session.begin():
+        db.session.add(empty_individual)
+    request.addfinalizer(lambda: db.session.delete(empty_individual))
+    patch_data = [utils.patch_add_op('individualUuid', str(empty_individual.guid))]
+    path = f'{asset_group_sighting_guid}/encounter/{encounter_guid}'
+    asset_group_utils.patch_asset_group_sighting(
+        flask_app_client,
+        researcher_1,
+        path,
+        patch_data,
+    )
 
 
 # similar to the above but against the AGS-as-sighting endpoint
@@ -130,66 +116,55 @@ def test_patch_asset_group(
     module_unavailable('asset_groups'), reason='AssetGroups module disabled'
 )
 def test_patch_asset_group_sighting_as_sighting(
-    flask_app_client, researcher_1, regular_user, test_root
+    flask_app_client, researcher_1, regular_user, test_root, request
 ):
     # pylint: disable=invalid-name
-    from tests.modules.asset_groups.resources.utils import AssetGroupCreationData
     from tests import utils
 
-    transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
-    asset_group_uuid = None
-    try:
-        data = AssetGroupCreationData(transaction_id)
-        data.add_filename(0, test_filename)
-        response = asset_group_utils.create_asset_group(
-            flask_app_client, regular_user, data.get()
-        )
-        asset_group_uuid = response.json['guid']
-        asset_group_sighting_guid = response.json['asset_group_sightings'][0]['guid']
+    (
+        asset_group_uuid,
+        asset_group_sighting_guid,
+        asset_guid,
+    ) = asset_group_utils.create_simple_asset_group(
+        flask_app_client, regular_user, request, test_root
+    )
 
-        # Regular user can create it but not read it??????
-        asset_group_utils.read_asset_group_sighting_as_sighting(
-            flask_app_client, regular_user, asset_group_sighting_guid, 403
-        )
+    # Regular user can create it but not read it??????
+    asset_group_utils.read_asset_group_sighting_as_sighting(
+        flask_app_client, regular_user, asset_group_sighting_guid, 403
+    )
 
-        # Researcher should be able to
-        group_sighting = asset_group_utils.read_asset_group_sighting_as_sighting(
-            flask_app_client, researcher_1, asset_group_sighting_guid
-        )
+    # Researcher should be able to
+    group_sighting = asset_group_utils.read_asset_group_sighting_as_sighting(
+        flask_app_client, researcher_1, asset_group_sighting_guid
+    )
 
-        # startTime and locationId are only present in the _as_sighting endpoints,
-        # since they are in the config of a standard AGS
-        for field in {'guid', 'stage', 'completion', 'assets', 'startTime', 'locationId'}:
-            assert field in group_sighting.json
-        assert group_sighting.json['asset_group_guid'] == asset_group_uuid
-        assert group_sighting.json['creator']['guid'] == str(regular_user.guid)
+    # startTime and locationId are only present in the _as_sighting endpoints,
+    # since they are in the config of a standard AGS
+    for field in {'guid', 'stage', 'completion', 'assets', 'startTime', 'locationId'}:
+        assert field in group_sighting.json
 
-        # Valid patch, adding a new encounter with an existing file
-        new_encounters = copy.deepcopy(group_sighting.json['encounters'])
-        new_encounters.append({})
-        patch_data = [utils.patch_replace_op('encounters', new_encounters)]
+    assert group_sighting.json['asset_group_guid'] == asset_group_uuid
+    assert group_sighting.json['creator']['guid'] == str(regular_user.guid)
 
-        # Should not work as contributor
-        asset_group_utils.patch_asset_group_sighting_as_sighting(
-            flask_app_client, regular_user, asset_group_sighting_guid, patch_data, 403
-        )
+    # Valid patch, adding a new encounter with an existing file
+    new_encounters = copy.deepcopy(group_sighting.json['encounters'])
+    new_encounters.append({})
+    patch_data = [utils.patch_replace_op('encounters', new_encounters)]
 
-        # should work as researcher
-        asset_group_utils.patch_asset_group_sighting_as_sighting(
-            flask_app_client, researcher_1, asset_group_sighting_guid, patch_data
-        )
+    # Should not work as contributor
+    asset_group_utils.patch_asset_group_sighting_as_sighting(
+        flask_app_client, regular_user, asset_group_sighting_guid, patch_data, 403
+    )
 
-        # chosen for reasons of incongruity as the naked mole rat is virtually blind
-        # so has no 'sight'
-        add_name_patch = [utils.patch_add_op('name', 'Naked Mole Rat')]
-        asset_group_utils.patch_asset_group_sighting_as_sighting(
-            flask_app_client, researcher_1, asset_group_sighting_guid, add_name_patch
-        )
+    # should work as researcher
+    asset_group_utils.patch_asset_group_sighting_as_sighting(
+        flask_app_client, researcher_1, asset_group_sighting_guid, patch_data
+    )
 
-    finally:
-        if asset_group_uuid:
-            asset_group_utils.delete_asset_group(
-                flask_app_client, regular_user, asset_group_uuid
-            )
-
-        tus_utils.cleanup_tus_dir(transaction_id)
+    # chosen for reasons of incongruity as the naked mole rat is virtually blind
+    # so has no 'sight'
+    add_name_patch = [utils.patch_add_op('name', 'Naked Mole Rat')]
+    asset_group_utils.patch_asset_group_sighting_as_sighting(
+        flask_app_client, researcher_1, asset_group_sighting_guid, add_name_patch
+    )

--- a/tests/modules/asset_groups/resources/test_permissions.py
+++ b/tests/modules/asset_groups/resources/test_permissions.py
@@ -71,8 +71,7 @@ def test_create_patch_asset_group(
     try:
         from app.modules.asset_groups.models import AssetGroup
 
-        data = asset_group_utils.AssetGroupCreationData(transaction_id)
-        data.add_filename(0, test_filename)
+        data = asset_group_utils.AssetGroupCreationData(transaction_id, test_filename)
 
         create_response = asset_group_utils.create_asset_group(
             flask_app_client, researcher_1, data.get()

--- a/tests/modules/asset_groups/resources/test_upload_file.py
+++ b/tests/modules/asset_groups/resources/test_upload_file.py
@@ -20,8 +20,7 @@ def test_create_open_submission(flask_app_client, regular_user, test_root, db):
     try:
         from app.modules.asset_groups.models import AssetGroup
 
-        data = asset_group_utils.AssetGroupCreationData(transaction_id)
-        data.add_filename(0, test_filename)
+        data = asset_group_utils.AssetGroupCreationData(transaction_id, test_filename)
         response = asset_group_utils.create_asset_group(
             flask_app_client, regular_user, data.get()
         )

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -67,353 +67,45 @@ def create_simple_asset_group(flask_app_client, user, request, test_root):
     return group_guid, ags_guids[0], asset_guids[0]
 
 
-class AssetGroupCreationData(object):
-    def __init__(self, transaction_id, filename=None, populate_default=True):
-
-        if not populate_default:
-            self.content = {}
-        else:
-            self.content = {
-                'description': 'This is a test asset_group, please ignore',
-                'uploadType': 'form',
-                'speciesDetectionModel': [
-                    'None',
-                ],
-                'transactionId': transaction_id,
-                'sightings': [
-                    {
-                        'startTime': '2000-01-01T01:01:01Z',
-                        # Yes, that really is a location, it's a village in Wiltshire https://en.wikipedia.org/wiki/Tiddleywink
-                        'locationId': 'Tiddleywink',
-                        'encounters': [{}],
-                    },
-                ],
-            }
-            if filename:
-                self.add_filename(0, filename)
-
-    def add_filename(self, sighting, filename):
-        if 'assetReferences' not in self.content['sightings'][sighting]:
-            self.content['sightings'][sighting]['assetReferences'] = []
-        self.content['sightings'][sighting]['assetReferences'].append(filename)
-
-    def add_sighting(self, location):
-        self.content['sightings'].append(
-            {
-                'locationId': location,
-                'startTime': '2000-01-01T01:01:01Z',
-                'assetReferences': [],
-                'encounters': [],
-            }
-        )
-
-    def add_encounter(self, sighting):
-        self.content['sightings'][sighting]['encounters'].append({})
-
-    def set_field(self, field, value):
-        self.content[field] = value
-
-    def remove_field(self, field):
-        del self.content[field]
-
-    def set_sighting_field(self, sighting, field, value):
-        self.content['sightings'][sighting][field] = value
-
-    def set_encounter_field(self, sighting, encounter, field, value):
-        self.content['sightings'][sighting]['encounters'][encounter][field] = value
-
-    def remove_encounter_field(self, sighting, encounter, field):
-        del self.content['sightings'][sighting]['encounters'][encounter][field]
-
-    def get(self):
-        return self.content
-
-
-def create_asset_group(
-    flask_app_client, user, data, expected_status_code=200, expected_error=''
+# Helper as used across multiple tests
+def patch_in_dummy_annotation(
+    flask_app_client, db, user, asset_group_sighting_uuid, asset_uuid, encounter_num=0
 ):
-    from app.modules.asset_groups.tasks import sage_detection
-
-    # Call sage_detection in the foreground by skipping "delay"
-    with mock.patch(
-        'app.modules.asset_groups.tasks.sage_detection.delay', side_effect=sage_detection
-    ):
-        if user:
-            with flask_app_client.login(user, auth_scopes=('asset_groups:write',)):
-                response = flask_app_client.post(
-                    '%s' % PATH,
-                    content_type='application/json',
-                    data=json.dumps(data),
-                )
-        else:
-            response = flask_app_client.post(
-                '%s' % PATH,
-                content_type='application/json',
-                data=json.dumps(data),
-            )
-
-    if expected_status_code == 200:
-        test_utils.validate_dict_response(
-            response, 200, {'guid', 'description', 'major_type'}
-        )
-    elif 400 <= expected_status_code < 500:
-        test_utils.validate_dict_response(
-            response, expected_status_code, {'status', 'message'}
-        )
-        assert response.json['message'] == expected_error, response.json['message']
-    else:
-        test_utils.validate_dict_response(
-            response, expected_status_code, {'status', 'message'}
-        )
-    return response
-
-
-# As for method above but simulate a successful initial response from Sage and do some minimal validation
-def create_asset_group_sim_sage_init_resp(
-    flask_app, flask_app_client, user, data, expected_status_code=200, expected_error=''
-):
-    # Simulate a valid response from Sage but don't actually send the request to Sage
-    with mock.patch.object(
-        flask_app.acm,
-        'request_passthrough_result',
-        return_value={'success': True},
-    ) as detection_started:
-        from app.modules.asset_groups import tasks
-
-        with mock.patch.object(
-            tasks.sage_detection,
-            'delay',
-            side_effect=lambda *args, **kwargs: tasks.sage_detection(*args, **kwargs),
-        ):
-            resp = create_asset_group(
-                flask_app_client, user, data, expected_status_code, expected_error
-            )
-        passed_args = detection_started.call_args[0]
-        try:
-            assert passed_args[:-2] == ('job.detect_request', 'post')
-            params = passed_args[-2]['params']
-            assert set(params.keys()) >= {
-                'endpoint',
-                'jobid',
-                'input',
-                'image_uuid_list',
-                'callback_url',
-                'callback_detailed',
-            }
-            assert set(params['input'].keys()) >= {
-                'start_detect',
-                'labeler_algo',
-                'labeler_model_tag',
-                'model_tag',
-            }
-            assert params['endpoint'] == '/api/engine/detect/cnn/lightnet/'
-            assert re.match('[a-f0-9-]{36}', params['jobid'])
-            assert re.match(
-                r'houston\+http://houston:5000/api/v1/asset_groups/sighting/[a-f0-9-]{36}/sage_detected/'
-                + params['jobid'],
-                params['callback_url'],
-            )
-            assert all(
-                re.match(
-                    r'houston\+http://houston:5000/api/v1/assets/src_raw/[a-f0-9-]{36}',
-                    uri,
-                )
-                for uri in json.loads(params['image_uuid_list'])
-            )
-        except Exception:
-            # Calling code cannot clear up the asset group as the resp is not passed if any of the assertions fail
-            # meaning that all subsequent tests would fail.
-            if 'guid' in resp.json:
-                delete_asset_group(flask_app_client, user, resp.json['guid'])
-            raise
-        return resp
-
-
-# Helper as many bulk uploads use a common set of files
-def create_bulk_tus_transaction(test_root):
-
-    transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
-    tus_utils.prep_tus_dir(test_root, filename='coelacanth.png')
-    tus_utils.prep_tus_dir(test_root, filename='fluke.jpg')
-    tus_utils.prep_tus_dir(test_root, filename='phoenix.jpg')
-    return transaction_id, [test_filename, 'coelacanth.png', 'fluke.jpg', 'phoenix.jpg']
-
-
-def get_bulk_creation_data(test_root, request, species_detection_model=None):
-    transaction_id, first_filename = tus_utils.prep_tus_dir(test_root)
-    tus_utils.prep_tus_dir(test_root, filename='coelacanth.png')
-    tus_utils.prep_tus_dir(test_root, filename='fluke.jpg')
-    tus_utils.prep_tus_dir(test_root, filename='phoenix.jpg')
-    request.addfinalizer(lambda: tus_utils.cleanup_tus_dir(transaction_id))
-
-    data = AssetGroupCreationData(transaction_id, first_filename)
-    data.add_encounter(0)
-    data.add_filename(0, 'coelacanth.png')
-    data.add_sighting('Hogpits Bottom')
-    data.add_encounter(1)
-    data.add_filename(1, 'fluke.jpg')
-    data.add_encounter(1)
-    data.add_filename(1, 'phoenix.jpg')
-    data.set_field('uploadType', 'bulk')
-    if species_detection_model:
-        data.set_field('speciesDetectionModel', [species_detection_model])
-
-    return data
-
-
-def get_bulk_creation_data_one_sighting(transaction_id, test_filename):
-    data = AssetGroupCreationData(transaction_id, test_filename)
-    data.add_encounter(0)
-    data.add_filename(0, 'fluke.jpg')
-    data.add_encounter(0)
-    data.add_filename(0, 'coelacanth.png')
-    data.add_encounter(0)
-    data.add_filename(0, 'phoenix.jpg')
-    data.set_field('uploadType', 'bulk')
-    return data
-
-
-# Create a default valid Sage detection response (to allow for the test to corrupt it accordingly)
-def build_sage_detection_response(asset_group_sighting_guid, job_uuid):
-    from app.modules.asset_groups.models import AssetGroupSighting
+    from app.modules.assets.models import Asset
+    from app.modules.annotations.models import Annotation
     import uuid
 
-    asset_group_sighting = AssetGroupSighting.query.get(asset_group_sighting_guid)
-    asset_ids = list(asset_group_sighting.jobs.values())[-1]['asset_ids']
+    asset = Asset.find(asset_uuid)
+    assert asset
 
-    # Generate the response back from Sage
-    sage_resp = {
-        'status': 'completed',
-        'jobid': str(job_uuid),
-        'json_result': {
-            'image_uuid_list': [
-                # Image UUID stored in acm (not the same as houston)
-                {'__UUID__': str(uuid.uuid4())}
-                for _ in asset_ids
-            ],
-            'results_list': [
-                [
-                    {
-                        'id': 1,
-                        'uuid': {'__UUID__': ANNOTATION_UUIDS[0]},
-                        'xtl': 459,
-                        'ytl': 126,
-                        'left': 459,
-                        'top': 126,
-                        'width': 531,
-                        'height': 539,
-                        'theta': 0.0,
-                        'confidence': 0.8568,
-                        'class': 'zebra_plains',
-                        'species': 'zebra_plains',
-                        'viewpoint': 'test',
-                        'quality': None,
-                        'multiple': False,
-                        'interest': False,
-                    },
-                    {
-                        'id': 2,
-                        'uuid': {'__UUID__': ANNOTATION_UUIDS[1]},
-                        'xtl': 26,
-                        'ytl': 145,
-                        'left': 26,
-                        'top': 145,
-                        'width': 471,
-                        'height': 500,
-                        'theta': 0.0,
-                        'confidence': 0.853,
-                        'class': 'zebra_plains',
-                        'species': 'zebra_plains',
-                        'viewpoint': 'test',
-                        'quality': None,
-                        'multiple': False,
-                        'interest': False,
-                    },
-                ],
-            ],
-        },
-    }
-
-    # Make sure results_list is the same length as the assets (just
-    # empty [])
-    sage_resp['json_result']['results_list'] += [[] for _ in range(len(asset_ids) - 1)]
-    return sage_resp
-
-
-def validate_file_data(data, filename):
-    import hashlib
-
-    assert hashlib.md5(data).hexdigest() == DERIVED_MD5SUM_VALUES[filename]
-
-
-def send_sage_detection_response(
-    flask_app_client,
-    user,
-    asset_group_sighting_guid,
-    job_guid,
-    data,
-    expected_status_code=200,
-):
-    with flask_app_client.login(user, auth_scopes=('asset_group_sightings:write',)):
-        response = flask_app_client.post(
-            f'{PATH}sighting/{asset_group_sighting_guid}/sage_detected/{job_guid}',
-            content_type='application/json',
-            data=json.dumps(data),
-        )
-    if expected_status_code == 200:
-        assert response.status_code == expected_status_code, response.status_code
-    else:
-        test_utils.validate_dict_response(
-            response, expected_status_code, {'status', 'message'}
-        )
-    return response
-
-
-# Does all up to the curation stage using simulated Sage Interactions
-def create_asset_group_to_curation(
-    flask_app, flask_app_client, user, internal_user, test_root, request
-):
-    # pylint: disable=invalid-name
-    from app.modules.asset_groups.models import (
-        AssetGroupSighting,
-        AssetGroupSightingStage,
+    # Create a dummy annotation for this Sighting
+    new_annot = Annotation(
+        guid=uuid.uuid4(),
+        content_guid=uuid.uuid4(),
+        asset=asset,
+        ia_class='none',
+        viewpoint='test',
+        bounds={'rect': [45, 5, 78, 3], 'theta': 4.8},
     )
+    with db.session.begin(subtransactions=True):
+        db.session.add(new_annot)
 
-    asset_group_uuid = None
-    data = get_bulk_creation_data(test_root, request)
-    # Use a real detection model to trigger a request sent to Sage
-    data.set_field('speciesDetectionModel', ['african_terrestrial'])
-
-    # and the sim_sage util to catch it
-    resp = create_asset_group_sim_sage_init_resp(
-        flask_app, flask_app_client, user, data.get()
+    # Patch it in
+    group_sighting = read_asset_group_sighting(
+        flask_app_client, user, asset_group_sighting_uuid
     )
-    asset_group_uuid = resp.json['guid']
-    request.addfinalizer(
-        lambda: delete_asset_group(flask_app_client, user, asset_group_uuid)
-    )
-    asset_group_sighting1_guid = resp.json['asset_group_sightings'][0]['guid']
+    encounter_guid = group_sighting.json['config']['encounters'][encounter_num]['guid']
 
-    ags1 = AssetGroupSighting.query.get(asset_group_sighting1_guid)
-    assert ags1
-
-    job_uuids = [guid for guid in ags1.jobs.keys()]
-    assert len(job_uuids) == 1
-    job_uuid = job_uuids[0]
-    assert ags1.jobs[job_uuid]['model'] == 'african_terrestrial'
-
-    # Simulate response from Sage
-    sage_resp = build_sage_detection_response(asset_group_sighting1_guid, job_uuid)
-    send_sage_detection_response(
+    patch_data = [
+        test_utils.patch_replace_op('annotations', [str(new_annot.content_guid)])
+    ]
+    patch_asset_group_sighting(
         flask_app_client,
-        internal_user,
-        asset_group_sighting1_guid,
-        job_uuid,
-        sage_resp,
+        user,
+        f'{asset_group_sighting_uuid}/encounter/{encounter_guid}',
+        patch_data,
     )
-    assert ags1.stage == AssetGroupSightingStage.curation
-
-    return asset_group_uuid, asset_group_sighting1_guid
+    return new_annot.guid
 
 
 def commit_asset_group_sighting(
@@ -431,175 +123,6 @@ def commit_asset_group_sighting(
         expected_status_code=expected_status_code,
         response_200={'guid'},
     )
-
-
-def commit_asset_group_sighting_sage_identification(
-    flask_app,
-    flask_app_client,
-    user,
-    asset_group_sighting_guid,
-    expected_status_code=200,
-):
-    from app.modules.sightings import tasks
-
-    # Start ID simulating success response from Sage
-    with mock.patch.object(
-        flask_app.acm,
-        'request_passthrough_result',
-        return_value={'success': True},
-    ):
-        with mock.patch.object(
-            tasks.send_identification,
-            'delay',
-            side_effect=lambda *args, **kwargs: tasks.send_identification(
-                *args, **kwargs
-            ),
-        ):
-            response = commit_asset_group_sighting(
-                flask_app_client, user, asset_group_sighting_guid, expected_status_code
-            )
-    return response
-
-
-def create_asset_group_with_annotation(
-    flask_app_client, db, user, transaction_id, test_filename
-):
-    data = AssetGroupCreationData(transaction_id, test_filename)
-    response = create_asset_group(flask_app_client, user, data.get())
-    asset_group_uuid = response.json['guid']
-    asset_group_sighting_guid = response.json['asset_group_sightings'][0]['guid']
-    asset_uuid = response.json['assets'][0]['guid']
-    annot_uuid = patch_in_dummy_annotation(
-        flask_app_client, db, user, asset_group_sighting_guid, asset_uuid
-    )
-    return asset_group_uuid, asset_group_sighting_guid, annot_uuid
-
-
-# Many tests require a committed assetgroup with one sighting, use this helper
-def create_and_commit_asset_group(
-    flask_app_client, db, user, transaction_id, test_filename
-):
-    (
-        asset_group_uuid,
-        asset_group_sighting_uuid,
-        annot_uuid,
-    ) = create_asset_group_with_annotation(
-        flask_app_client, db, user, transaction_id, test_filename
-    )
-
-    response = commit_asset_group_sighting(
-        flask_app_client, user, asset_group_sighting_uuid
-    )
-
-    sighting_uuid = response.json['guid']
-    return asset_group_uuid, sighting_uuid, annot_uuid
-
-
-def create_asset_group_and_sighting(
-    flask_app_client, user, request, test_root=None, data=None
-):
-    from app.modules.sightings.models import Sighting
-    from app.modules.asset_groups.models import AssetGroup
-
-    if not data:
-        # Need at least one of them set
-        assert test_root is not None
-        transaction_id, filenames = create_bulk_tus_transaction(test_root)
-        request.addfinalizer(lambda: tus_utils.cleanup_tus_dir(transaction_id))
-        import random
-
-        locationId = random.randrange(10000)
-        data = {
-            'description': 'This is a test asset_group, please ignore',
-            'uploadType': 'bulk',
-            'speciesDetectionModel': ['None'],
-            'transactionId': transaction_id,
-            'sightings': [
-                {
-                    'startTime': '2000-01-01T01:01:01Z',
-                    'locationId': f'Location {locationId}',
-                    'encounters': [
-                        {
-                            'decimalLatitude': test_utils.random_decimal_latitude(),
-                            'decimalLongitude': test_utils.random_decimal_longitude(),
-                            # Yes, that really is a location, it's a village in Wiltshire
-                            # https://en.wikipedia.org/wiki/Tiddleywink
-                            'verbatimLocality': 'Tiddleywink',
-                            'locationId': f'Location {locationId}',
-                        },
-                        {
-                            'decimalLatitude': test_utils.random_decimal_latitude(),
-                            'decimalLongitude': test_utils.random_decimal_longitude(),
-                            'verbatimLocality': 'Tiddleywink',
-                            'locationId': f'Location {locationId}',
-                        },
-                    ],
-                    'assetReferences': [
-                        filenames[0],
-                        filenames[1],
-                        filenames[2],
-                        filenames[3],
-                    ],
-                },
-            ],
-        }
-
-    create_response = create_asset_group(flask_app_client, user, data)
-    asset_group_uuid = create_response.json['guid']
-    request.addfinalizer(
-        lambda: delete_asset_group(flask_app_client, user, asset_group_uuid)
-    )
-    asset_group = AssetGroup.query.get(asset_group_uuid)
-    assert create_response.json['description'] == data['description']
-    assert create_response.json['owner_guid'] == str(user.guid)
-
-    # Commit them all
-    sightings = []
-    for asset_group_sighting in create_response.json['asset_group_sightings']:
-        commit_response = commit_asset_group_sighting(
-            flask_app_client, user, asset_group_sighting['guid']
-        )
-        sighting_uuid = commit_response.json['guid']
-        sighting = Sighting.query.get(sighting_uuid)
-        sightings.append(sighting)
-
-    return asset_group, sightings
-
-
-def create_asset_group_with_sighting_and_individual(
-    flask_app_client,
-    user,
-    request,
-    test_root=None,
-    asset_group_data=None,
-    individual_data=None,
-):
-    from app.modules.individuals.models import Individual
-
-    asset_group, sightings = create_asset_group_and_sighting(
-        flask_app_client, user, request, test_root, asset_group_data
-    )
-
-    # Extract the encounters to use to create an individual
-    encounters = sightings[0].encounters
-    assert len(encounters) >= 1
-    if individual_data:
-        individual_data['encounters'] = [{'id': str(encounters[0].guid)}]
-    else:
-        individual_data = {'encounters': [{'id': str(encounters[0].guid)}]}
-
-    individual_response = individual_utils.create_individual(
-        flask_app_client, user, 200, individual_data
-    )
-
-    individual_guid = individual_response.json['result']['id']
-    request.addfinalizer(
-        lambda: individual_utils.delete_individual(
-            flask_app_client, user, individual_guid
-        )
-    )
-    individual = Individual.query.get(individual_guid)
-    return asset_group, sightings, individual
 
 
 def patch_asset_group(
@@ -779,6 +302,440 @@ def read_asset_group_sighting_as_sighting(
     return response
 
 
+###################################################################################################################
+# Complexity that is only required for the specific testing of edge cases in the Asset group code
+###################################################################################################################
+
+
+class AssetGroupCreationData(object):
+    def __init__(self, transaction_id, filename=None, populate_default=True):
+
+        if not populate_default:
+            self.content = {}
+        else:
+            self.content = {
+                'description': 'This is a test asset_group, please ignore',
+                'uploadType': 'form',
+                'speciesDetectionModel': [
+                    'None',
+                ],
+                'transactionId': transaction_id,
+                'sightings': [
+                    {
+                        'startTime': '2000-01-01T01:01:01Z',
+                        # Yes, that really is a location, it's a village in Wiltshire https://en.wikipedia.org/wiki/Tiddleywink
+                        'locationId': 'Tiddleywink',
+                        'encounters': [{}],
+                    },
+                ],
+            }
+            if filename:
+                self.add_filename(0, filename)
+
+    def add_filename(self, sighting, filename):
+        if 'assetReferences' not in self.content['sightings'][sighting]:
+            self.content['sightings'][sighting]['assetReferences'] = []
+        self.content['sightings'][sighting]['assetReferences'].append(filename)
+
+    def add_sighting(self, location):
+        self.content['sightings'].append(
+            {
+                'locationId': location,
+                'startTime': '2000-01-01T01:01:01Z',
+                'assetReferences': [],
+                'encounters': [],
+            }
+        )
+
+    def add_encounter(self, sighting):
+        self.content['sightings'][sighting]['encounters'].append({})
+
+    def set_field(self, field, value):
+        self.content[field] = value
+
+    def remove_field(self, field):
+        del self.content[field]
+
+    def set_sighting_field(self, sighting, field, value):
+        self.content['sightings'][sighting][field] = value
+
+    def set_encounter_field(self, sighting, encounter, field, value):
+        self.content['sightings'][sighting]['encounters'][encounter][field] = value
+
+    def remove_encounter_field(self, sighting, encounter, field):
+        del self.content['sightings'][sighting]['encounters'][encounter][field]
+
+    def get(self):
+        return self.content
+
+
+def create_asset_group(
+    flask_app_client, user, data, expected_status_code=200, expected_error=''
+):
+    from app.modules.asset_groups.tasks import sage_detection
+
+    # Call sage_detection in the foreground by skipping "delay"
+    with mock.patch(
+        'app.modules.asset_groups.tasks.sage_detection.delay', side_effect=sage_detection
+    ):
+        if user:
+            with flask_app_client.login(user, auth_scopes=('asset_groups:write',)):
+                response = flask_app_client.post(
+                    '%s' % PATH,
+                    content_type='application/json',
+                    data=json.dumps(data),
+                )
+        else:
+            response = flask_app_client.post(
+                '%s' % PATH,
+                content_type='application/json',
+                data=json.dumps(data),
+            )
+
+    if expected_status_code == 200:
+        test_utils.validate_dict_response(
+            response, 200, {'guid', 'description', 'major_type'}
+        )
+    elif 400 <= expected_status_code < 500:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+        assert response.json['message'] == expected_error, response.json['message']
+    else:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+    return response
+
+
+# As for method above but simulate a successful initial response from Sage and do some minimal validation
+# Note this is just the ack to say that Sage has received the request, not the detection response itself
+def create_asset_group_sim_sage_init_resp(
+    flask_app, flask_app_client, user, data, expected_status_code=200, expected_error=''
+):
+    # Simulate a valid response from Sage but don't actually send the request to Sage
+    with mock.patch.object(
+        flask_app.acm,
+        'request_passthrough_result',
+        return_value={'success': True},
+    ) as detection_started:
+        from app.modules.asset_groups import tasks
+
+        with mock.patch.object(
+            tasks.sage_detection,
+            'delay',
+            side_effect=lambda *args, **kwargs: tasks.sage_detection(*args, **kwargs),
+        ):
+            resp = create_asset_group(
+                flask_app_client, user, data, expected_status_code, expected_error
+            )
+        passed_args = detection_started.call_args[0]
+        try:
+            assert passed_args[:-2] == ('job.detect_request', 'post')
+            params = passed_args[-2]['params']
+            assert set(params.keys()) >= {
+                'endpoint',
+                'jobid',
+                'input',
+                'image_uuid_list',
+                'callback_url',
+                'callback_detailed',
+            }
+            assert set(params['input'].keys()) >= {
+                'start_detect',
+                'labeler_algo',
+                'labeler_model_tag',
+                'model_tag',
+            }
+            assert params['endpoint'] == '/api/engine/detect/cnn/lightnet/'
+            assert re.match('[a-f0-9-]{36}', params['jobid'])
+            assert re.match(
+                r'houston\+http://houston:5000/api/v1/asset_groups/sighting/[a-f0-9-]{36}/sage_detected/'
+                + params['jobid'],
+                params['callback_url'],
+            )
+            assert all(
+                re.match(
+                    r'houston\+http://houston:5000/api/v1/assets/src_raw/[a-f0-9-]{36}',
+                    uri,
+                )
+                for uri in json.loads(params['image_uuid_list'])
+            )
+        except Exception:
+            # Calling code cannot clear up the asset group as the resp is not passed if any of the assertions fail
+            # meaning that all subsequent tests would fail.
+            if 'guid' in resp.json:
+                delete_asset_group(flask_app_client, user, resp.json['guid'])
+            raise
+        return resp
+
+
+# Helper as many bulk uploads use a common set of files
+def create_bulk_tus_transaction(test_root):
+
+    transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
+    tus_utils.prep_tus_dir(test_root, filename='coelacanth.png')
+    tus_utils.prep_tus_dir(test_root, filename='fluke.jpg')
+    tus_utils.prep_tus_dir(test_root, filename='phoenix.jpg')
+    return transaction_id, [test_filename, 'coelacanth.png', 'fluke.jpg', 'phoenix.jpg']
+
+
+def get_bulk_creation_data(test_root, request, species_detection_model=None):
+    transaction_id, first_filename = tus_utils.prep_tus_dir(test_root)
+    tus_utils.prep_tus_dir(test_root, filename='coelacanth.png')
+    tus_utils.prep_tus_dir(test_root, filename='fluke.jpg')
+    tus_utils.prep_tus_dir(test_root, filename='phoenix.jpg')
+    request.addfinalizer(lambda: tus_utils.cleanup_tus_dir(transaction_id))
+
+    data = AssetGroupCreationData(transaction_id, first_filename)
+    data.add_encounter(0)
+    data.add_filename(0, 'coelacanth.png')
+    data.add_sighting('Hogpits Bottom')
+    data.add_encounter(1)
+    data.add_filename(1, 'fluke.jpg')
+    data.add_encounter(1)
+    data.add_filename(1, 'phoenix.jpg')
+    data.set_field('uploadType', 'bulk')
+    if species_detection_model:
+        data.set_field('speciesDetectionModel', [species_detection_model])
+
+    return data
+
+
+# Create a default valid Sage detection response (to allow for the test to corrupt it accordingly)
+def build_sage_detection_response(asset_group_sighting_guid, job_uuid):
+    from app.modules.asset_groups.models import AssetGroupSighting
+    import uuid
+
+    asset_group_sighting = AssetGroupSighting.query.get(asset_group_sighting_guid)
+    asset_ids = list(asset_group_sighting.jobs.values())[-1]['asset_ids']
+
+    # Generate the response back from Sage
+    sage_resp = {
+        'status': 'completed',
+        'jobid': str(job_uuid),
+        'json_result': {
+            'image_uuid_list': [
+                # Image UUID stored in acm (not the same as houston)
+                {'__UUID__': str(uuid.uuid4())}
+                for _ in asset_ids
+            ],
+            'results_list': [
+                [
+                    {
+                        'id': 1,
+                        'uuid': {'__UUID__': ANNOTATION_UUIDS[0]},
+                        'xtl': 459,
+                        'ytl': 126,
+                        'left': 459,
+                        'top': 126,
+                        'width': 531,
+                        'height': 539,
+                        'theta': 0.0,
+                        'confidence': 0.8568,
+                        'class': 'zebra_plains',
+                        'species': 'zebra_plains',
+                        'viewpoint': 'test',
+                        'quality': None,
+                        'multiple': False,
+                        'interest': False,
+                    },
+                    {
+                        'id': 2,
+                        'uuid': {'__UUID__': ANNOTATION_UUIDS[1]},
+                        'xtl': 26,
+                        'ytl': 145,
+                        'left': 26,
+                        'top': 145,
+                        'width': 471,
+                        'height': 500,
+                        'theta': 0.0,
+                        'confidence': 0.853,
+                        'class': 'zebra_plains',
+                        'species': 'zebra_plains',
+                        'viewpoint': 'test',
+                        'quality': None,
+                        'multiple': False,
+                        'interest': False,
+                    },
+                ],
+            ],
+        },
+    }
+
+    # Make sure results_list is the same length as the assets (just
+    # empty [])
+    sage_resp['json_result']['results_list'] += [[] for _ in range(len(asset_ids) - 1)]
+    return sage_resp
+
+
+def validate_file_data(data, filename):
+    import hashlib
+
+    assert hashlib.md5(data).hexdigest() == DERIVED_MD5SUM_VALUES[filename]
+
+
+def send_sage_detection_response(
+    flask_app_client,
+    user,
+    asset_group_sighting_guid,
+    job_guid,
+    data=None,
+    expected_status_code=200,
+):
+    if not data:
+        data = build_sage_detection_response(asset_group_sighting_guid, job_guid)
+    with flask_app_client.login(user, auth_scopes=('asset_group_sightings:write',)):
+        response = flask_app_client.post(
+            f'{PATH}sighting/{asset_group_sighting_guid}/sage_detected/{job_guid}',
+            content_type='application/json',
+            data=json.dumps(data),
+        )
+    if expected_status_code == 200:
+        assert response.status_code == expected_status_code, response.status_code
+    else:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+    return response
+
+
+# As for the normal commit but fake a response from Sage indicating Success
+def commit_asset_group_sighting_sage_identification(
+    flask_app,
+    flask_app_client,
+    user,
+    asset_group_sighting_guid,
+    expected_status_code=200,
+):
+    from app.modules.sightings import tasks
+
+    # Start ID simulating success response from Sage
+    with mock.patch.object(
+        flask_app.acm,
+        'request_passthrough_result',
+        return_value={'success': True},
+    ):
+        with mock.patch.object(
+            tasks.send_identification,
+            'delay',
+            side_effect=lambda *args, **kwargs: tasks.send_identification(
+                *args, **kwargs
+            ),
+        ):
+            response = commit_asset_group_sighting(
+                flask_app_client, user, asset_group_sighting_guid, expected_status_code
+            )
+    return response
+
+
+def create_asset_group_and_sighting(
+    flask_app_client, user, request, test_root=None, data=None
+):
+    from app.modules.sightings.models import Sighting
+    from app.modules.asset_groups.models import AssetGroup
+
+    if not data:
+        # Need at least one of them set
+        assert test_root is not None
+        transaction_id, filenames = create_bulk_tus_transaction(test_root)
+        request.addfinalizer(lambda: tus_utils.cleanup_tus_dir(transaction_id))
+        import random
+
+        locationId = random.randrange(10000)
+        data = {
+            'description': 'This is a test asset_group, please ignore',
+            'uploadType': 'bulk',
+            'speciesDetectionModel': ['None'],
+            'transactionId': transaction_id,
+            'sightings': [
+                {
+                    'startTime': '2000-01-01T01:01:01Z',
+                    'locationId': f'Location {locationId}',
+                    'encounters': [
+                        {
+                            'decimalLatitude': test_utils.random_decimal_latitude(),
+                            'decimalLongitude': test_utils.random_decimal_longitude(),
+                            # Yes, that really is a location, it's a village in Wiltshire
+                            # https://en.wikipedia.org/wiki/Tiddleywink
+                            'verbatimLocality': 'Tiddleywink',
+                            'locationId': f'Location {locationId}',
+                        },
+                        {
+                            'decimalLatitude': test_utils.random_decimal_latitude(),
+                            'decimalLongitude': test_utils.random_decimal_longitude(),
+                            'verbatimLocality': 'Tiddleywink',
+                            'locationId': f'Location {locationId}',
+                        },
+                    ],
+                    'assetReferences': [
+                        filenames[0],
+                        filenames[1],
+                        filenames[2],
+                        filenames[3],
+                    ],
+                },
+            ],
+        }
+
+    create_response = create_asset_group(flask_app_client, user, data)
+    asset_group_uuid = create_response.json['guid']
+    request.addfinalizer(
+        lambda: delete_asset_group(flask_app_client, user, asset_group_uuid)
+    )
+    asset_group = AssetGroup.query.get(asset_group_uuid)
+    assert create_response.json['description'] == data['description']
+    assert create_response.json['owner_guid'] == str(user.guid)
+
+    # Commit them all
+    sightings = []
+    for asset_group_sighting in create_response.json['asset_group_sightings']:
+        commit_response = commit_asset_group_sighting(
+            flask_app_client, user, asset_group_sighting['guid']
+        )
+        sighting_uuid = commit_response.json['guid']
+        sighting = Sighting.query.get(sighting_uuid)
+        sightings.append(sighting)
+
+    return asset_group, sightings
+
+
+def create_asset_group_with_sighting_and_individual(
+    flask_app_client,
+    user,
+    request,
+    test_root=None,
+    asset_group_data=None,
+    individual_data=None,
+):
+    from app.modules.individuals.models import Individual
+
+    asset_group, sightings = create_asset_group_and_sighting(
+        flask_app_client, user, request, test_root, asset_group_data
+    )
+
+    # Extract the encounters to use to create an individual
+    encounters = sightings[0].encounters
+    assert len(encounters) >= 1
+    if individual_data:
+        individual_data['encounters'] = [{'id': str(encounters[0].guid)}]
+    else:
+        individual_data = {'encounters': [{'id': str(encounters[0].guid)}]}
+
+    individual_response = individual_utils.create_individual(
+        flask_app_client, user, 200, individual_data
+    )
+
+    individual_guid = individual_response.json['result']['id']
+    request.addfinalizer(
+        lambda: individual_utils.delete_individual(
+            flask_app_client, user, individual_guid
+        )
+    )
+    individual = Individual.query.get(individual_guid)
+    return asset_group, sightings, individual
+
+
 def simulate_job_detection_response(
     flask_app_client,
     user,
@@ -790,18 +747,6 @@ def simulate_job_detection_response(
     path = f'sighting/{asset_group_sighting_uuid}/sage_detected/{job_id}'
     data = build_sage_detection_response(asset_group_sighting_uuid, job_id)
 
-    return simulate_detection_response(
-        flask_app_client,
-        user,
-        path,
-        data,
-        expected_status_code,
-    )
-
-
-def simulate_detection_response(
-    flask_app_client, user, path, data, expected_status_code=200
-):
     with flask_app_client.login(user, auth_scopes=('asset_group_sightings:write',)):
         response = flask_app_client.post(
             f'{PATH}{path}',
@@ -816,47 +761,6 @@ def simulate_detection_response(
             response, expected_status_code, {'status', 'message'}
         )
     return response
-
-
-# Helper as used across multiple tests
-def patch_in_dummy_annotation(
-    flask_app_client, db, user, asset_group_sighting_uuid, asset_uuid, encounter_num=0
-):
-    from app.modules.assets.models import Asset
-    from app.modules.annotations.models import Annotation
-    import uuid
-
-    asset = Asset.find(asset_uuid)
-    assert asset
-
-    # Create a dummy annotation for this Sighting
-    new_annot = Annotation(
-        guid=uuid.uuid4(),
-        content_guid=uuid.uuid4(),
-        asset=asset,
-        ia_class='none',
-        viewpoint='test',
-        bounds={'rect': [45, 5, 78, 3], 'theta': 4.8},
-    )
-    with db.session.begin(subtransactions=True):
-        db.session.add(new_annot)
-
-    # Patch it in
-    group_sighting = read_asset_group_sighting(
-        flask_app_client, user, asset_group_sighting_uuid
-    )
-    encounter_guid = group_sighting.json['config']['encounters'][encounter_num]['guid']
-
-    patch_data = [
-        test_utils.patch_replace_op('annotations', [str(new_annot.content_guid)])
-    ]
-    patch_asset_group_sighting(
-        flask_app_client,
-        user,
-        f'{asset_group_sighting_uuid}/encounter/{encounter_guid}',
-        patch_data,
-    )
-    return new_annot.guid
 
 
 def detect_asset_group_sighting(

--- a/tests/modules/audit_logs/resources/test_audit_log.py
+++ b/tests/modules/audit_logs/resources/test_audit_log.py
@@ -124,15 +124,11 @@ def test_most_ia_pipeline_audit_log(
     assert ags1.jobs[job_uuid]['model'] == 'african_terrestrial'
 
     # Simulate response from Sage
-    sage_resp = asset_group_utils.build_sage_detection_response(
-        asset_group_sighting1_guid, job_uuid
-    )
     asset_group_utils.send_sage_detection_response(
         flask_app_client,
         internal_user,
         asset_group_sighting1_guid,
         job_uuid,
-        sage_resp,
     )
     assert ags1.stage == AssetGroupSightingStage.curation
 

--- a/tests/modules/sightings/resources/test_identify_sighting.py
+++ b/tests/modules/sightings/resources/test_identify_sighting.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import uuid
-import tests.extensions.tus.utils as tus_utils
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.modules.sightings.resources.utils as sighting_utils
 import tests.utils as test_utils
@@ -17,94 +15,90 @@ def test_sighting_identification(
     internal_user,
     test_root,
     db,
+    request,
 ):
     # pylint: disable=invalid-name
     from app.modules.sightings.models import Sighting, SightingStage
 
-    asset_group_uuids = []
-    sighting_uuids = []
-    transactions = []
-    try:
-        # Create two sightings so that there will be a valid annotation when doing ID for the second one.
-        # Otherwise the get_matching_set_data in sightings will return an empty list
-        transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
-        (
-            asset_group_uuid,
-            sighting_uuid,
-            annot_uuid,
-        ) = asset_group_utils.create_and_commit_asset_group(
-            flask_app_client, db, researcher_1, transaction_id, test_filename
-        )
-        asset_group_uuids.append(asset_group_uuid)
-        sighting_uuids.append(sighting_uuid)
-        transactions.append(transaction_id)
-        # Fake it being all the way though to processed or it won't be valid in the matching set
-        sighting = Sighting.query.get(sighting_uuid)
-        sighting.stage = SightingStage.processed
+    # Create two sightings so that there will be a valid annotation when doing ID for the second one.
+    # Otherwise the get_matching_set_data in sightings will return an empty list
+    (
+        asset_group_uuid1,
+        asset_group_sighting_guid1,
+        asset_uuid1,
+    ) = asset_group_utils.create_simple_asset_group(
+        flask_app_client, researcher_1, request, test_root
+    )
+    asset_group_utils.patch_in_dummy_annotation(
+        flask_app_client, db, researcher_1, asset_group_sighting_guid1, asset_uuid1
+    )
+    commit_response = asset_group_utils.commit_asset_group_sighting(
+        flask_app_client, researcher_1, asset_group_sighting_guid1
+    )
+    sighting_uuid = commit_response.json['guid']
 
-        # Second sighting, the one we'll use for testing, Create with annotation but don't commit.... yet
-        transaction_id, test_filename = tus_utils.prep_tus_dir(
-            test_root, str(uuid.uuid4())
-        )
-        (
-            asset_group_uuid,
-            asset_group_sighting_uuid,
-            annot_uuid,
-        ) = asset_group_utils.create_asset_group_with_annotation(
-            flask_app_client, db, researcher_1, transaction_id, test_filename
-        )
+    # Fake it being all the way though to processed or it won't be valid in the matching set
+    sighting = Sighting.query.get(sighting_uuid)
+    sighting.stage = SightingStage.processed
 
-        asset_group_uuids.append(asset_group_uuid)
-        transactions.append(transaction_id)
+    # Second sighting, the one we'll use for testing, Create with annotation but don't commit.... yet
+    (
+        asset_group_uuid2,
+        asset_group_sighting_guid2,
+        asset_uuid2,
+    ) = asset_group_utils.create_simple_asset_group(
+        flask_app_client, researcher_1, request, test_root
+    )
+    asset_group_utils.patch_in_dummy_annotation(
+        flask_app_client, db, researcher_1, asset_group_sighting_guid2, asset_uuid2
+    )
 
-        # Here starts the test for real
-        # Create ID config and patch it in
-        id_configs = [
-            {
-                'algorithms': ['hotspotter_nosv'],
-                'matchingSetDataOwners': 'mine',
-            }
-        ]
-        patch_data = [test_utils.patch_replace_op('idConfigs', id_configs)]
-        asset_group_utils.patch_asset_group_sighting(
-            flask_app_client, researcher_1, asset_group_sighting_uuid, patch_data
-        )
+    # Here starts the test for real
+    # Create ID config and patch it in
+    id_configs = [
+        {
+            'algorithms': [
+                'hotspotter_nosv',
+            ],
+            'matchingSetDataOwners': 'mine',
+        }
+    ]
+    patch_data = [test_utils.patch_replace_op('idConfigs', id_configs)]
+    asset_group_utils.patch_asset_group_sighting(
+        flask_app_client,
+        researcher_1,
+        asset_group_sighting_guid2,
+        patch_data,
+    )
 
-        # Start ID simulating success response from Sage
-        response = asset_group_utils.commit_asset_group_sighting_sage_identification(
-            flask_app, flask_app_client, researcher_1, asset_group_sighting_uuid
-        )
-        sighting_uuid = response.json['guid']
-        sighting_uuids.append(sighting_uuid)
-        sighting = Sighting.query.get(sighting_uuid)
+    # Start ID simulating success response from Sage
+    response = asset_group_utils.commit_asset_group_sighting_sage_identification(
+        flask_app, flask_app_client, researcher_1, asset_group_sighting_guid2
+    )
+    sighting_uuid = response.json['guid']
 
-        assert sighting.stage == SightingStage.identification
+    sighting = Sighting.query.get(sighting_uuid)
+    assert sighting.stage == SightingStage.identification
 
-        # Make sure the correct job is created and get ID
-        job_uuids = [guid for guid in sighting.jobs.keys()]
-        assert len(job_uuids) == 1
-        job_uuid = job_uuids[0]
-        assert sighting.jobs[job_uuid]['algorithm'] == 'hotspotter_nosv'
+    # Make sure the correct job is created and get ID
+    job_uuids = [guid for guid in sighting.jobs.keys()]
+    assert len(job_uuids) == 1
+    job_uuid = job_uuids[0]
+    assert sighting.jobs[job_uuid]['algorithm'] == 'hotspotter_nosv'
 
-        # Simulate response from Sage
-        sage_resp = sighting_utils.build_sage_identification_response(
-            job_uuid,
-            sighting.jobs[job_uuid]['annotation'],
-            sighting.jobs[job_uuid]['algorithm'],
-        )
+    # Simulate response from Sage
+    sage_resp = sighting_utils.build_sage_identification_response(
+        job_uuid,
+        sighting.jobs[job_uuid]['annotation'],
+        sighting.jobs[job_uuid]['algorithm'],
+    )
 
-        sighting_utils.send_sage_identification_response(
-            flask_app_client,
-            internal_user,
-            sighting_uuid,
-            job_uuid,
-            sage_resp,
-        )
-        assert all(not job['active'] for job in sighting.jobs.values())
-        assert sighting.stage == SightingStage.un_reviewed
-
-    finally:
-        for group in asset_group_uuids:
-            asset_group_utils.delete_asset_group(flask_app_client, researcher_1, group)
-        for trans in transactions:
-            tus_utils.cleanup_tus_dir(trans)
+    sighting_utils.send_sage_identification_response(
+        flask_app_client,
+        internal_user,
+        sighting_uuid,
+        job_uuid,
+        sage_resp,
+    )
+    assert all(not job['active'] for job in sighting.jobs.values())
+    assert sighting.stage == SightingStage.un_reviewed

--- a/tests/modules/sightings/resources/utils.py
+++ b/tests/modules/sightings/resources/utils.py
@@ -46,23 +46,10 @@ def cleanup_tus_dir(tid):
 def create_sighting(
     flask_app_client,
     user,
-    test_root,
-    request,
     data_in={'locationId': 'PYTEST', 'startTime': '2000-01-01T01:01:01Z'},
     expected_status_code=200,
     expected_error=None,
 ):
-    from tests.modules.asset_groups.resources import utils as asset_group_utils
-
-    asset_group_data = asset_group_utils.AssetGroupCreationData()
-
-    asset_group, sightings = asset_group_utils.create_asset_group_and_sighting(
-        flask_app_client,
-        user,
-        test_root,
-        request,
-        asset_group_data.get(),
-    )
     response = test_utils.post_via_flask(
         flask_app_client,
         user,

--- a/tests/modules/sightings/resources/utils.py
+++ b/tests/modules/sightings/resources/utils.py
@@ -46,10 +46,23 @@ def cleanup_tus_dir(tid):
 def create_sighting(
     flask_app_client,
     user,
+    test_root,
+    request,
     data_in={'locationId': 'PYTEST', 'startTime': '2000-01-01T01:01:01Z'},
     expected_status_code=200,
     expected_error=None,
 ):
+    from tests.modules.asset_groups.resources import utils as asset_group_utils
+
+    asset_group_data = asset_group_utils.AssetGroupCreationData()
+
+    asset_group, sightings = asset_group_utils.create_asset_group_and_sighting(
+        flask_app_client,
+        user,
+        test_root,
+        request,
+        asset_group_data.get(),
+    )
     response = test_utils.post_via_flask(
         flask_app_client,
         user,

--- a/tests/modules/test_ia_pipeline.py
+++ b/tests/modules/test_ia_pipeline.py
@@ -50,15 +50,11 @@ def test_ia_pipeline_sim_detect_response(
         assert ags1.jobs[job_uuid]['model'] == 'african_terrestrial'
 
         # Simulate response from Sage
-        sage_resp = asset_group_utils.build_sage_detection_response(
-            asset_group_sighting1_guid, job_uuid
-        )
         asset_group_utils.send_sage_detection_response(
             flask_app_client,
             internal_user,
             asset_group_sighting1_guid,
             job_uuid,
-            sage_resp,
         )
         assert ags1.stage == AssetGroupSightingStage.curation
 

--- a/tests/tasks/app/test_job_control.py
+++ b/tests/tasks/app/test_job_control.py
@@ -24,8 +24,7 @@ def test_asset_group_detection_jobs(
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     asset_group_uuid = None
     try:
-        data = asset_group_utils.AssetGroupCreationData(transaction_id)
-        data.add_filename(0, test_filename)
+        data = asset_group_utils.AssetGroupCreationData(transaction_id, test_filename)
         data.set_field('speciesDetectionModel', ['african_terrestrial'])
 
         # Simulate a valid response from Sage but don't actually send the request to Sage
@@ -116,8 +115,7 @@ def test_sighting_identification_jobs(
             test_root, str(uuid.uuid4())
         )
 
-        data = asset_group_utils.AssetGroupCreationData(transaction_id)
-        data.add_filename(0, test_filename)
+        data = asset_group_utils.AssetGroupCreationData(transaction_id, test_filename)
         response = asset_group_utils.create_asset_group(
             flask_app_client, researcher_1, data.get()
         )


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Refactored and simplified the AssetGroupSighting test utils
- Tests now use a limited set of utils that should be clearer

---
- create_simple_asset_group added which does the finalizer bits for the tus transaction and the asset group so the calling code doesn't need to.
- AssetGroupCreationData constructor takes an optioonal filename as virtually all tests populate it 
- send_sage_detection_response now has data as optional and creates it if needed (in all tests at the moment) 

