### PR TITLE
DEX-603 DEX-596 DEX-598 Allow null as the value in PATCH requests

### DIFF
--- a/app/extensions/config/parameters.py
+++ b/app/extensions/config/parameters.py
@@ -12,6 +12,7 @@ from .models import HoustonConfig
 class PatchHoustonConfigParameters(PatchJSONParametersWithPassword):
     VALID_FIELDS = _CONFIG_PATH_CHOICES + ['current_password']
     PATH_CHOICES = tuple('/%s' % field for field in VALID_FIELDS)
+    NON_NULL_PATHS = ('/ENV',)
 
     @classmethod
     def add(cls, obj, field, value, state):

--- a/app/modules/annotations/parameters.py
+++ b/app/modules/annotations/parameters.py
@@ -53,6 +53,8 @@ class PatchAnnotationDetailsParameters(PatchJSONParameters):
         )
     )
 
+    NON_NULL_PATHS = ('/ia_class',)
+
     @classmethod
     def add(cls, obj, field, value, state):
         if field == 'keywords':

--- a/flask_restx_patched/parameters.py
+++ b/flask_restx_patched/parameters.py
@@ -76,12 +76,13 @@ class PatchJSONParameters(Parameters):
     op = base_fields.String(required=True)  # pylint: disable=invalid-name
 
     PATH_CHOICES = None
+    NON_NULL_PATHS = ()
 
     path = base_fields.String(required=True)
 
     NO_VALUE_OPERATIONS = (OP_REMOVE,)
 
-    value = base_fields.Raw(required=False)
+    value = base_fields.Raw(required=False, allow_none=True)
 
     def __init__(self, *args, **kwargs):
         if 'many' in kwargs:
@@ -121,6 +122,13 @@ class PatchJSONParameters(Parameters):
             raise ValidationError('Path is required and must always begin with /')
         else:
             data['field_name'] = data['path'][1:]
+
+        if (
+            data['op'] not in self.NO_VALUE_OPERATIONS
+            and data['path'] in self.NON_NULL_PATHS
+            and not data.get('value')
+        ):
+            raise ValidationError('value cannot be null')
 
     @classmethod
     def perform_patch(cls, operations, obj, state=None):

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -301,6 +301,49 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
         },
     }
 
+    # PATCH asset group sightings encounter with sex None
+    response = session.patch(
+        codex_url(
+            f'/api/v1/asset_groups/sighting/as_sighting/{ags_guids[0]}/encounter/{encounter_guids[0]}'
+        ),
+        json=[
+            {
+                'op': 'replace',
+                'path': '/sex',
+                'value': None,
+            }
+        ],
+    )
+    assert response.status_code == 200
+    assert response.json()['encounters'] == [
+        {
+            # 2021-11-13T16:57:41.937173+00:00
+            'createdHouston': encounters[0]['createdHouston'],
+            'customFields': {
+                enc_test_cfd: 'CFD_TEST_VALUE',
+            },
+            'decimalLatitude': 63.142385,
+            'decimalLongitude': -21.596914,
+            'guid': encounter_guids[0],
+            'hasEdit': True,
+            'hasView': True,
+            'id': encounter_guids[0],
+            'individual': {},
+            'owner': {
+                'full_name': my_name,
+                'guid': my_guid,
+                'profile_fileupload': None,
+            },
+            'sex': None,
+            'submitter': None,
+            'taxonomy': {'id': tx_id},
+            'time': encounter_timestamp,
+            # 2021-11-13T16:57:41.937187+00:00
+            'updatedHouston': response.json()['updatedHouston'],
+            'version': None,
+        },
+    ]
+
     # Commit asset group sighting (becomes sighting)
     response = session.post(
         codex_url(f'/api/v1/asset_groups/sighting/{ags_guids[0]}/commit')

--- a/tests/modules/asset_groups/resources/test_patch_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_patch_asset_group.py
@@ -165,6 +165,21 @@ def test_patch_asset_group_sighting_as_sighting(
     # chosen for reasons of incongruity as the naked mole rat is virtually blind
     # so has no 'sight'
     add_name_patch = [utils.patch_add_op('name', 'Naked Mole Rat')]
-    asset_group_utils.patch_asset_group_sighting_as_sighting(
+    response = asset_group_utils.patch_asset_group_sighting_as_sighting(
         flask_app_client, researcher_1, asset_group_sighting_guid, add_name_patch
     )
+
+    # Patch encounter in asset group sighting
+    encounter_guids = [e['guid'] for e in response.json['encounters']]
+
+    # Set first encounter sex to male
+    response = utils.patch_via_flask(
+        flask_app_client,
+        researcher_1,
+        scopes='asset_groups:write',
+        path=f'/api/v1/asset_groups/sighting/as_sighting/{asset_group_sighting_guid}/encounter/{encounter_guids[0]}',
+        data=[{'op': 'replace', 'path': '/sex', 'value': 'male'}],
+        expected_status_code=200,
+        response_200={'guid', 'encounters'},
+    )
+    assert [e['sex'] for e in response.json['encounters']] == ['male', None]

--- a/tests/modules/asset_groups/resources/test_patch_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_patch_asset_group.py
@@ -183,3 +183,15 @@ def test_patch_asset_group_sighting_as_sighting(
         response_200={'guid', 'encounters'},
     )
     assert [e['sex'] for e in response.json['encounters']] == ['male', None]
+
+    # Set first encounter sex to null
+    response = utils.patch_via_flask(
+        flask_app_client,
+        researcher_1,
+        scopes='asset_groups:write',
+        path=f'/api/v1/asset_groups/sighting/as_sighting/{asset_group_sighting_guid}/encounter/{encounter_guids[0]}',
+        data=[{'op': 'replace', 'path': '/sex', 'value': None}],
+        expected_status_code=200,
+        response_200={'guid', 'encounters'},
+    )
+    assert [e['sex'] for e in response.json['encounters']] == [None, None]


### PR DESCRIPTION
- Add PATCH asset_groups/sighting/as_sighting/<id>/encounter/<id>

  This is exactly the same as
  `PATCH asset_groups/sighting/<id>/encounter/<id>` except it returns the
  result using `AssetGroupSightingAsSightingSchema`.

- Allow null as the value in PATCH requests

  When sending `"value": null` in PATCH requests, the server returned 422
  Unprocessable Entity error.  An example request is:
  
  ```
  PATCH /api/v1/asset_groups/sighting/<id>/encounter/<id>
  
  [{"op": "replace", "path": "/sex", "value": null}]
  ```
  
  This should be valid but the server returned 422.
  
  The error was raised in
  `flask_restx_patched.parameters.PatchJSONParameters.validate_patch_structure`, specifically:
  
  ```
  if data['op'] not in self.NO_VALUE_OPERATIONS and 'value' not in data:
      raise ValidationError('value is required')
  ```
  
  `value` was not in `data` even though `"value": null` was sent.  I'll
  explain what I found:
  
  The `PatchJSONParameters` class is a subclass of `marshmallow.Schema`,
  the fields were:
  
  ```
  op = base_fields.String(required=True)
  path = base_fields.String(required=True)
  value = base_fields.Raw(required=False)
  ```
  
  It turns out if `value` is `None`, the `value` field just doesn't get
  included.  What we needed is explicitly say `None` is allowed by adding
  `allow_none=True` to the `value` field definition.
  
  This changed the behavior of all the PATCH code.  There are 2 tests that
  depended on not allowing `null` as a valid value.
  
  In order to fix them, I added `NON_NULL_PATHS` to `PatchJSONParameters`,
  so if adding or replacing any of the `NON_NULL_PATHS`,
  `validate_patch_structure` will raise a validation error and 422 is
  returned.
