### PR TITLE
606 patch of annot in AGS is singular add and remove, replace not sup…

### DIFF
--- a/app/modules/asset_groups/metadata.py
+++ b/app/modules/asset_groups/metadata.py
@@ -152,14 +152,7 @@ class AssetGroupMetadata(object):
             )
 
         for annot_uuid in annotations:
-            # Need to find the annotation for which the asset is part of the current asset group
-            annots = [
-                annot
-                for annot in Annotation.query.filter_by(content_guid=annot_uuid).all()
-                if annot.asset.asset_group_guid == asset_group_sighting.asset_group_guid
-            ]
-
-            if len(annots) != 1:
+            if not Annotation.query.get(annot_uuid):
                 raise AssetGroupMetadataError(
                     log, f'{debug} annotation:{str(annot_uuid)} not found'
                 )

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -266,16 +266,9 @@ class AssetGroupSighting(db.Model, HoustonModel):
 
                 annotations = req_data.get('annotations', [])
                 for annot_uuid in annotations:
-                    annots = [
-                        annot
-                        for annot in Annotation.query.filter_by(
-                            content_guid=annot_uuid
-                        ).all()
-                        if annot.asset.asset_group_guid == self.asset_group_guid
-                    ]
-                    # Must be valid, checked in metadata parsing
-                    assert len(annots) == 1
-                    annot = annots[0]
+                    annot = Annotation.query.get(annot_uuid)
+                    assert annot
+
                     AuditLog.audit_log_object(
                         log,
                         new_encounter,

--- a/app/modules/asset_groups/parameters.py
+++ b/app/modules/asset_groups/parameters.py
@@ -8,7 +8,7 @@ import uuid
 
 from app.modules.sightings.parameters import PatchSightingDetailsParameters
 from app.modules.encounters.parameters import PatchEncounterDetailsParameters
-
+from .metadata import AssetGroupMetadata, AssetGroupMetadataError
 from flask_restx_patched import Parameters, PatchJSONParameters
 from flask_login import current_user  # NOQA
 
@@ -74,9 +74,6 @@ class PatchAssetGroupSightingDetailsParameters(PatchJSONParameters):
     def add(cls, obj, field, value, state):
         # Encounter is special in that it can only be added to an AssetGroupSightingDetails.
         if field == 'encounters':
-            # Reuse metadata methods to validate ID Config, creating a single entry list for the encounters
-            from .metadata import AssetGroupMetadata
-
             AssetGroupMetadata.validate_encounters(
                 [
                     value,
@@ -107,8 +104,6 @@ class PatchAssetGroupSightingDetailsParameters(PatchJSONParameters):
     # metadata functionality
     @classmethod
     def validate_asset_references(cls, obj, asset_refs):
-        from .metadata import AssetGroupMetadataError
-
         for filename in asset_refs:
             # asset must exist and must be part of the group
             if not obj.asset_group.get_asset_for_file(filename):
@@ -118,9 +113,6 @@ class PatchAssetGroupSightingDetailsParameters(PatchJSONParameters):
 
     @classmethod
     def replace(cls, obj, field, value, state):
-        # Reuse metadata methods to validate ID Config
-        from .metadata import AssetGroupMetadata
-
         ret_val = False
 
         if field == 'config':
@@ -180,16 +172,12 @@ class PatchAssetGroupSightingDetailsParameters(PatchJSONParameters):
 class PatchAssetGroupSightingAsSightingParameters(
     PatchAssetGroupSightingDetailsParameters
 ):
-
     # These don't exist as entities in the AssetGroupSighting, they're just config blobs
     # but we allow patching faking them to be real
     # This uses the fact that anything that is an EDM sighting path is in the
     # AssetGroupSighting in the same format
-
     @classmethod
     def replace(cls, obj, field, value, state):
-        # Reuse metadata methods to validate ID Config
-        from .metadata import AssetGroupMetadata
 
         ret_val = False
 
@@ -223,7 +211,11 @@ class PatchAssetGroupSightingAsSightingParameters(
 
 class PatchAssetGroupSightingEncounterDetailsParameters(PatchJSONParameters):
     # pylint: disable=abstract-method,missing-docstring
-    OPERATION_CHOICES = (PatchJSONParameters.OP_REPLACE, PatchJSONParameters.OP_ADD)
+    OPERATION_CHOICES = (
+        PatchJSONParameters.OP_REPLACE,
+        PatchJSONParameters.OP_ADD,
+        PatchJSONParameters.OP_REMOVE,
+    )
     # These don't exist as entities in the AssetGroupSighting, they're just config blobs
     # but we allow patching faking them to be real
 
@@ -234,17 +226,7 @@ class PatchAssetGroupSightingEncounterDetailsParameters(PatchJSONParameters):
     )
 
     @classmethod
-    def add(cls, obj, field, value, state):
-        # Add and replace are the same operation so reuse the one method
-        return cls.replace(obj, field, value, state)
-
-    @classmethod
-    def replace(cls, obj, field, value, state):
-        # Reuse metadata methods to validate fields
-        from .metadata import AssetGroupMetadata, AssetGroupMetadataError
-
-        ret_val = True
-
+    def _get_encounter_data(cls, obj, state):
         assert 'encounter_uuid' in state
         encounter_uuid = state['encounter_uuid']
         encounter_metadata = obj.get_encounter_metadata(encounter_uuid)
@@ -254,15 +236,45 @@ class PatchAssetGroupSightingEncounterDetailsParameters(PatchJSONParameters):
                 log,
                 f'Encounter {encounter_uuid} not found in AssetGroupSighting {obj.guid}',
             )
+        return encounter_uuid, encounter_metadata
+
+    @classmethod
+    def add(cls, obj, field, value, state):
+
+        # Annotations are special in that it can only be added, not replaced.
+        if field == 'annotations':
+            encounter_uuid, encounter_metadata = cls._get_encounter_data(obj, state)
+
+            AssetGroupMetadata.validate_annotations(
+                obj,
+                [
+                    value,
+                ],
+                f'Encounter {encounter_uuid}',
+            )
+            if 'annotations' not in encounter_metadata.keys():
+                encounter_metadata['annotations'] = []
+            encounter_metadata['annotations'].append(value)
+            # force the write to the database
+            obj.config = obj.config
+            return True
+
+        else:
+            # For everything else, Add and replace are the same operation so reuse the one method
+            return cls.replace(obj, field, value, state)
+
+    @classmethod
+    def replace(cls, obj, field, value, state):
+
+        ret_val = True
+        encounter_uuid, encounter_metadata = cls._get_encounter_data(obj, state)
 
         if field == 'ownerEmail':
             AssetGroupMetadata.validate_owner_email(value, f'Encounter {encounter_uuid}')
             encounter_metadata[field] = value
         elif field == 'annotations':
-            AssetGroupMetadata.validate_annotations(
-                obj, value, f'Encounter {encounter_uuid}'
-            )
-            encounter_metadata[field] = value
+            # Cannot replace the list, must do add and remove on individual annotations
+            ret_val = False
         elif field == 'individualUuid':
             AssetGroupMetadata.validate_individual(value, f'Encounter {encounter_uuid}')
             encounter_metadata[field] = value
@@ -270,4 +282,27 @@ class PatchAssetGroupSightingEncounterDetailsParameters(PatchJSONParameters):
             encounter_metadata[field] = value
         # force the write to the database
         obj.config = obj.config
+        return ret_val
+
+    @classmethod
+    def remove(cls, obj, field, value, state):
+        ret_val = False
+        changed = False
+        encounter_uuid, encounter_metadata = cls._get_encounter_data(obj, state)
+        if field == 'annotations':
+            # 'remove' passed for the annotation even if it wasn't there to start with
+            ret_val = True
+            if 'annotations' in encounter_metadata.keys():
+                if not isinstance(value, str):
+                    # but fails for invalid value type
+                    ret_val = False
+                else:
+                    for config_annotation in encounter_metadata['annotations']:
+                        if config_annotation['guid'] == value:
+                            encounter_metadata['annotations'].remove(config_annotation)
+                            changed = True
+        if changed:
+            # Force the DB write
+            obj.config = obj.config
+
         return ret_val

--- a/app/modules/assets/schemas.py
+++ b/app/modules/assets/schemas.py
@@ -19,6 +19,8 @@ class BaseAssetSchema(ModelSchema):
     Base Asset schema exposes only the most general fields.
     """
 
+    dimensions = base_fields.Function(Asset.get_dimensions)
+
     class Meta:
         # pylint: disable=missing-docstring
         model = Asset
@@ -54,12 +56,15 @@ class DetailedAssetSchema(BaseAssetSchema):
 
 
 class DetailedAssetGroupAssetSchema(BaseAssetSchema):
-    fields = BaseAssetSchema.Meta.fields + (
-        Asset.created.key,
-        Asset.updated.key,
-        'annotations',
-        'dimensions',
-    )
+    annotations = base_fields.Nested('BaseAnnotationSchema', many=True)
+
+    class Meta(BaseAssetSchema.Meta):
+        fields = BaseAssetSchema.Meta.fields + (
+            Asset.created.key,
+            Asset.updated.key,
+            'annotations',
+            'dimensions',
+        )
 
 
 def not_negative(value):

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -477,6 +477,7 @@ def test_bulk_upload(session, login, codex_url, test_root, request):
         sighting_guids.append(response.json()['guid'])
 
 
+# Run the integration test enough times and it leaves a load of groups which causes the limit to be reached
 def disabled_test_remove_all_groups(session, login, codex_url, test_root, request):
     login(session)
     groups = session.get(codex_url('/api/v1/asset_groups/'))

--- a/integration_tests/test_sage_detection.py
+++ b/integration_tests/test_sage_detection.py
@@ -62,13 +62,21 @@ def test_create_asset_group_detection(session, codex_url, test_root, login):
     first_job = response_json['jobs'][job_id]
     job_start = first_job['start']
     annotations = first_job['json_result']['results_list'][0]
-    annotation_uuids = [annot['uuid']['__UUID__'] for annot in annotations]
+    sage_annotation_uuids = [annot['uuid']['__UUID__'] for annot in annotations]
+
     assert response_json == {
         'assets': [
             {
                 'guid': asset_guids[0],
                 'src': f'/api/v1/assets/src/{asset_guids[0]}',
                 'filename': 'zebra.jpg',
+                'annotations': response_json['assets'][0]['annotations'],
+                'created': response_json['assets'][0]['created'],
+                'updated': response_json['assets'][0]['updated'],
+                'dimensions': {
+                    'height': 664,
+                    'width': 1000,
+                },
             }
         ],
         'completion': 10,
@@ -89,7 +97,7 @@ def test_create_asset_group_detection(session, codex_url, test_root, login):
                         [
                             {
                                 'id': annotations[0]['id'],
-                                'uuid': {'__UUID__': annotation_uuids[0]},
+                                'uuid': {'__UUID__': sage_annotation_uuids[0]},
                                 'xtl': 178,
                                 'ytl': 72,
                                 'left': 178,

--- a/tests/modules/asset_groups/resources/test_patch_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_patch_asset_group.py
@@ -109,7 +109,6 @@ def test_patch_asset_group(
         patch_data,
     )
 
-    # TODO look at this block. Where does it need to go
     # Valid patch, removing the added encounter
     guid_to_go = patch_resp.json['config']['encounters'][-1]['guid']
     patch_remove = [utils.patch_remove_op('encounters', guid_to_go)]

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -80,7 +80,6 @@ def patch_in_dummy_annotation(
     # Create a dummy annotation for this Sighting
     new_annot = Annotation(
         guid=uuid.uuid4(),
-        content_guid=uuid.uuid4(),
         asset=asset,
         ia_class='none',
         viewpoint='test',
@@ -95,9 +94,7 @@ def patch_in_dummy_annotation(
     )
     encounter_guid = group_sighting.json['config']['encounters'][encounter_num]['guid']
 
-    patch_data = [
-        test_utils.patch_replace_op('annotations', [str(new_annot.content_guid)])
-    ]
+    patch_data = [test_utils.patch_add_op('annotations', [str(new_annot.guid)])]
     patch_asset_group_sighting(
         flask_app_client,
         user,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -489,3 +489,9 @@ def dummy_sighting_info():
 
 def dummy_detection_info():
     return ['None']
+
+
+def print_message(message):
+    import json
+
+    print(json.dumps(message, indent=4, sort_keys=True))


### PR DESCRIPTION
…ported. Also must be the annot guid, not the content guid

<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Patch of Annotation on AssetGroupSighting Encounter supports add and remove but not replace.
- Add and remove are of a single annotation and must use the annotation primary key guid, not the content guid as previously 

---


**REST API Updates **
[PATCH] /api/v1/assetgroupsightings/{sighting_guid}/encounter/{encounter_guid}
```
{
    "path": "/annotations",
    "op": "add",
    "value": annotation_guid
}
```
[PATCH] /api/v1/assetgroupsightings/{sighting_guid}/encounter/{encounter_guid}
```
{
    "path": "/annotations",
    "op": "remove",
    "value": annotation_guid 
}
```


