### PR TITLE
Move frontend build stage lower in image instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,3 @@
-FROM node:lts as frontend
-# "mws" or "codex"
-ARG PROJECT
-# Copy the necessary source items
-RUN mkdir /code
-COPY ./scripts /code/scripts
-# Build the frontend
-RUN set -x \
-    && cd /code \
-    && git clone https://github.com/WildMeOrg/${PROJECT}-frontend.git _frontend.${PROJECT} \
-    && export DEBUG=1 \
-    && /bin/bash -c "source ./scripts/${PROJECT}/build.frontend.sh && build" \
-    && /bin/bash -c "source ./scripts/${PROJECT}/build.frontend.sh && install"
-
-
 FROM node:lts as swagger-ui
 # Copy the necessary source items
 RUN mkdir /code
@@ -96,6 +81,21 @@ COPY ./.dockerfiles/docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT [ "/docker-entrypoint.sh" ]
 #: default command within the entrypoint
 # CMD [ "invoke", "app.run" ]
+
+
+FROM node:lts as frontend
+# "mws" or "codex"
+ARG PROJECT
+# Copy the necessary source items
+RUN mkdir /code
+COPY ./scripts /code/scripts
+# Build the frontend
+RUN set -x \
+    && cd /code \
+    && git clone https://github.com/WildMeOrg/${PROJECT}-frontend.git _frontend.${PROJECT} \
+    && export DEBUG=1 \
+    && /bin/bash -c "source ./scripts/${PROJECT}/build.frontend.sh && build" \
+    && /bin/bash -c "source ./scripts/${PROJECT}/build.frontend.sh && install"
 
 
 FROM main as with_frontend


### PR DESCRIPTION
This moves the frontend build stage (see Docker build stages for
details) lower in the Dockerfile. This corrects and issue where older
style building (i.e. `DOCKER_BUILDKIT=0`) linearly reads and executes
the file. In most cases we're targetting the `main` build stage, which
does not use the `frontend` build stage. By moving it lower in the
file we allow the older build process to complete the `main` stage
build.

To reproduce use
`DOCKER_BUILDKIT=0 docker build --target main .`.
Prior to this change it will fail. After this change it will
succeed.
