### PR TITLE
Dex 511 notif timestamp

### DIFF
--- a/app/modules/notifications/models.py
+++ b/app/modules/notifications/models.py
@@ -209,10 +209,7 @@ class Notification(db.Model, HoustonModel):
     recipient = db.relationship('User', back_populates='notifications')
     sender_guid = db.Column(db.GUID, nullable=True)
 
-    created = db.Column(
-        db.DateTime, index=True, default=datetime.utcnow, nullable=False
-    )
-
+    created = db.Column(db.DateTime, index=True, default=datetime.utcnow, nullable=False)
 
     def __repr__(self):
         return (

--- a/app/modules/notifications/models.py
+++ b/app/modules/notifications/models.py
@@ -6,6 +6,7 @@ Notifications database models
 
 from app.extensions import db, HoustonModel
 from app.utils import HoustonException
+from datetime import datetime  # NOQA
 
 import enum
 import uuid
@@ -207,6 +208,11 @@ class Notification(db.Model, HoustonModel):
     )
     recipient = db.relationship('User', back_populates='notifications')
     sender_guid = db.Column(db.GUID, nullable=True)
+
+    created = db.Column(
+        db.DateTime, index=True, default=datetime.utcnow, nullable=False
+    )
+
 
     def __repr__(self):
         return (

--- a/app/modules/notifications/schemas.py
+++ b/app/modules/notifications/schemas.py
@@ -43,6 +43,7 @@ class BaseNotificationSchema(ModelSchema):
             'sender_name',
             Notification.sender_guid.key,
             Notification.message_type.key,
+            Notification.created,
         )
         dump_only = (Notification.guid.key,)
 

--- a/app/modules/notifications/schemas.py
+++ b/app/modules/notifications/schemas.py
@@ -33,6 +33,7 @@ class BaseNotificationSchema(ModelSchema):
     """
 
     sender_name = base_fields.Function(Notification.get_sender_name)
+    created = base_fields.DateTime()
 
     class Meta:
         # pylint: disable=missing-docstring
@@ -43,7 +44,7 @@ class BaseNotificationSchema(ModelSchema):
             'sender_name',
             Notification.sender_guid.key,
             Notification.message_type.key,
-            Notification.created,
+            'created',
         )
         dump_only = (Notification.guid.key,)
 

--- a/tests/modules/notifications/resources/utils.py
+++ b/tests/modules/notifications/resources/utils.py
@@ -14,6 +14,7 @@ EXPECTED_NOTIFICATION_KEYS = {
     'sender_name',
     'sender_guid',
     'message_values',
+    'created',
 }
 EXPECTED_LIST_KEYS = {
     'guid',
@@ -21,6 +22,7 @@ EXPECTED_LIST_KEYS = {
     'message_type',
     'sender_name',
     'sender_guid',
+    'created',
 }
 
 


### PR DESCRIPTION
There were some test failures that I believe are unrelated to this work, but feel free to punt the PR into "unapproved" if that is not the case.

Pretty simple stuff, just adding a 'created' date time on notifications, which is indexed in the db, and including that field in the default schema.