### PR TITLE
Add additional settings to configure redis connectivity

### DIFF
--- a/.dockerfiles/redis/redis.conf
+++ b/.dockerfiles/redis/redis.conf
@@ -1,0 +1,1 @@
+requirepass seekret_development_password

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -126,7 +126,7 @@ def create_app(
 
     # Set up celery using redis as the broker and result backend
     # Use the same redis instance as tus but use database "1"
-    redis_uri = f'redis://{app.config["REDIS_HOST"]}/1'
+    redis_uri = app.config['REDIS_CONNECTION_STRING']
     app.celery = Celery('houston', broker=redis_uri, backend=redis_uri)
     # celery.conf.update(app.config)
 

--- a/app/extensions/tus/flask_tus_cont.py
+++ b/app/extensions/tus/flask_tus_cont.py
@@ -35,7 +35,7 @@ class TusManager(object):
         self.upload_folder = app.config['UPLOADS_DATABASE_PATH']
         self.tus_max_file_size = app.config.get('tus_max_file_size_in_bytes', 4294967296)
         self.file_overwrite = app.config.get('tus_file_overwrite', True)
-        self.redis_host = app.config['REDIS_HOST']
+        self.redis_connection_string = app.config['REDIS_CONNECTION_STRING']
 
         self._register_routes()
         self.app = app
@@ -105,7 +105,7 @@ class TusManager(object):
 
     # handle redis server connection
     def redis_connect(self):
-        return redis.Redis(host=self.redis_host)
+        return redis.from_url(self.redis_connection_string)
 
     @property
     def redis_connection(self):

--- a/docker-compose.codex.yml
+++ b/docker-compose.codex.yml
@@ -24,8 +24,10 @@ services:
 
   redis:
     image: redis:latest
+    command: ["redis-server", "/redis.conf"]
     volumes:
       - redis-var:/data
+      - .dockerfiles/redis/redis.conf:/redis.conf
     networks:
       - intranet
 
@@ -129,6 +131,7 @@ services:
       ELASTICSEARCH_HOSTS: "${ELASTICSEARCH_HOSTS}"
       HOUSTON_URL: "${HOUSTON_URL}"
       REDIS_HOST: redis
+      REDIS_PASSWORD: "seekret_development_password"
       GITLAB_PROTO: "${GITLAB_PROTO}"
       GITLAB_HOST: "${GITLAB_HOST}"
       GITLAB_PORT: "${GITLAB_PORT}"

--- a/tests/test_app_creation.py
+++ b/tests/test_app_creation.py
@@ -31,7 +31,8 @@ class FauxConfig:
         self.PROJECT_CONTEXT = context
         self.PROJECT_ENVIRONMENT = environment
 
-    REDIS_HOST = 'redis'
+    REDIS_CONNECTION_STRING = 'redis://redis/1'
+    REDIS_USE_SSL = False
     FAUX = True
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -18,6 +18,7 @@ import random
 import uuid
 import os
 
+from config import get_preliminary_config
 from . import TEST_ASSET_GROUP_UUID, TEST_EMPTY_ASSET_GROUP_UUID
 
 from flask_restx_patched import is_extension_enabled, is_module_enabled
@@ -447,9 +448,10 @@ def row_count(db, cls):
 
 def redis_unavailable(cached_value=[]):
     if len(cached_value) == 0:
+        config = get_preliminary_config(environment='testing')
         try:
-            host = os.getenv('REDIS_HOST') or 'localhost'
-            redis.Redis(host=host).get('test')
+            url = config.REDIS_CONNECTION_STRING
+            redis.from_url(url).get('test')
             cached_value.append(False)
         except redis.exceptions.ConnectionError:
             cached_value.append(True)


### PR DESCRIPTION
This change comes about due to needing both password authentication
and an ssl connection to the production redis instance (i.e. Azure
Redis service).

These changes are backwards compatible, in that the
user can still only supply `REDIS_HOST` for a plain redis service
instance, which is still in use within the mws composition.

To configure the redis connection to use SSL, set
`REDIS_USE_SSL=1` env var. To disable set to `0` (default).

The password is optional and can be set via the `REDIS_PASSWORD` env
var.

Optionally, the database number can also be set using the
`REDIS_DATABASE` env var.
