### PR TITLE
[MWS-102] Modernize Docker Compose Start-up

### DIFF
--- a/.dockerfiles/www/nginx.conf
+++ b/.dockerfiles/www/nginx.conf
@@ -1,7 +1,14 @@
+map $request_uri $loggable {
+  / 0;
+  default 1;
+}
+
 server {
     listen       80;
     server_name  0.0.0.0;
     client_max_body_size 2g;
+
+    access_log /var/log/nginx/access.log combined if=$loggable;
 
     proxy_set_header Host $http_host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -3,3 +3,6 @@ version: "3"
 services:
   acm:
     image: wildme/wbia:arm64
+
+  edm:
+    image: wildme/edm:arm64

--- a/docker-compose.codex.yml
+++ b/docker-compose.codex.yml
@@ -3,11 +3,19 @@ version: "3.8"
 services:
 
   db:
-    image: postgres:10
+    image: postgres:13.4
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
+    user: postgres
     volumes:
       - db-pgdata-var:/var/lib/postgresql/data
       # DB initialization scripts
       - .dockerfiles/db/initdb.d/:/docker-entrypoint-initdb.d/
+    networks:
+      - intranet
     environment:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
       WBIA_DB_NAME: "${WBIA_DB_NAME}"
@@ -19,12 +27,15 @@ services:
       HOUSTON_DB_NAME: "${HOUSTON_DB_NAME}"
       HOUSTON_DB_USER: "${HOUSTON_DB_USER}"
       HOUSTON_DB_PASSWORD: "${HOUSTON_DB_PASSWORD}"
-    networks:
-      - intranet
 
   redis:
     image: redis:latest
     command: ["redis-server", "/redis.conf"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
     volumes:
       - redis-var:/data
       - .dockerfiles/redis/redis.conf:/redis.conf
@@ -34,31 +45,41 @@ services:
   elasticsearch:
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.1
-    environment:
-      "discovery.type": single-node
-    ports:
-      # development exposure, not exposed in production
-      - 9200:9200
-      - 9300:9300
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
     # volumes:
     #   - es-var:/usr/share/elasticsearch/data
     networks:
       - intranet
+    ports:
+      # development exposure, not exposed in production
+      - 9200:9200
+      - 9300:9300
+    environment:
+      "discovery.type": single-node
 
   acm:
     # https://github.com/WildMeOrg/wildbook-ia
     image: wildme/wbia:latest
-    depends_on:
-      - db
     command: ["--db-uri", "${WBIA_DB_URI}"]
+    depends_on:
+      db:
+        condition: service_healthy
+    # healthcheck:  # WBIA defines it's own health check
+    volumes:
+      - acm-database-var:/data/db
+      - acm-cache-var:/cache
     networks:
       - intranet
     ports:
       # FIXME: exposed for developer verification
       - "82:5000"
-    volumes:
-      - acm-database-var:/data/db
-      - acm-cache-var:/cache
     environment:
       WBIA_DB_URI: "${WBIA_DB_URI}"
       HOUSTON_CLIENT_ID: "${HOUSTON_CLIENT_ID}"
@@ -69,10 +90,16 @@ services:
     #  - git clone -b next-gen git@github.com:WildMeOrg/Wildbook.git && cd Wildbook
     #  - ./scripts/build.docker.sh
     image: wildme/edm:latest
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/dbconnections.jsp"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
     volumes:
       - edm-var:/data/wildbook_data_dir
-    # depends_on:
-    #   - db
     networks:
       - intranet
     ports:
@@ -95,7 +122,25 @@ services:
     build: &houston-build
       context: .
       target: main
-    command: [ "wait-for", "db:5432", "--", "wait-for", "edm:8080", "--", "wait-for", "--timeout=60", "elasticsearch:9200", "--", "invoke", "app.run", "--host", "0.0.0.0" ]
+    command: ["invoke", "app.run", "--host", "0.0.0.0" ]
+    depends_on:
+      db:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:5000/api/v1/site-info/heartbeat"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
+    volumes: &houston-volumes
+      - houston-var:/data
+      # These are added for development. Do not mount these in production.
+      - .dockerfiles/docker-entrypoint.sh:/docker-entrypoint.sh
+      - .dockerfiles/docker-entrypoint-init.d.codex:/docker-entrypoint-init.d
+      - .dockerfiles/docker-entrypoint-always-init.d:/docker-entrypoint-always-init.d
+      # FIXME: pull in development code while working on bringing up the container
+      - .:/code
     networks:
       - intranet
       - frontend
@@ -121,10 +166,10 @@ services:
       GITLAB_ADMIN_PASSWORD: "${GITLAB_ADMIN_PASSWORD}"
       GITLAB_REMOTE_URI: "${GITLAB_REMOTE_URI}"
       GITLAB_REMOTE_LOGIN_PAT: "${GITLAB_REMOTE_LOGIN_PAT}"
+      GITLAB_NAMESPACE: "${GITLAB_NAMESPACE}"
       GIT_SSH_KEY: "${GIT_SSH_KEY}"
       GIT_PUBLIC_NAME: "${GIT_PUBLIC_NAME}"
       GIT_EMAIL: "${GIT_EMAIL}"
-      GITLAB_NAMESPACE: "${GITLAB_NAMESPACE}"
       OAUTH_CLIENT_ID: "${HOUSTON_CLIENT_ID}"
       OAUTH_CLIENT_SECRET: "${HOUSTON_CLIENT_SECRET}"
       OAUTH_USER_EMAIL: "${OAUTH_USER_EMAIL}"
@@ -132,57 +177,84 @@ services:
       WILDBOOK_DB_NAME: "${WILDBOOK_DB_NAME}"
       WILDBOOK_DB_USER: "${WILDBOOK_DB_USER}"
       WILDBOOK_DB_PASSWORD: "${WILDBOOK_DB_PASSWORD}"
-    volumes: &houston-volumes
-      - houston-var:/data
-      # These are added for development. Do not mount these in production.
-      - .dockerfiles/docker-entrypoint.sh:/docker-entrypoint.sh
-      - .dockerfiles/docker-entrypoint-init.d.codex:/docker-entrypoint-init.d
-      - .dockerfiles/docker-entrypoint-always-init.d:/docker-entrypoint-always-init.d
-      # FIXME: pull in development code while working on bringing up the container
-      - .:/code
 
   celery_beat:
     image: wildme/houston:latest
     build: *houston-build
-    command: [ "wait-for", "--timeout=600", "houston:5000", "--", "celery", "-A", "app.extensions.celery.celery", "beat", "-s", "/data/var/celerybeat-schedule", "-l", "DEBUG"]
+    command: ["celery", "-A", "app.extensions.celery.celery", "beat", "-s", "/data/var/celerybeat-schedule", "-l", "DEBUG"]
+    depends_on:
+      houston:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "celery", "-A", "app.extensions.celery.celery", "status"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
+    volumes: *houston-volumes
     networks:
       - intranet
     environment: *houston-environment
-    volumes: *houston-volumes
 
   celery_worker:
     image: wildme/houston:latest
     build: *houston-build
-    command: [ "wait-for", "--timeout=600", "houston:5000", "--", "celery", "-A", "app.extensions.celery.celery", "worker", "-l", "DEBUG"]
+    command: ["celery", "-A", "app.extensions.celery.celery", "worker", "-l", "DEBUG"]
+    depends_on:
+      houston:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "celery", "-A", "app.extensions.celery.celery", "status"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
+    volumes: *houston-volumes
     networks:
       - intranet
     environment: *houston-environment
-    volumes: *houston-volumes
 
   dev-frontend:
     # this component is intended to only be used in development
     image: node:lts
     working_dir: /code
     entrypoint: "/docker-entrypoint.sh"
-    networks:
-      - intranet
-    environment:
-      HOST: "0.0.0.0"
-      # See port served by 'www' component (i.e. the reverse proxy)
-      PORT: "84"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:3000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
     volumes:
       - .dockerfiles/dev-frontend/docker-entrypoint.sh:/docker-entrypoint.sh
       - ./_frontend.codex:/code
+    networks:
+      - intranet
+    environment:
+      # See port served by 'www' component (i.e. the reverse proxy)
+      HOST: "0.0.0.0"
+      PORT: "84"
 
   www:
     image: nginx:latest
+    depends_on:
+      edm:
+        condition: service_healthy
+      # acm:
+      #   condition: service_healthy
+      houston:
+        condition: service_healthy
+      dev-frontend:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
+    volumes:
+      - .dockerfiles/www/nginx.conf:/etc/nginx/conf.d/default.conf
     networks:
       - intranet
       - frontend
     ports:
       - "84:80"
-    volumes:
-      - .dockerfiles/www/nginx.conf:/etc/nginx/conf.d/default.conf
 
 networks:
   intranet:

--- a/docker-compose.mws.yml
+++ b/docker-compose.mws.yml
@@ -3,11 +3,19 @@ version: "3.8"
 services:
 
   db:
-    image: postgres:10
+    image: postgres:13.4
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
+    user: postgres
     volumes:
       - db-pgdata-var:/var/lib/postgresql/data
       # DB initialization scripts
       - .dockerfiles/db/initdb.d/:/docker-entrypoint-initdb.d/
+    networks:
+      - intranet
     environment:
       POSTGRES_PASSWORD: "${POSTGRES_PASSWORD}"
       WBIA_DB_NAME: "${WBIA_DB_NAME}"
@@ -19,44 +27,59 @@ services:
       HOUSTON_DB_NAME: "${HOUSTON_DB_NAME}"
       HOUSTON_DB_USER: "${HOUSTON_DB_USER}"
       HOUSTON_DB_PASSWORD: "${HOUSTON_DB_PASSWORD}"
-    networks:
-      - intranet
 
   redis:
     image: redis:latest
+    command: ["redis-server", "/redis.conf"]
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
     volumes:
       - redis-var:/data
+      - .dockerfiles/redis/redis.conf:/redis.conf
     networks:
       - intranet
 
   elasticsearch:
     # https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.10.1
-    environment:
-      "discovery.type": single-node
-    ports:
-      # development exposure, not exposed in production
-      - 9200:9200
-      - 9300:9300
+    depends_on:
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
     # volumes:
     #   - es-var:/usr/share/elasticsearch/data
     networks:
       - intranet
+    ports:
+      # development exposure, not exposed in production
+      - 9200:9200
+      - 9300:9300
+    environment:
+      "discovery.type": single-node
 
   acm:
     # https://github.com/WildMeOrg/wildbook-ia
     image: wildme/wbia:latest
-    depends_on:
-      - db
     command: ["--db-uri", "${WBIA_DB_URI}"]
+    depends_on:
+      db:
+        condition: service_healthy
+    # healthcheck:  # WBIA defines it's own health check
+    volumes:
+      - acm-database-var:/data/db
+      - acm-cache-var:/cache
     networks:
       - intranet
     ports:
       # FIXME: exposed for developer verification
       - "82:5000"
-    volumes:
-      - acm-database-var:/data/db
-      - acm-cache-var:/cache
     environment:
       WBIA_DB_URI: "${WBIA_DB_URI}"
       HOUSTON_CLIENT_ID: "${HOUSTON_CLIENT_ID}"
@@ -68,7 +91,25 @@ services:
     build: &houston-build
       context: .
       target: main
-    command: [ "wait-for", "db:5432", "--", "wait-for", "--timeout=60", "elasticsearch:9200", "--", "invoke", "app.run", "--host", "0.0.0.0" ]
+    command: ["invoke", "app.run", "--host", "0.0.0.0" ]
+    depends_on:
+      db:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:5000/api/v1/site-info/heartbeat"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
+    volumes: &houston-volumes
+      - houston-var:/data
+      # These are added for development. Do not mount these in production.
+      - .dockerfiles/docker-entrypoint.sh:/docker-entrypoint.sh
+      - .dockerfiles/docker-entrypoint-init.d.mws:/docker-entrypoint-init.d
+      - .dockerfiles/docker-entrypoint-always-init.d:/docker-entrypoint-always-init.d
+      # FIXME: pull in development code while working on bringing up the container
+      - .:/code
     networks:
       - intranet
       - frontend
@@ -84,6 +125,17 @@ services:
       ELASTICSEARCH_HOSTS: "${ELASTICSEARCH_HOSTS}"
       HOUSTON_URL: "${HOUSTON_URL}"
       REDIS_HOST: redis
+      REDIS_PASSWORD: "seekret_development_password"
+      GITLAB_PROTO: "${GITLAB_PROTO}"
+      GITLAB_HOST: "${GITLAB_HOST}"
+      GITLAB_PORT: "${GITLAB_PORT}"
+      GITLAB_ADMIN_PASSWORD: "${GITLAB_ADMIN_PASSWORD}"
+      GITLAB_REMOTE_URI: "${GITLAB_REMOTE_URI}"
+      GITLAB_REMOTE_LOGIN_PAT: "${GITLAB_REMOTE_LOGIN_PAT}"
+      GITLAB_NAMESPACE: "${GITLAB_NAMESPACE}"
+      GIT_SSH_KEY: "${GIT_SSH_KEY}"
+      GIT_PUBLIC_NAME: "${GIT_PUBLIC_NAME}"
+      GIT_EMAIL: "${GIT_EMAIL}"
       OAUTH_CLIENT_ID: "${HOUSTON_CLIENT_ID}"
       OAUTH_CLIENT_SECRET: "${HOUSTON_CLIENT_SECRET}"
       OAUTH_USER_EMAIL: "${OAUTH_USER_EMAIL}"
@@ -91,68 +143,82 @@ services:
       WILDBOOK_DB_NAME: "${WILDBOOK_DB_NAME}"
       WILDBOOK_DB_USER: "${WILDBOOK_DB_USER}"
       WILDBOOK_DB_PASSWORD: "${WILDBOOK_DB_PASSWORD}"
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:5000/api/v1/site-info/heartbeat"]
-      timeout: 45s
-      interval: 10s
-      retries: 10
-    volumes: &houston-volumes
-      - houston-var:/data
-      # These are added for development. Do not mount these in production.
-      - .dockerfiles/docker-entrypoint.sh:/docker-entrypoint.sh
-      - .dockerfiles/docker-entrypoint-init.d.mws:/docker-entrypoint-init.d
-      - .dockerfiles/docker-entrypoint-always-init.d:/docker-entrypoint-always-init.d
-      # FIXME: pull in development code while working on bringing up the container
-      - .:/code
 
   celery_beat:
     image: wildme/houston:latest
     build: *houston-build
-    command: [ "wait-for", "db:5432", "--", "celery", "-A", "app.extensions.celery.celery", "beat", "-s", "/data/var/celerybeat-schedule", "-l", "DEBUG"]
-    networks:
-      - intranet
+    command: ["celery", "-A", "app.extensions.celery.celery", "beat", "-s", "/data/var/celerybeat-schedule", "-l", "DEBUG"]
     depends_on:
       houston:
         condition: service_healthy
-    environment: *houston-environment
+    healthcheck:
+      test: [ "CMD", "celery", "-A", "app.extensions.celery.celery", "status"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
     volumes: *houston-volumes
+    networks:
+      - intranet
+    environment: *houston-environment
 
   celery_worker:
     image: wildme/houston:latest
     build: *houston-build
-    command: [ "wait-for", "db:5432", "--", "celery", "-A", "app.extensions.celery.celery", "worker", "-l", "DEBUG"]
-    networks:
-      - intranet
+    command: ["celery", "-A", "app.extensions.celery.celery", "worker", "-l", "DEBUG"]
     depends_on:
       houston:
         condition: service_healthy
-    environment: *houston-environment
+    healthcheck:
+      test: [ "CMD", "celery", "-A", "app.extensions.celery.celery", "status"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
     volumes: *houston-volumes
+    networks:
+      - intranet
+    environment: *houston-environment
 
   dev-frontend:
     # this component is intended to only be used in development
     image: node:lts
     working_dir: /code
     entrypoint: "/docker-entrypoint.sh"
-    networks:
-      - intranet
-    environment:
-      HOST: "0.0.0.0"
-      # See port served by 'www' component (i.e. the reverse proxy)
-      PORT: "84"
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:3000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
     volumes:
       - .dockerfiles/dev-frontend/docker-entrypoint.sh:/docker-entrypoint.sh
       - ./_frontend.mws:/code
+    networks:
+      - intranet
+    environment:
+      # See port served by 'www' component (i.e. the reverse proxy)
+      HOST: "0.0.0.0"
+      PORT: "84"
 
   www:
     image: nginx:latest
+    depends_on:
+      # acm:
+      #   condition: service_healthy
+      houston:
+        condition: service_healthy
+      dev-frontend:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 30s
+      timeout: 10s
+      retries: 20
+    volumes:
+      - .dockerfiles/www/nginx.conf:/etc/nginx/conf.d/default.conf
     networks:
       - intranet
       - frontend
     ports:
       - "84:80"
-    volumes:
-      - .dockerfiles/www/nginx.conf:/etc/nginx/conf.d/default.conf
 
 networks:
   intranet:


### PR DESCRIPTION
## Pull Request Overview

- Bumps PostGRES to version 13.4, which will be incompatible with any pre-existing version 10.X database volumes.  This puts the local docker db service in line with the version used by the Azure PostGRES service.  For example, below is the Codex service dependency:

```
dev-frontend
|
|   db
|   |
|   |---> acm
|   |---> edm
|   |
|   |---> redis
|   |     |
|   |     |---> elasticsearch
|   |     |
|   |---------> houston
|               |
|               |---> celery_beat
|               |---> celery_worker
|               |
|-------------------> www
```

- Adds health checks to all services and ties the start-up dependency order on `condition: service_healthy`.  This removes the need for `wait-for` in the docker-compose files.
- Turns off noisy logging for the health check URL endpoints for Nginx and Houston
- Updates the MWS `docker-compose.mws.yml` file to update it with changes in the Codex version.
- Adds `wildme/edm:arm64` to support ARM64 architectures and specified in the `docker-compose.arm64.yml` override template.

## Reviewer note

Merging this PR will require any existing databases (using version 10.X) to be deleted and reprovisioned (using version 13.4) or upgraded.

The Codecov patch test is expected to fail

## Docker Container Status During Start-up

```
IMAGE                       STATUS                             PORTS                    NAMES
wildme/houston:latest       Created                                                     houston-celery_worker-1
wildme/houston:latest       Created                                                     houston-celery_beat-1
nginx:latest                Created                                                     houston-www-1
wildme/houston:latest       Created                                                     houston-houston-1
wildme/wbia:arm64           Up 8 seconds (health: starting)    0.0.0.0:82->5000/tcp     houston-acm-1
elasticsearch-oss:7.10.1    Up 8 seconds (health: starting)    0.0.0.0:9200->9200/tcp   houston-elasticsearch-1
wildme/edm:arm64            Up 8 seconds (health: starting)    0.0.0.0:81->8080/tcp     houston-edm-1
node:lts                    Up 39 seconds (health: starting)                            houston-dev-frontend-1
postgres:13.4               Up 39 seconds (healthy)            5432/tcp                 houston-db-1
redis:latest                Up 39 seconds (healthy)            6379/tcp                 houston-redis-1
```

## Docker Container Status After Start-up (with Health Status)

```
IMAGE                      STATUS                              PORTS                    NAMES
wildme/houston:latest      Up 2 minutes (healthy)              5000/tcp                 houston-celery_worker-1
wildme/houston:latest      Up 2 minutes (healthy)              5000/tcp                 houston-celery_beat-1
nginx:latest               Up 2 minutes (healthy)              0.0.0.0:84->80/tcp       houston-www-1
wildme/houston:latest      Up 2 minutes (healthy)              0.0.0.0:83->5000/tcp     houston-houston-1
wildme/wbia:arm64          Up 2 minutes (healthy)              0.0.0.0:82->5000/tcp     houston-acm-1
elasticsearch-oss:7.10.1   Up 2 minutes (healthy)              0.0.0.0:9200->9200/tcp   houston-elasticsearch-1
wildme/edm:arm64           Up 2 minutes (healthy)              0.0.0.0:81->8080/tcp     houston-edm-1
node:lts                   Up 2 minutes (healthy)                                       houston-dev-frontend-1
postgres:13.4              Up 2 minutes (healthy)              5432/tcp                 houston-db-1
redis:latest               Up 2 minutes (healthy)              6379/tcp                 houston-redis-1
```