### PR TITLE
Add DELETE /api/v1/asset_groups/sighting/as_sighting/<id> API

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -1642,6 +1642,14 @@ class AssetGroup(db.Model, HoustonModel):
         # for its completion)
         delete_remote.delay(str(self.guid))
 
+    def delete_asset_group_sighting(self, asset_group_sighting):
+        with db.session.begin(subtransactions=True):
+            for asset in self.assets:
+                asset_ags = self.get_asset_group_sightings_for_asset(asset)
+                if asset_ags == [asset_group_sighting]:
+                    asset.delete_cascade()
+            asset_group_sighting.delete()
+
     # stub of DEX-220 ... to be continued
     def justify_existence(self):
         if self.assets:  # we have assets, so we live on

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -461,6 +461,32 @@ class AssetGroupSightingAsSighting(Resource):
         AuditLog.patch_object(log, asset_group_sighting, args, duration=timer.elapsed())
         return asset_group_sighting
 
+    @api.permission_required(
+        permissions.ObjectAccessPermission,
+        kwargs_on_request=lambda kwargs: {
+            'obj': kwargs['asset_group_sighting'],
+            'action': AccessOperation.DELETE,
+        },
+    )
+    @api.login_required(oauth_scopes=['asset_group_sightings:write'])
+    @api.response(code=HTTPStatus.CONFLICT)
+    @api.response(code=HTTPStatus.NO_CONTENT)
+    def delete(self, asset_group_sighting):
+        """Delete an asset group sighting by ID."""
+        asset_group = asset_group_sighting.asset_group
+        if [asset_group_sighting] == asset_group.asset_group_sightings:
+            # Delete the only asset group sighting deletes the asset group
+            try:
+                asset_group.delete()
+            except HoustonException as ex:
+                abort(
+                    ex.status_code,
+                    ex.message,
+                    edm_status_code=ex.get_val('edm_status_code', None),
+                )
+        else:
+            asset_group.delete_asset_group_sighting(asset_group_sighting)
+
 
 @api.route('/sighting/<uuid:asset_group_sighting_guid>/encounter/<uuid:encounter_guid>')
 @api.response(

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -65,6 +65,10 @@ OBJECT_USER_MAP = {
         'is_admin',
         'is_researcher',
     ],
+    ('AssetGroupSighting', AccessOperation.DELETE): [
+        'is_admin',
+        'is_researcher',
+    ],
     ('Individual', AccessOperation.READ): ['is_researcher'],
     ('AssetGroupSighting', AccessOperation.WRITE_PRIVILEGED): ['is_internal'],
     ('Encounter', AccessOperation.READ): ['is_researcher'],

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -440,12 +440,3 @@ def test_bulk_upload(session, login, codex_url, test_root, request):
         )
         assert response.status_code == 200
         sighting_guids.append(response.json()['guid'])
-
-
-# Run the integration test enough times and it leaves a load of groups which causes the limit to be reached
-def test_remove_all_groups(session, login, codex_url, test_root, request):
-    login(session)
-    groups = session.get(codex_url('/api/v1/asset_groups/'))
-    for group_dat in groups.json():
-        group_guid = group_dat['guid']
-        session.delete(codex_url(f'/api/v1/asset_groups/{group_guid}'))


### PR DESCRIPTION
- Move test_remove_all_groups to integration tests cleanup fixture

  `test_remove_all_groups` isn't actually a test, it's just some code to
  remove groups as groups are created during the tests.
  
  Create a new "cleanup" session fixture that cleans up after an
  integration test run.

- Add DELETE /api/v1/asset_groups/sighting/as_sighting/<id> API

  We had no ways of deleting an asset group sighting before.  When the
  only asset group sighting in the asset group is deleted, the asset group
  itself is also deleted.

