### PR TITLE
Fix RecursionError when edm authentication fails

### DIFF
--- a/app/extensions/restManager/RestManager.py
+++ b/app/extensions/restManager/RestManager.py
@@ -181,7 +181,7 @@ class RestManager(RestManagerUserMixin):
         for target in self.uris:
             self._ensure_session(target)
 
-    def _ensure_session(self, target):
+    def _ensure_session(self, target, reauthenticating=False):
         """
         Ensures that a session always exists, uses the presence of the auth credentials in the
         environment to determine if a login is required.
@@ -208,6 +208,7 @@ class RestManager(RestManagerUserMixin):
                 password,
                 target=target,
                 ensure_initialized=False,
+                reauthenticated=reauthenticating,
             )
             assert (
                 not isinstance(response, requests.models.Response) or response.ok
@@ -293,7 +294,7 @@ class RestManager(RestManagerUserMixin):
                 response = json.loads(response.text, object_hook=_json_object_hook)
         elif response.status_code == 401 and not reauthenticated:
             # Try re-authenticating
-            self._ensure_session(target)
+            self._ensure_session(target, reauthenticating=True)
             return self._request(
                 method,
                 tag,


### PR DESCRIPTION
`_ensure_session` calls `_request` which calls `_ensure_session` again:

```
2022-01-18 01:54:18,180 [INFO] [werkzeug] 172.31.0.2 - - [18/Jan/2022 01:54:18] "GET /api/v1/configuration/default/__bundle_setup HTTP/1.0" 500 -
Traceback (most recent call last):
  ...
  File "/usr/local/lib/python3.9/site-packages/flask_restx/resource.py", line 49, in dispatch_request
    resp = meth(*args, **kwargs)
  File "/code/app/modules/configuration/resources.py", line 132, in get
    data = current_app.edm.get_dict(
  File "/code/app/extensions/restManager/RestManager.py", line 342, in get_dict
    response = self._request(
  File "/code/app/extensions/restManager/RestManager.py", line 255, in _request
    self._ensure_initialized()
  File "/code/app/extensions/restManager/RestManager.py", line 225, in _ensure_initialized
    self._init_all_sessions()
  File "/code/app/extensions/restManager/RestManager.py", line 182, in _init_all_sessions
    self._ensure_session(target)
  File "/code/app/extensions/restManager/RestManager.py", line 204, in _ensure_session
    response = self._request(
  File "/code/app/extensions/restManager/RestManager.py", line 296, in _request
    self._ensure_session(target)
  File "/code/app/extensions/restManager/RestManager.py", line 204, in _ensure_session
    response = self._request(
  File "/code/app/extensions/restManager/RestManager.py", line 296, in _request
    self._ensure_session(target)
  ...
  File "/code/app/extensions/restManager/RestManager.py", line 204, in _ensure_session
    response = self._request(
  File "/code/app/extensions/restManager/RestManager.py", line 289, in _request
    response = request_func(endpoint_encoded, **passthrough_kwargs)
  File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 542, in get
    return self.request('GET', url, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 529, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 645, in send
    r = adapter.send(request, **kwargs)
  ...
RecursionError: maximum recursion depth exceeded while calling a Python object
```

Add `reauthenticating` to `_ensure_session` so `_request` knows when to stop
reauthenticating.

