### PR TITLE
Swagger UI fix

### DIFF
--- a/app/templates/swagger-ui.html
+++ b/app/templates/swagger-ui.html
@@ -110,7 +110,28 @@
                     SwaggerUIStandalonePreset.slice(1) // No Topbar
                 ],
                 plugins: [
-                    SwaggerUIBundle.plugins.DownloadUrl
+                    SwaggerUIBundle.plugins.DownloadUrl,
+                    {# added to correct security problem #}
+                    {# see also https://github.com/advisories/GHSA-qrmm-w75w-3wpx #}
+                    function UrlParamDisablePlugin() {
+                      return {
+                        statePlugins: {
+                          spec: {
+                            wrapActions: {
+                              // Remove the ?url parameter from loading an external OpenAPI definition.
+                              updateUrl: (oriAction) => (payload) => {
+                                const url = new URL(window.location.href)
+                                if (url.searchParams.has('url')) {
+                                  url.searchParams.delete('url')
+                                  window.location.replace(url.toString())
+                                }
+                                return oriAction(payload)
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
                 ],
                 {% if config.SWAGGER_SUPPORTED_SUBMIT_METHODS is defined -%}
                   supportedSubmitMethods: {{ config.SWAGGER_SUPPORTED_SUBMIT_METHODS | tojson}},

--- a/scripts/swagger/build.sh
+++ b/scripts/swagger/build.sh
@@ -45,7 +45,8 @@ function build() {
 
     npm install --legacy-peer-deps
 
-    npm audit fix --force
+    # FIXME: added --audit-level=high to circumvent https://github.com/advisories/GHSA-qrmm-w75w-3wpx
+    npm audit fix --force --audit-level=high
 
     # Copy files
     cp node_modules/swagger-ui-dist/{swagger-ui*.{css,js}{,.map},favicon*.png,oauth2-redirect.html} swagger_static/

--- a/scripts/swagger/build.sh
+++ b/scripts/swagger/build.sh
@@ -30,6 +30,7 @@ function build() {
     # Update code
     pushd "${SOURCE_PATH}"
 
+    set -ex
     # Remove any pre-downloaded modules
     rm -rf node_modules/
     rm -rf package-lock.json
@@ -53,6 +54,7 @@ function build() {
 
     cp -R node_modules/typeface-droid-sans/files swagger_static/
 
+    set ex
     popd
 }
 


### PR DESCRIPTION
This follows the guidance for fixing the swagger-ui against a security
issue. See https://github.com/advisories/GHSA-qrmm-w75w-3wpx for
details. This is largely untested, though I have put `?url=blah` in to
ensure this plugin does as intended.

The build script has been updated to ignore the security problem, but still allow >= high audit problems to stop the build.

Once the swagger-ui-dist package has been released with the fix we can remove all the changes made in this PR.