### PR TITLE
DEX-595: fixes and tests for delete-cascade in EDM

### DIFF
--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -36,7 +36,7 @@ class EDMManager(RestManager):
     ENDPOINT_PREFIX = 'api'
 
     # this is based on edm date of most recent commit (we must be at or greater than this)
-    MIN_VERSION = '2021-12-01 01:02:03 -0700'
+    MIN_VERSION = '2021-12-07 01:02:03 -0700'
 
     # We use // as a shorthand for prefix
     # fmt: off

--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -238,6 +238,7 @@ class EncounterByID(Resource):
         if deleted_individuals:
             from app.modules.individuals.models import Individual
 
+            deleted_ids = []
             for indiv_guid in deleted_individuals:
                 goner = Individual.query.get(indiv_guid)
                 if goner is None:
@@ -246,6 +247,8 @@ class EncounterByID(Resource):
                     )
                 else:
                     log.info(f'EDM requested cascade-delete of {goner}; deleting')
+                    deleted_ids.append(indiv_guid)
                     goner.delete()
 
+            resp.headers['x-deletedIndividual-guids'] = ', '.join(deleted_ids)
         return resp

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -267,7 +267,6 @@ class Sighting(db.Model, FeatherModel):
     def delete_from_edm_by_guid(cls, current_app, guid, request):
         assert guid is not None
         (response, response_data, result,) = current_app.edm.request_passthrough_parsed(
-            # response = current_app.edm.request_passthrough(
             'sighting.data',
             'delete',
             {},

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -260,17 +260,19 @@ class Sighting(db.Model, FeatherModel):
                 asset = assets.pop()
                 asset.delete()
 
-    def delete_from_edm(self, current_app):
-        return Sighting.delete_from_edm_by_guid(current_app, self.guid)
+    def delete_from_edm(self, current_app, request):
+        return Sighting.delete_from_edm_by_guid(current_app, self.guid, request)
 
     @classmethod
-    def delete_from_edm_by_guid(cls, current_app, guid):
+    def delete_from_edm_by_guid(cls, current_app, guid, request):
         assert guid is not None
-        response = current_app.edm.request_passthrough(
+        (response, response_data, result,) = current_app.edm.request_passthrough_parsed(
+            # response = current_app.edm.request_passthrough(
             'sighting.data',
             'delete',
             {},
             guid,
+            request_headers=request.headers,
         )
         return response
 

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -599,7 +599,21 @@ class SightingByID(Resource):
         Delete a Sighting by ID.
         """
         # first try delete on edm
-        response = sighting.delete_from_edm(current_app, request)
+        try:
+            response = sighting.delete_from_edm(current_app, request)
+        except HoustonException as ex:
+            edm_status_code = ex.get_val('edm_status_code', 400)
+            log.warning(
+                f'Sighting.delete {sighting.guid} failed: ({ex.status_code} / edm={edm_status_code}) {ex.message}'
+            )
+            abort(
+                success=False,
+                edm_status_code=edm_status_code,
+                passed_message='Delete failed',
+                message='Error',
+                code=400,
+            )
+
         response_data = None
         if response.ok:
             response_data = response.json()

--- a/tests/modules/sightings/resources/test_delete_cascade.py
+++ b/tests/modules/sightings/resources/test_delete_cascade.py
@@ -121,7 +121,7 @@ def test_individual_cascade(flask_app_client, test_root, researcher_1, request, 
     response = encounter_utils.delete_encounter(
         flask_app_client, researcher_1, encounter1_id, headers=headers
     )
-    # this is reported by edm, which sighting got cascade-deleted
+    # this is reported by edm, which individuals got cascade-deleted
     assert response.headers.get('x-deletedIndividual-guids') == individual_id
     ct = test_utils.all_count(db)
     assert ct['Encounter'] == orig_ct['Encounter'] + 1

--- a/tests/modules/sightings/resources/test_delete_cascade.py
+++ b/tests/modules/sightings/resources/test_delete_cascade.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-docstring
+
+# purpose of this is to really try to cover all permutations of the edm delete-cascade scenarios.  DEX-595
+#
+# there are a couple cases already covered:
+#
+# - tests/modules/encounters/resources/test_delete_encounter.py::test_delete_method
+#   this checks direct "DELETE encounter-guid" api, when enc-delete takes a sighting *and* indvidiual with it
+#
+# - tests/modules/sightings/resources/test_create_sighting.py::test_create_and_modify_and_delete_sighting
+#   checks PATCH on sighting path=/encounters op=remove, but only checks sighting-delete-cascade
+#
+# but there may be some redundancy with these tests in here.
+
+
+from tests.modules.sightings.resources import utils as sighting_utils
+from tests.modules.individuals.resources import utils as individual_utils
+from tests.modules.encounters.resources import utils as encounter_utils
+from tests import utils as test_utils
+import datetime
+import pytest
+
+from tests.utils import module_unavailable
+
+timestamp = datetime.datetime.now().isoformat() + 'Z'
+
+
+# this one will do nothing with individuals
+@pytest.mark.skipif(
+    module_unavailable('sightings', 'encounters'), reason='Sightings module disabled'
+)
+def test_sighting_cascade(flask_app_client, test_root, researcher_1, request, db):
+    from app.modules.sightings.models import Sighting
+
+    orig_ct = test_utils.all_count(db)
+    data_in = {
+        'encounters': [{}, {}],
+        'startTime': timestamp,
+        'locationId': 'test',
+    }
+    uuids = sighting_utils.create_sighting(
+        flask_app_client, researcher_1, request, test_root, data_in
+    )
+
+    sighting_id = uuids['sighting']
+    sighting = Sighting.query.get(sighting_id)
+    assert sighting is not None
+    assert len(uuids['encounters']) == 2
+    enc0_id = uuids['encounters'][0]
+    enc1_id = uuids['encounters'][1]
+    assert enc0_id is not None
+    assert enc1_id is not None
+
+    ct = test_utils.all_count(db)
+    assert ct['Sighting'] == orig_ct['Sighting'] + 1
+    assert ct['Encounter'] == orig_ct['Encounter'] + 2
+
+    # okay cuz we are left with a single encounter still
+    response = encounter_utils.delete_encounter(flask_app_client, researcher_1, enc0_id)
+    ct = test_utils.all_count(db)
+    assert ct['Sighting'] == orig_ct['Sighting'] + 1
+    assert ct['Encounter'] == orig_ct['Encounter'] + 1
+
+    # this should fail, as its final encounter
+    response = encounter_utils.delete_encounter(
+        flask_app_client, researcher_1, enc1_id, expected_status_code=400
+    )
+    # 604 is the sighting-specific block from edm
+    assert response.json.get('edm_status_code') == 604
+
+    # now it should work, taking the sighting with it
+    headers = (('x-allow-delete-cascade-sighting', True),)
+    response = encounter_utils.delete_encounter(
+        flask_app_client, researcher_1, enc1_id, headers=headers
+    )
+    # this is reported by edm, which sighting got cascade-deleted
+    assert response.headers.get('x-deletedSighting-guid') == sighting_id
+    ct = test_utils.all_count(db)
+    assert ct['Sighting'] == orig_ct['Sighting']
+    assert ct['Encounter'] == orig_ct['Encounter']
+
+
+# this one only tests individuals
+@pytest.mark.skipif(
+    module_unavailable('sightings', 'encounters'), reason='Sightings module disabled'
+)
+def test_individual_cascade(flask_app_client, test_root, researcher_1, request, db):
+    orig_ct = test_utils.all_count(db)
+    data_in = {
+        'encounters': [{}, {}],
+        'startTime': timestamp,
+        'locationId': 'test',
+    }
+    uuids = individual_utils.create_individual_and_sighting(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root,
+        sighting_data=data_in,
+    )
+    assert len(uuids['encounters']) == 2
+    sighting_id = uuids['sighting']
+    encounter1_id = uuids['encounters'][0]
+    encounter2_id = uuids['encounters'][1]
+    individual_id = uuids['individual']
+    ct = test_utils.all_count(db)
+    assert ct['Sighting'] == orig_ct['Sighting'] + 1
+    assert ct['Encounter'] == orig_ct['Encounter'] + 2
+    assert ct['Individual'] == orig_ct['Individual'] + 1
+
+    # note only encounter1 has individual on it, so this should trigger cascade
+    response = encounter_utils.delete_encounter(
+        flask_app_client, researcher_1, encounter1_id, expected_status_code=400
+    )
+    # 605 is the individual-specific block from edm
+    assert response.json.get('edm_status_code') == 605
+
+    # now it should be okay
+    headers = (('x-allow-delete-cascade-individual', True),)
+    response = encounter_utils.delete_encounter(
+        flask_app_client, researcher_1, encounter1_id, headers=headers
+    )
+    # this is reported by edm, which sighting got cascade-deleted
+    assert response.headers.get('x-deletedIndividual-guids') == individual_id
+    ct = test_utils.all_count(db)
+    assert ct['Encounter'] == orig_ct['Encounter'] + 1
+    assert ct['Individual'] == orig_ct['Individual']
+
+    # now we add an individual to encounter2
+    individual_data_in = {
+        'encounters': [{'id': str(encounter2_id)}],
+    }
+    individual_response = individual_utils.create_individual(
+        flask_app_client, researcher_1, 200, individual_data_in
+    )
+    assert individual_response.json['result']['id'] is not None
+    individual_id = individual_response.json['result']['id']
+    ct = test_utils.all_count(db)
+    assert ct['Encounter'] == orig_ct['Encounter'] + 1
+    assert ct['Individual'] == orig_ct['Individual'] + 1
+
+    # this will allow cascade delete of individual and sighting
+    headers = (
+        ('x-allow-delete-cascade-sighting', True),
+        ('x-allow-delete-cascade-individual', True),
+    )
+    response = encounter_utils.delete_encounter(
+        flask_app_client, researcher_1, encounter2_id, headers=headers
+    )
+    assert response.headers.get('x-deletedSighting-guid') == sighting_id
+    assert response.headers.get('x-deletedIndividual-guids') == individual_id
+    # should bring us back to where we started
+    ct = test_utils.all_count(db)
+    assert ct['Sighting'] == orig_ct['Sighting']
+    assert ct['Encounter'] == orig_ct['Encounter']
+    assert ct['Individual'] == orig_ct['Individual']
+
+
+# this tests deleting a sighting which contains encounters which have individuals
+@pytest.mark.skipif(
+    module_unavailable('sightings', 'encounters'), reason='Sightings module disabled'
+)
+def test_multi_cascade(flask_app_client, test_root, researcher_1, request, db):
+    orig_ct = test_utils.all_count(db)
+    data_in = {
+        'encounters': [{}, {}],
+        'startTime': timestamp,
+        'locationId': 'test',
+    }
+    uuids = individual_utils.create_individual_and_sighting(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root,
+        sighting_data=data_in,
+    )
+    assert len(uuids['encounters']) == 2
+    sighting_id = uuids['sighting']
+    # encounter1_id = uuids['encounters'][0]
+    encounter2_id = uuids['encounters'][1]
+    individual1_id = uuids['individual']
+    ct = test_utils.all_count(db)
+    assert ct['Sighting'] == orig_ct['Sighting'] + 1
+    assert ct['Encounter'] == orig_ct['Encounter'] + 2
+    assert ct['Individual'] == orig_ct['Individual'] + 1
+
+    # note only encounter1 has individual on it, so add one to encounter2
+    individual_data_in = {
+        'encounters': [{'id': str(encounter2_id)}],
+    }
+    individual_response = individual_utils.create_individual(
+        flask_app_client, researcher_1, 200, individual_data_in
+    )
+    assert individual_response.json['result']['id'] is not None
+    individual2_id = individual_response.json['result']['id']
+    ct = test_utils.all_count(db)
+    assert ct['Individual'] == orig_ct['Individual'] + 2
+
+    response = sighting_utils.delete_sighting(
+        flask_app_client, researcher_1, sighting_id, expected_status_code=400
+    )
+    # 605 means individual-delete-cascade is blocking
+    assert response.json.get('edm_status_code') == 605
+
+    # lets say we are okay - should delete *two* individuals
+    headers = (('x-allow-delete-cascade-individual', True),)
+    response = sighting_utils.delete_sighting(
+        flask_app_client, researcher_1, sighting_id, headers=headers
+    )
+    assert response
+    assert individual1_id
+    assert individual2_id
+    # import utool as ut
+    # ut.embed()
+    # assert response.headers.get('x-deletedIndividual-guids') == individual_id
+    # ct = test_utils.all_count(db)

--- a/tests/modules/sightings/resources/test_delete_cascade.py
+++ b/tests/modules/sightings/resources/test_delete_cascade.py
@@ -209,9 +209,10 @@ def test_multi_cascade(flask_app_client, test_root, researcher_1, request, db):
         flask_app_client, researcher_1, sighting_id, headers=headers
     )
     assert response
-    assert individual1_id
-    assert individual2_id
-    # import utool as ut
-    # ut.embed()
-    # assert response.headers.get('x-deletedIndividual-guids') == individual_id
-    # ct = test_utils.all_count(db)
+    assert response.headers
+    del_indiv_header = response.headers.get('x-deletedIndividual-guids')
+    assert del_indiv_header == ', '.join(
+        [individual1_id, individual2_id]
+    ) or del_indiv_header == ', '.join([individual2_id, individual1_id])
+    ct = test_utils.all_count(db)
+    assert ct['Individual'] == orig_ct['Individual']

--- a/tests/modules/sightings/resources/utils.py
+++ b/tests/modules/sightings/resources/utils.py
@@ -294,9 +294,11 @@ def patch_sighting(
     return response
 
 
-def delete_sighting(flask_app_client, user, sight_guid, expected_status_code=204):
+def delete_sighting(
+    flask_app_client, user, sight_guid, expected_status_code=204, headers=None
+):
     with flask_app_client.login(user, auth_scopes=('sightings:write',)):
-        response = flask_app_client.delete('%s%s' % (PATH, sight_guid))
+        response = flask_app_client.delete('%s%s' % (PATH, sight_guid), headers=headers)
 
     if expected_status_code == 204:
         assert response.status_code == 204, response.json
@@ -304,6 +306,7 @@ def delete_sighting(flask_app_client, user, sight_guid, expected_status_code=204
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message'}
         )
+    return response
 
 
 # Create a default valid Sage detection response (to allow for the test to corrupt it accordingly)


### PR DESCRIPTION
## Pull Request Overview

- Tweaks to logic (both [in EDM](https://github.com/WildMeOrg/Wildbook/commit/4a2c7a3ecc034485844c98beac7fa1a41febcc92) and houston) to better handle **cascade-delete** of Individual(s) when a Sighting is removed
- Adds a specific test for various cascade-delete cases

---

**Review Notes**
- Sighting resources.py API `DELETE` call now does this work
- Made modification of `sighting.delete_from_edm()` to use different passthrough call in order to handle Headers
