### PR TITLE
404 or 500 from EDM causes deletion to continue

### DIFF
--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -280,7 +280,10 @@ class Sighting(db.Model, FeatherModel):
         try:
             (response, response_data, result) = self.delete_from_edm(current_app, request)
         except HoustonException as ex:
-            if ex.get_val('edm_status_code', 0) == 500:
+            if (
+                ex.get_val('edm_status_code', 0) == 404
+                or ex.get_val('edm_status_code', 0) == 500
+            ):
                 # assume that means that we tried to delete a non-existent sighting
                 # TODO handle failure
                 self.delete_cascade()


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- EDM Sighting deletion now sometimes returnd 404, sometimes 500 on failure
- In either case, delete what was created in Houston assuming that the EDM resources have gone. 

---

