### PR TITLE
DEX-660: allow time and timeSpecificity on AGS encounter PATCH

### DIFF
--- a/app/modules/asset_groups/parameters.py
+++ b/app/modules/asset_groups/parameters.py
@@ -224,6 +224,8 @@ class PatchAssetGroupSightingEncounterDetailsParameters(PatchJSONParameters):
     PATH_CHOICES = PatchEncounterDetailsParameters.PATH_CHOICES_EDM + (
         '/ownerEmail',
         '/owner',  # Needed as that is the field name in the encounter that we're pretending to be
+        '/time',
+        '/timeSpecificity',
         '/annotations',
         '/individualUuid',
     )


### PR DESCRIPTION
## Pull Request Overview

- When PATCH'ing an encounter within an AssetGroupSighting, `time` and `timeSpecificity` were not allowed; add them to valid fields
- Test for above