### PR TITLE
DEX-502 Add encounters index to load_codex_indexes task

### DIFF
--- a/tests/modules/elasticsearch/test_tasks.py
+++ b/tests/modules/elasticsearch/test_tasks.py
@@ -80,9 +80,10 @@ def test_load_codex_indexes(monkeypatch, flask_app):
     # Capture elasticsearch object saving for proof checks
     captures = []
     capture_save = lambda self, **kwargs: captures.append([self, kwargs])  # noqa: E731
-    from gumby.models import Individual
+    from gumby.models import Individual, Encounter
 
     monkeypatch.setattr(Individual, 'save', capture_save)
+    monkeypatch.setattr(Encounter, 'save', mock.Mock())
 
     # Call the target function
     tasks.load_codex_indexes()


### PR DESCRIPTION
Add encounters index to elastic search (also see WildMeOrg/gumby#5)

I'm not sure what we actually want to search but I got something in elastic search so I thought we can adjust it from here...

---

To test this branch you'll need to install the `encounters-index` branch of gumby:

```bash
docker-compose restart houston
```

Add encounters to elastic search:

```bash
docker-compose exec houston /bin/bash
echo 'from app.modules.elasticsearch.tasks import load_encounters_index; load_encounters_index()' | invoke app.shell
````

Then you can go to http://localhost:9200/encounters/_search to look at the results:

```json
{
  "took": 1327,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 10000,
      "relation": "gte"
    },
    "max_score": 1,
    "hits": [
      {
        "_index": "encounters",
        "_type": "_doc",
        "_id": "encounter_d7210c39-cfe2-449e-b5d3-28af0233a598",
        "_score": 1,
        "_source": {
          "id": "d7210c39-cfe2-449e-b5d3-28af0233a598",
          "point": "0.580981666666667,37.6601566666667",
          "sex": "female",
          "genus": "Equus",
          "species": "Equus grevyi"
        }
      },
      ...
    ]
  }
}
```