### PR TITLE
Fix invalid ssh key

### DIFF
--- a/.dockerfiles/docker-entrypoint-init.d.codex/set_up_gitlab.sh
+++ b/.dockerfiles/docker-entrypoint-init.d.codex/set_up_gitlab.sh
@@ -82,7 +82,7 @@ EOF
         echo "Found and removing existing SSH key pair"
         rm -f ${GIT_SSH_KEY_FILEPATH} ${GIT_SSH_KEY_FILEPATH}.pub
     fi
-    ssh-keygen -t rsa -b 4096 -C "Houston (${user_id})" -f "${GIT_SSH_KEY_FILEPATH}" -N ""
+    ssh-keygen -t ecdsa -b 521 -C "Houston (${user_id})" -f "${GIT_SSH_KEY_FILEPATH}" -N ""
     echo "Send the 'houston' user's public ssh key to gitlab"
     resp=$(gitlab user-key create --user-id ${user_id} --title "Houston Application" --key "$(cat ${GIT_SSH_KEY_FILEPATH}.pub)")
     # See also https://docs.gitlab.com/ee/ssh/

--- a/config/base.py
+++ b/config/base.py
@@ -391,6 +391,12 @@ class AssetGroupConfig(object):
         if not fp.exists():
             with fp.open('w') as fb:
                 fb.write(self.GIT_SSH_KEY)
+                # Write a newline at the end of the file to avoid
+                # `Load key "/data/var/id_ssh_key": invalid format`
+                fb.write('\n')
+        # Ensure permissions are read-only for the runtime user
+        # to avoid `Load key "/data/var/id_ssh_key": bad permissions`
+        fp.chmod(0o400)
         return fp
 
     @property


### PR DESCRIPTION
### Invalid file from environment variable

Corrects and issue where the `GIT_SSH_KEY` environment variable is a string without a trailing newline (i.e. `\n`). The newline is required to make the file valid from the SSH client utility perspective. Adding extra newlines is not an issue.

This problem is only visible when `${DATA_ROOT}/id_ssh_key` file does not exist and the user supplies the `GIT_SSH_KEY` to the application. You'd not see this in the default docker-compose scenario because we create the keyfile on startup, thus the affected block of code is not run. This comes up, when you've got an instance of gitlab that has an SSH key preregistered, which is part of the production deployment story.

### Default file permission are too insecure

Corrects file permisions when the python configuration code writes the ssh key file. This avoids ssh failing because the key file is insecure. ssh sees the file as insecure if anyone but the owner can read the file.

### SSH key type change

Also, now using the more secure ECDSA type for generating the SSH key.