### PR TITLE
DEX-585: merging Individuals with new Names

### DIFF
--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -486,20 +486,14 @@ class Individual(db.Model, FeatherModel):
                     name.context = Individual._incremented_context(
                         name.context, contexts_on_self
                     )
-                    log.warn(f'>>>>>>>>>>>>> just incremented to {name.context}!!!')
                 name.individual_guid = self.guid  # attach name to self
                 # does name actually get stored here?
-                log.warn(f'>>>>>>>>>>>>> adding {name} to self')
                 contexts_on_self.add(name.context)
         # now we deal with overrides
         for name in self.names:
             if name.context in override_contexts:
                 name.value = override[name.context]
-                log.warn(
-                    f'>>>>>>>>>>>>> found override-context {name.context}, updating value to {name.value}'
-                )
-        # self.names = self.names
-        db.session.refresh(self)
+        db.session.refresh(self)  # updates .names on all parties
         return self.names
 
     @classmethod
@@ -509,7 +503,6 @@ class Individual(db.Model, FeatherModel):
         ct = -1
         reg = '^' + ctx + r'(\d+)'
         for ex in existing:
-            # print(f'#### {ex}:{ct}')
             if ex == ctx and ct < 0:
                 ct = 0  # this at least should happen
                 continue
@@ -517,9 +510,7 @@ class Individual(db.Model, FeatherModel):
             if not m:
                 continue
             val = int(m.groups()[0])
-            # print(f'>>>> val={val},ct={ct}')
             ct = max(val, ct)
-            # print(f'>>>> ct={ct}')
         if ct < 0:
             raise ValueError(f'no matches of {ctx} in {existing}')
         ct += 1

--- a/tests/modules/individuals/resources/test_merge_conflicts.py
+++ b/tests/modules/individuals/resources/test_merge_conflicts.py
@@ -5,6 +5,7 @@ from tests.modules.individuals.resources import utils as individual_utils
 import pytest
 from tests import utils as test_utils
 import logging
+from app.modules.individuals.models import Individual
 
 log = logging.getLogger(__name__)
 
@@ -92,8 +93,6 @@ def test_get_conflicts(
     assert res == {'sex': True}
 
     # add some names with a common context
-    from app.modules.individuals.models import Individual
-
     individual1 = Individual.query.get(individual1_guid)
     individual2 = Individual.query.get(individual2_guid)
     assert individual1

--- a/tests/modules/individuals/resources/utils.py
+++ b/tests/modules/individuals/resources/utils.py
@@ -220,6 +220,5 @@ def merge_conflicts(
         data=individuals,
         expected_status_code=expected_status_code,
         response_200=set(),
-        returns_list=True,
     )
     return resp.json

--- a/tests/modules/individuals/test_merge.py
+++ b/tests/modules/individuals/test_merge.py
@@ -363,3 +363,37 @@ def test_failure_cases(db, flask_app_client, researcher_1, request):
     assert rtn
     assert len(rtn) == 2
     assert set([individual1, individual2]) == set(rtn)
+
+
+@pytest.mark.skipif(
+    test_utils.module_unavailable('individuals', 'encounters', 'sightings'),
+    reason='Individuals module disabled',
+)
+def test_merge_names(db, flask_app_client, researcher_1, admin_user, request, test_root):
+    from app.modules.individuals.models import Individual
+
+    individual1_uuids = individual_utils.create_individual_and_sighting(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root,
+    )
+    individual2_uuids = individual_utils.create_individual_and_sighting(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root,
+    )
+
+    individual1_id = individual1_uuids['individual']
+    individual2_id = individual2_uuids['individual']
+
+    shared_context = 'test-context'
+    individual1 = Individual.query.get(individual1_id)
+    individual1.add_name(shared_context, 'one', researcher_1)
+    individual1.add_name('another', 'another', researcher_1)
+    individual2 = Individual.query.get(individual2_id)
+    individual2.add_name(shared_context, 'two', researcher_1)
+    import utool as ut
+
+    ut.embed()

--- a/tests/modules/individuals/test_merge.py
+++ b/tests/modules/individuals/test_merge.py
@@ -404,21 +404,15 @@ def test_merge_names(db, flask_app_client, researcher_1, admin_user, request, te
     overridden_context = 'test-override'
     individual1.add_name(shared_context, 'one', researcher_1)
     individual1.add_name('another', 'another', researcher_1)
-    individual1.add_name(
-        overridden_context, 'gone1', researcher_1
-    )  # blown away by override
-    individual2.add_name(
-        shared_context, 'two', researcher_1
-    )  # should get bumped to have 2 suffix
-    individual2.add_name(
-        overridden_context, 'gone2', researcher_1
-    )  # blown away by override
-    individual3.add_name(
-        shared_context, 'three', researcher_1
-    )  # should get bumped to have 3 suffix
-    individual3.add_name(
-        'third', '333', researcher_1
-    )  # should get bumped to have 3 suffix
+    # blown away by override
+    individual1.add_name(overridden_context, 'gone1', researcher_1)
+    # should get bumped to have 1 suffix
+    individual2.add_name(shared_context, 'two', researcher_1)
+    # blown away by override
+    individual2.add_name(overridden_context, 'gone2', researcher_1)
+    # should get bumped to have 2 suffix
+    individual3.add_name(shared_context, 'three', researcher_1)
+    individual3.add_name('third', '333', researcher_1)
     assert len(individual1.names) == 3
     assert len(individual2.names) == 2
     assert len(individual3.names) == 2
@@ -470,9 +464,9 @@ def test_merge_names(db, flask_app_client, researcher_1, admin_user, request, te
     individual3_id = individual3_uuids['individual']
     individual2 = Individual.query.get(individual2_id)
     individual3 = Individual.query.get(individual3_id)
-    # should be ignored via override
+    # both of these should be ignored via override
     individual2.add_name(shared_context, 'AAA', researcher_1)
-    individual3.add_name(shared_context, 'BBB', researcher_1)  # ditto
+    individual3.add_name(shared_context, 'BBB', researcher_1)
     individual3.add_name('endearment', 'sweetie', researcher_1)  # will get added
     assert len(individual2.names) == 1
     assert len(individual3.names) == 2
@@ -484,3 +478,9 @@ def test_merge_names(db, flask_app_client, researcher_1, admin_user, request, te
     assert len(individual1.names) == 7  # original 6 (one swapped out - override) + 1 new
     assert len(individual2.names) == 0
     assert len(individual3.names) == 0
+    # verify override one stuck
+    found = False
+    for name in individual1.names:
+        if name.context == shared_context and name.value == final_value:
+            found = True
+    assert found

--- a/tests/modules/individuals/test_merge.py
+++ b/tests/modules/individuals/test_merge.py
@@ -384,16 +384,103 @@ def test_merge_names(db, flask_app_client, researcher_1, admin_user, request, te
         request,
         test_root,
     )
+    individual3_uuids = individual_utils.create_individual_and_sighting(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root,
+    )
 
     individual1_id = individual1_uuids['individual']
     individual2_id = individual2_uuids['individual']
-
-    shared_context = 'test-context'
+    individual3_id = individual3_uuids['individual']
     individual1 = Individual.query.get(individual1_id)
+    individual2 = Individual.query.get(individual2_id)
+    individual3 = Individual.query.get(individual3_id)
+
+    # this tests directly individual.merge_names() which currently is only used
+    #   from within merging
+    shared_context = 'test-context'
+    overridden_context = 'test-override'
     individual1.add_name(shared_context, 'one', researcher_1)
     individual1.add_name('another', 'another', researcher_1)
-    individual2 = Individual.query.get(individual2_id)
-    individual2.add_name(shared_context, 'two', researcher_1)
-    import utool as ut
+    individual1.add_name(
+        overridden_context, 'gone1', researcher_1
+    )  # blown away by override
+    individual2.add_name(
+        shared_context, 'two', researcher_1
+    )  # should get bumped to have 2 suffix
+    individual2.add_name(
+        overridden_context, 'gone2', researcher_1
+    )  # blown away by override
+    individual3.add_name(
+        shared_context, 'three', researcher_1
+    )  # should get bumped to have 3 suffix
+    individual3.add_name(
+        'third', '333', researcher_1
+    )  # should get bumped to have 3 suffix
+    assert len(individual1.names) == 3
+    assert len(individual2.names) == 2
+    assert len(individual3.names) == 2
 
-    ut.embed()
+    individual1.merge_names([individual2, individual3], {overridden_context: 'winner'})
+    assert len(individual1.names) == 6
+    assert len(individual2.names) == 1  # overridden one is left behind to die
+    assert len(individual3.names) == 0
+    assert {
+        shared_context,
+        f'{shared_context}1',
+        f'{shared_context}2',
+        'another',
+        'third',
+        overridden_context,
+    } == set([name.context for name in individual1.names])
+
+    # test fail_on_conflict flag (currently not used anywhere) - should raise ValueError
+    individual4_uuids = individual_utils.create_individual_and_sighting(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root,
+    )
+    individual4_id = individual4_uuids['individual']
+    individual4 = Individual.query.get(individual4_id)
+    individual4.add_name(shared_context, 'break', researcher_1)
+    try:
+        individual1.merge_names([individual4], fail_on_conflict=True)
+    except ValueError as ve:
+        assert str(ve).startswith(f'conflict on context {shared_context}')
+    assert len(individual1.names) == 6
+    assert len(individual4.names) == 1
+
+    # now we try as a part of an actual merge, with an override as well
+    individual2_uuids = individual_utils.create_individual_and_sighting(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root,
+    )
+    individual3_uuids = individual_utils.create_individual_and_sighting(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root,
+    )
+    individual2_id = individual2_uuids['individual']
+    individual3_id = individual3_uuids['individual']
+    individual2 = Individual.query.get(individual2_id)
+    individual3 = Individual.query.get(individual3_id)
+    # should be ignored via override
+    individual2.add_name(shared_context, 'AAA', researcher_1)
+    individual3.add_name(shared_context, 'BBB', researcher_1)  # ditto
+    individual3.add_name('endearment', 'sweetie', researcher_1)  # will get added
+    assert len(individual2.names) == 1
+    assert len(individual3.names) == 2
+
+    final_value = 'final-value'
+    merge_from = [individual2, individual3]
+    parameters = {'override': {'name_context': {shared_context: final_value}}}
+    individual1.merge_from(*merge_from, parameters=parameters)
+    assert len(individual1.names) == 7  # original 6 (one swapped out - override) + 1 new
+    assert len(individual2.names) == 0
+    assert len(individual3.names) == 0


### PR DESCRIPTION
## Pull Request Overview

- `individual.merge_names()` created to handle Name-resolution when merging (via method or API)
- `find_merge_conflicts()` (used by related API) now detects conflicts in **Name contexts** as well

**Review Notes**
- Default behavior is to _increment context string_ when duplicates conflict across Individuals.  The **target Individual** (surviving the merge) will keep the Name context as-is (e.g. "`context`"), while subsequent merged-in Names will become `context1`, `context2`, and so on.
- `parameters` passed into merging (via method or API) may now contain:
```
{
    "override": {
        "name_context": {
            CONTEXT1: OVERRIDING_VALUE1,
            CONTEXT2: OVERRIDING_VALUE2, ...
        }
        ...
    },
    ...
}
```
which will beat out any other names with the referenced _contexts_.  No incrementing will occur.
