### PR TITLE
646 species detection models in AGS and Sighting response

### DIFF
--- a/app/extensions/gitlab.py
+++ b/app/extensions/gitlab.py
@@ -57,6 +57,9 @@ class GitlabManager(object):
         return self._gl_group
 
     def get_project(self, name):
+        if not self._is_gitlab_configured():
+            log.warning('Gitlab not configured, no project')
+            return None
         """Lookup a specific gitlab project/repo by name that is within the preconfigured namespace/group"""
         self._ensure_initialized()
 
@@ -69,6 +72,10 @@ class GitlabManager(object):
             return projects[0]
         else:
             return None
+
+    def _is_gitlab_configured(self):
+        remote_uri = current_app.config.get('GITLAB_REMOTE_URI', None)
+        return remote_uri != '-'
 
     def _ensure_initialized(self):
         if not self.initialized:

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -417,7 +417,8 @@ class AssetGroupSighting(db.Model, HoustonModel):
     @staticmethod
     def config_field_getter(field_name, default=None, cast=None):
         def getter(self):
-            value = self.config and self.config.get(field_name)
+            value = self.get_config_field(field_name)
+
             if cast is not None and value:
                 value = cast(value)
             return value or default
@@ -425,7 +426,10 @@ class AssetGroupSighting(db.Model, HoustonModel):
         return getter
 
     def get_config_field(self, field):
-        return self.config.get(field) if isinstance(self.config, dict) else None
+        value = self.config.get(field) if isinstance(self.config, dict) else None
+        if not value:
+            value = self.asset_group.get_config_field(field)
+        return value
 
     def get_custom_fields(self):
         return self.__class__.config_field_getter('customFields', default={})(self)

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -424,6 +424,9 @@ class AssetGroupSighting(db.Model, HoustonModel):
 
         return getter
 
+    def get_config_field(self, field):
+        return self.config.get(field) if isinstance(self.config, dict) else None
+
     def get_custom_fields(self):
         return self.__class__.config_field_getter('customFields', default={})(self)
 

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -173,6 +173,10 @@ class AssetGroupSightingAsSightingSchema(ModelSchema):
     comments = base_fields.Function(
         AssetGroupSighting.config_field_getter('comments', default=None)
     )
+    speciesDetectionModel = base_fields.Function(
+        AssetGroupSighting.config_field_getter('speciesDetectionModel', default=[])
+    )
+
     # These are fields that are in Sighting but don't exist for
     # AssetGroupSighting
     createdEDM = base_fields.DateTime(default=None)

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -256,6 +256,20 @@ class Sighting(db.Model, FeatherModel):
         else:
             return None
 
+    # returns a getter for a given config field, allowing for casting and default vals
+    @staticmethod
+    def config_field_getter(field_name, default=None, cast=None):
+        def getter(self):
+            value = (
+                self.asset_group_sighting
+                and self.asset_group_sighting.get_config_field(field_name)
+            )
+            if cast is not None and value:
+                value = cast(value)
+            return value or default
+
+        return getter
+
     @classmethod
     def check_jobs(cls):
         for sighting in Sighting.query.all():

--- a/app/modules/sightings/schemas.py
+++ b/app/modules/sightings/schemas.py
@@ -97,6 +97,9 @@ class AugmentedEdmSightingSchema(TimedSightingSchema):
     )
     featuredAssetGuid = base_fields.UUID(attribute='featured_asset_guid')
     creator = base_fields.Nested('PublicUserSchema', attribute='get_owner', many=False)
+    speciesDetectionModel = base_fields.Function(
+        Sighting.config_field_getter('speciesDetectionModel', default=[])
+    )
 
     class Meta(TimedSightingSchema.Meta):
         """
@@ -114,6 +117,7 @@ class AugmentedEdmSightingSchema(TimedSightingSchema):
             'creator',
             'time',
             'timeSpecificity',
+            'speciesDetectionModel',
         )
 
 

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -227,7 +227,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
         'hasView': True,
         'locationId': 'PYTEST',
         'stage': 'curation',
-        'speciesDetectionModel': [],
+        'speciesDetectionModel': ['african_terrestrial'],
         'time': '2000-01-01T01:01:01+00:00',
         'timeSpecificity': 'time',
         # 2021-11-12T18:28:32.744135+00:00
@@ -325,7 +325,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
         'detection_start_time': response.json()['detection_start_time'],
         'identification_start_time': None,
         'review_time': None,
-        'speciesDetectionModel': [],
+        'speciesDetectionModel': ['african_terrestrial'],
         'unreviewed_start_time': response.json()['unreviewed_start_time'],
     }
 

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -227,6 +227,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
         'hasView': True,
         'locationId': 'PYTEST',
         'stage': 'curation',
+        'speciesDetectionModel': [],
         'time': '2000-01-01T01:01:01+00:00',
         'timeSpecificity': 'time',
         # 2021-11-12T18:28:32.744135+00:00
@@ -324,6 +325,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
         'detection_start_time': response.json()['detection_start_time'],
         'identification_start_time': None,
         'review_time': None,
+        'speciesDetectionModel': [],
         'unreviewed_start_time': response.json()['unreviewed_start_time'],
     }
 

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -120,6 +120,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
         'customFields': occ_custom_fields,
         'decimalLatitude': -39.063228,
         'decimalLongitude': 21.832598,
+        'speciesDetectionModel': [],
         'encounters': [
             {
                 # 2021-11-09T11:15:24.343018+00:00
@@ -256,6 +257,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
         'time': '2000-01-01T01:01:01+00:00',
         'timeSpecificity': 'time',
         'stage': 'un_reviewed',
+        'speciesDetectionModel': [],
         # 2021-11-16T09:45:26.717432+00:00
         'updatedHouston': response.json()['updatedHouston'],
         'version': sighting_version,

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -120,7 +120,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
         'customFields': occ_custom_fields,
         'decimalLatitude': -39.063228,
         'decimalLongitude': 21.832598,
-        'speciesDetectionModel': [],
+        'speciesDetectionModel': ['african_terrestrial'],
         'encounters': [
             {
                 # 2021-11-09T11:15:24.343018+00:00
@@ -257,7 +257,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
         'time': '2000-01-01T01:01:01+00:00',
         'timeSpecificity': 'time',
         'stage': 'un_reviewed',
-        'speciesDetectionModel': [],
+        'speciesDetectionModel': ['african_terrestrial'],
         # 2021-11-16T09:45:26.717432+00:00
         'updatedHouston': response.json()['updatedHouston'],
         'version': sighting_version,

--- a/tests/modules/test_ia_pipeline.py
+++ b/tests/modules/test_ia_pipeline.py
@@ -45,6 +45,11 @@ def test_ia_pipeline_sim_detect_response(
         ags1 = AssetGroupSighting.query.get(asset_group_sighting1_guid)
         assert ags1
 
+        ags_as_sighting = asset_group_utils.read_asset_group_sighting_as_sighting(
+            flask_app_client, researcher_1, asset_group_sighting1_guid
+        )
+        assert ags_as_sighting.json['speciesDetectionModel'] == ['african_terrestrial']
+
         job_uuids = [guid for guid in ags1.jobs.keys()]
         assert len(job_uuids) == 1
         job_uuid = job_uuids[0]
@@ -68,6 +73,10 @@ def test_ia_pipeline_sim_detect_response(
         encounters = sighting.get_encounters()
         assert len(encounters) == 2
 
+        sighting_resp = sighting_utils.read_sighting(
+            flask_app_client, researcher_1, sighting_uuid
+        )
+        assert sighting_resp.json['speciesDetectionModel'] == ['african_terrestrial']
         # Deliberately do not test the contents. This is fluid and for our debug only
         asset_group_utils.read_asset_group(
             flask_app_client, staff_user, f'{asset_group_uuid}/debug'


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Added speciesDetectionModel to Sighting and AGS as sighting responses
- Fixed gitlab not configured Error so that it's a warning instead

---

**REST API Updates **
As requested
```
[GET] /api/v1/asset_group/sighting/as_sighting/{guid} and  /api/v1/sighting/{guid} contains speciesDetectionModel

"speciesDetectionModel": [
        "african_terrestrial"
    ],

```

