### PR TITLE
Fix frontend serving routes to exclude /{login,logout}

### DIFF
--- a/.dockerfiles/www/codex.conf
+++ b/.dockerfiles/www/codex.conf
@@ -6,7 +6,7 @@ server {
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     # proxy_set_header X-Forwarded-Host $http_host;
-    location ~ /(houston|api|swaggerui|login|logout) {
+    location ~ /(houston|api|swaggerui) {
         proxy_pass http://houston:5000;
     }
     location / {


### PR DESCRIPTION
The `/login` and `/logout` routes shouldn't be served by houston.
This change removes them from nginx's location rule.
