### PR TITLE
DEX-645 back end add time and timeSpecificity parameters to ags patch…

### DIFF
--- a/app/modules/asset_groups/parameters.py
+++ b/app/modules/asset_groups/parameters.py
@@ -68,6 +68,8 @@ class PatchAssetGroupSightingDetailsParameters(PatchJSONParameters):
         '/idConfigs',
         '/assetReferences',
         '/name',
+        '/time',
+        '/timeSpecificity',
     )
 
     @classmethod


### PR DESCRIPTION
## Pull Request Overview

- Added time and timeSpecificity as params to the asset group sighting PATCH api
- Followed JVO's exact instructions lol

---

**Review Notes**
- Previously, a patch request resulted in a 402 error with "no valid choice" for the specified time and timeSpecificity paths.
- I don't _think_ any db table modifications are needed, but I have absolutely no idea.