### PR TITLE
DEX-243 Add sightings index to load_codex_indexes task

### DIFF
--- a/app/modules/elasticsearch/tasks.py
+++ b/app/modules/elasticsearch/tasks.py
@@ -119,7 +119,6 @@ SELECT
   END AS sex,
   ta."SCIENTIFICNAME" as taxonomy,
   en."LIVINGSTATUS" AS living_status,
-  en."LIFESTAGE" AS lifestage
 FROM
   "ENCOUNTER" AS en
   LEFT JOIN "TAXONOMY" AS ta ON ta."ID" = en."TAXONOMY_ID_OID"

--- a/app/modules/elasticsearch/tasks.py
+++ b/app/modules/elasticsearch/tasks.py
@@ -117,14 +117,12 @@ SELECT
   CASE WHEN en."SEX" = 'unk' THEN 'unknown'
        ELSE en."SEX"
   END AS sex,
-  en."GENUS" AS genus,
-  an."SPECIES" AS species,
+  ta."SCIENTIFICNAME" as taxonomy,
   en."LIVINGSTATUS" AS living_status,
   en."LIFESTAGE" AS lifestage
 FROM
   "ENCOUNTER" AS en
-  LEFT JOIN "ENCOUNTER_ANNOTATIONS" AS ea ON ea."ID_OID" = en."ID"
-  LEFT JOIN "ANNOTATION" AS an ON ea."ID_EID" = an."ID"
+  LEFT JOIN "TAXONOMY" AS ta ON ta."ID" = en."TAXONOMY_ID_OID"
 """
 
 

--- a/app/modules/elasticsearch/tasks.py
+++ b/app/modules/elasticsearch/tasks.py
@@ -145,9 +145,6 @@ SIGHTINGS_INDEX_SQL = """\
 SELECT
   oc."ID" AS id,
   NULLIF((oc."DECIMALLATITUDE"::float || ',' || oc."DECIMALLONGITUDE")::text, ',') AS point,
-  start_time."DATETIME" AS start_time,
-  end_time."DATETIME" AS end_time,
-  -- First encounter genus
   (
     SELECT max("GENUS")
     FROM "ENCOUNTER" en
@@ -160,18 +157,9 @@ SELECT
       RIGHT JOIN "ENCOUNTER" en ON ea."ID_OID" = en."ID"
       RIGHT JOIN "OCCURRENCE_ENCOUNTERS" oe ON oe."ID_EID" = en."ID"
     WHERE oe."ID_OID" = oc."ID") AS species,
-  oc."GROUPBEHAVIOR" AS group_behavior,
-  oc."GROUPCOMPOSITION" AS group_composition,
-  oc."FIELDSTUDYSITE" AS field_study_site,
-  oc."INITIALCUE" AS initial_cue,
-  oc."SEASTATE" AS sea_state,
-  oc."HUMANACTIVITYNEARBY" AS human_activity_nearby,
-  oc."OBSERVER" AS observer,
   oc."COMMENTS" AS comments
 FROM
   "OCCURRENCE" oc
-  LEFT JOIN "COMPLEXDATETIME" start_time ON start_time."COMPLEXDATETIME_ID" = oc."STARTTIME_COMPLEXDATETIME_ID_OID"
-  LEFT JOIN "COMPLEXDATETIME" end_time ON end_time."COMPLEXDATETIME_ID" = oc."ENDTIME_COMPLEXDATETIME_ID_OID"
 """
 
 

--- a/app/modules/elasticsearch/tasks.py
+++ b/app/modules/elasticsearch/tasks.py
@@ -145,21 +145,14 @@ SIGHTINGS_INDEX_SQL = """\
 SELECT
   oc."ID" AS id,
   NULLIF((oc."DECIMALLATITUDE"::float || ',' || oc."DECIMALLONGITUDE")::text, ',') AS point,
-  (
-    SELECT max("GENUS")
-    FROM "ENCOUNTER" en
-      RIGHT JOIN "OCCURRENCE_ENCOUNTERS" oe ON oe."ID_EID" = en."ID"
-    WHERE oe."ID_OID" = oc."ID") AS genus,
-  (
-    SELECT max("SPECIES")
-    FROM "ANNOTATION" an
-      RIGHT JOIN "ENCOUNTER_ANNOTATIONS" ea ON ea."ID_EID" = an."ID"
-      RIGHT JOIN "ENCOUNTER" en ON ea."ID_OID" = en."ID"
-      RIGHT JOIN "OCCURRENCE_ENCOUNTERS" oe ON oe."ID_EID" = en."ID"
-    WHERE oe."ID_OID" = oc."ID") AS species,
+  (array_agg(ta."SCIENTIFICNAME"))[1] AS taxonomy,
   oc."COMMENTS" AS comments
 FROM
   "OCCURRENCE" oc
+  LEFT JOIN "OCCURRENCE_ENCOUNTERS" oe ON oe."ID_OID" = oc."ID"
+  LEFT JOIN "ENCOUNTER" en ON en."ID" = oe."ID_EID"
+  LEFT JOIN "TAXONOMY" ta ON ta."ID" = en."TAXONOMY_ID_OID"
+GROUP BY oc."ID"
 """
 
 

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -79,7 +79,7 @@ def wait_for(
     url,
     response_checker,
     status_code=200,
-    timeout=6 * 60,
+    timeout=10 * 60,
     *args,
     **kwargs,
 ):

--- a/tests/modules/elasticsearch/test_tasks.py
+++ b/tests/modules/elasticsearch/test_tasks.py
@@ -80,10 +80,11 @@ def test_load_codex_indexes(monkeypatch, flask_app):
     # Capture elasticsearch object saving for proof checks
     captures = []
     capture_save = lambda self, **kwargs: captures.append([self, kwargs])  # noqa: E731
-    from gumby.models import Individual, Encounter
+    from gumby.models import Individual, Encounter, Sighting
 
     monkeypatch.setattr(Individual, 'save', capture_save)
     monkeypatch.setattr(Encounter, 'save', mock.Mock())
+    monkeypatch.setattr(Sighting, 'save', mock.Mock())
 
     # Call the target function
     tasks.load_codex_indexes()


### PR DESCRIPTION
Add sightings index to elasticsearch

We need to do this in order to merge this PR:

1. Review and merge WildMeOrg/gumby#6
2. Remove ":skull: Install the gumby sightings-index branch" commit from this PR (<- added to make the tests pass before the gumby PR is merged)
3. Review and merge this PR

---

To test the sightings search:

```bash
docker-compose restart houston
```

Add encounters to elastic search:

```bash
docker-compose exec houston /bin/bash
echo 'from app.modules.elasticsearch.tasks import load_sightings_index; load_sightings_index()' | invoke app.shell
````

Then you can go to http://localhost:9200/sightings/_search to look at the results:

```json
{
  "took": 10,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 10000,
      "relation": "gte"
    },
    "max_score": 1,
    "hits": [
      {
        "_index": "sightings",
        "_type": "_doc",
        "_id": "sighting_5126a4ae-2444-4d3c-8b6d-7a16547ab804",
        "_score": 1,
        "_source": {
          "id": "5126a4ae-2444-4d3c-8b6d-7a16547ab804",
          "point": "0.324113337,36.87953407",
          "start_time": "2020-03-09T00:00:00+00:00",
          "end_time": "2020-03-09T00:00:00+00:00",
          "genus": "Equus",
          "group_behavior": "Grazing",
          "field_study_site": "Mpala",
          "comments": "None"
        }
      },
      ...
```