### PR TITLE
A check, a method change, and a script

### DIFF
--- a/app/modules/app_ui.py
+++ b/app/modules/app_ui.py
@@ -18,7 +18,6 @@ from flask import (
 from flask_login import login_user, logout_user, login_required, current_user
 
 from app.modules.auth.views import (
-    _url_for,
     _is_safe_url,
 )
 from app.modules.auth.utils import (
@@ -129,14 +128,14 @@ def user_login(email=None, password=None, remember=None, refer=None, *args, **kw
 
     user = User.find(email=email, password=password)
 
-    redirect = _url_for(failure_refer)
+    redirect = url_for(failure_refer)
     if user is not None:
         if True not in [user.in_alpha, user.in_beta, user.is_staff, user.is_admin]:
             flash(
                 'Your login was correct, but Wildbook is in BETA at the moment and is invite-only.',
                 'danger',
             )
-            redirect = _url_for(failure_refer)
+            redirect = url_for(failure_refer)
         else:
             status = login_user(user, remember=remember)
 
@@ -159,10 +158,10 @@ def user_login(email=None, password=None, remember=None, refer=None, *args, **kw
                     'We could not log you in, most likely due to your account being disabled.  Please speak to a staff member.',
                     'danger',
                 )
-                redirect = _url_for(failure_refer)
+                redirect = url_for(failure_refer)
     else:
         flash('Username or password unrecognized.', 'danger')
-        redirect = _url_for(failure_refer)
+        redirect = url_for(failure_refer)
 
     return flask.redirect(redirect)
 
@@ -196,7 +195,7 @@ def user_logout(refer=None, *args, **kwargs):
     flash('You were successfully logged out.', 'warning')
 
     if refer is None:
-        redirect = _url_for('backend.home')
+        redirect = url_for('backend.home')
     else:
         redirect = refer
 
@@ -242,7 +241,7 @@ def create_admin_user(email=None, password=None, repeat_password=None, *args, **
                 if admin.is_admin:
                     message = 'Success creating startup admin user.'
                     # update configuration value for admin user created
-                    return flask.redirect(_url_for('backend.home'))
+                    return flask.redirect(url_for('backend.home'))
                 else:
                     message = 'We failed to create or update the user as an admin.'
             else:

--- a/app/modules/app_ui.py
+++ b/app/modules/app_ui.py
@@ -168,7 +168,7 @@ def user_login(email=None, password=None, remember=None, refer=None, *args, **kw
 
 
 @backend_blueprint.route('/logout', methods=['GET'])
-@frontend_blueprint.route('/logout', methods=['POST'])
+@frontend_blueprint.route('/logout', methods=['GET', 'POST'])
 @login_required
 def user_logout(refer=None, *args, **kwargs):
     # pylint: disable=unused-argument

--- a/app/modules/auth/views.py
+++ b/app/modules/auth/views.py
@@ -20,14 +20,6 @@ from app.extensions import oauth2, login_manager
 from app.modules.users.models import User
 
 
-def _url_for(value, *args, **kwargs):
-    # kwargs['_external'] = 'https'
-    # kwargs['_scheme'] = 'https'
-    kwargs['_external'] = 'http'
-    kwargs['_scheme'] = 'http'
-    return url_for(value, *args, **kwargs)
-
-
 def _is_safe_url(target):
     ref_url = urlparse(request.host_url)
     test_url = urlparse(urljoin(request.host_url, target))
@@ -63,4 +55,4 @@ def load_user(guid):
 @login_manager.unauthorized_handler
 def unauthorized():
     flash('You tried to load an unauthorized page.', 'danger')
-    return flask.redirect(_url_for('backend.home'))
+    return flask.redirect(url_for('backend.home'))

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -207,11 +207,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
                 'hasEdit': True,
                 'hasView': True,
                 'individual': {},
-                'owner': {
-                    'full_name': my_name,
-                    'guid': my_guid,
-                    'profile_fileupload': None,
-                },
+                'owner': creator_data,
                 'sex': 'male',
                 'submitter': None,
                 'taxonomy': tx_id,

--- a/integration_tests/test_collaborations.py
+++ b/integration_tests/test_collaborations.py
@@ -59,7 +59,7 @@ def test_collaboration(session, codex_url, login, logout, admin_email):
     logout(session)
 
     # Log in as new user and check collaboration request
-    login(session, new_email)
+    login(session, new_email, password='password')
     response = session.get(codex_url('/api/v1/users/me'))
     assert response.status_code == 200
     assert collaboration_guid in [c['guid'] for c in response.json()['collaborations']]

--- a/integration_tests/test_notifications.py
+++ b/integration_tests/test_notifications.py
@@ -12,7 +12,7 @@ def test_notification_preferences(session, login, logout, codex_url):
     logout(session)
 
     # GET user
-    login(session, email=new_email)
+    login(session, email=new_email, password='password')
     response = session.get(codex_url('/api/v1/users/me'))
     assert response.status_code == 200
     assert response.json()['notification_preferences'] == {

--- a/integration_tests/test_sage_detection.py
+++ b/integration_tests/test_sage_detection.py
@@ -84,7 +84,7 @@ def test_create_asset_group_detection(session, codex_url, test_root, login):
         'asset_group_guid': asset_group_guid,
         'sighting_guid': None,
         'creator': {
-            'full_name': 'Test admin',
+            'full_name': me['full_name'],
             'guid': me['guid'],
             'profile_fileupload': None,
         },

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -284,7 +284,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
         'updatedHouston': response.json()['updatedHouston'],
         'version': sighting_version,
         'creator': {
-            'full_name': 'Test admin',
+            'full_name': admin_name,
             'guid': my_guid,
             'profile_fileupload': None,
         },

--- a/scripts/tests/run_remote_integration_test.sh
+++ b/scripts/tests/run_remote_integration_test.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+set -e
+
+timeout=${TIMEOUT-20}
+poll_frequency=${POLL_FREQUENCY-1}
+url=${CODEX_URL}
+admin_email=${ADMIN_EMAIL-'root@example.org'}
+admin_password=${ADMIN_PASSWORD-password}
+admin_name=${ADMIN_NAME-'Test admin'}
+site_name=${SITE_NAME-'Mytestsite'}
+browser=${BROWSER-chrome}
+use_headless=${BROWSER_HEADLESS-true}
+
+
+function print_help(){
+  cat <<EOF
+Usage: ${0} ARGS
+
+Arguments:
+  --url   - URL to the target deployment
+  -u | --admin-email   - administrative email address
+  -p | --admin-password   - administrative password
+  --admin-name   - administrative name
+  --site-name   - site name
+
+EOF
+}
+
+
+for arg in $@
+do
+  case $arg in
+    --url)
+      url="$2"
+      shift
+      shift
+    ;;
+    -u|--admin-email)
+      admin_email="$2"
+      shift
+      shift
+    ;;
+    -p|--admin-password)
+      admin_password="$2"
+      shift
+      shift
+      ;;
+    --admin-name)
+      admin_name="$2"
+      shift
+      shift
+      ;;
+    --site-name)
+      site_name="$2"
+      shift
+      shift
+      ;;
+    [?])
+      echo "Invalid Argument Passed: $arg"
+      print_help
+      exit 1
+    ;;
+  esac
+done
+
+
+script="
+apt update
+apt install -y python3-pip
+pip install -r /code/integration_tests/requirements.txt
+pytest -vv -x /code/integration_tests
+"
+
+
+function main() {
+  if [ -z "$url" ]; then
+    print_help
+    exit 1
+  fi
+
+  docker run --rm \
+    -it \
+    -e TIMEOUT="$timeout" \
+    -e POLL_FREQUENCY="$poll_frequency" \
+    -e CODEX_URL="$url" \
+    -e ADMIN_EMAIL="$admin_email" \
+    -e ADMIN_PASSWORD="$admin_password" \
+    -e ADMIN_NAME="$admin_name" \
+    -e SITE_NAME="$site_name" \
+    -e BROWSER="$browser" \
+    -e BROWSER_HEADLESS="$use_headless" \
+    -v ${PWD}/integration_tests:/code/integration_tests \
+    -v ${PWD}/tests:/code/tests \
+    -w /code \
+    -u root \
+    --entrypoint sh \
+    selenium/standalone-chrome \
+    -c "$script"
+  exit $?
+}
+
+
+# check to see if this file is being run or sourced from another script
+function _is_sourced() {
+  # See also https://unix.stackexchange.com/a/215279
+  # macos bash source check OR { linux shell check }
+  [[ "${#BASH_SOURCE[@]}" -eq 0 ]] || { [ "${#FUNCNAME[@]}" -ge 2 ]  && [ "${FUNCNAME[0]}" = '_is_sourced' ] && [ "${FUNCNAME[1]}" = 'source' ]; }
+}
+
+
+if ! _is_sourced; then
+  main "$@"
+fi

--- a/scripts/tests/run_tasks_for_coverage.sh
+++ b/scripts/tests/run_tasks_for_coverage.sh
@@ -56,6 +56,12 @@ fi
 # warm-ups
 coverage run --append `which invoke` app.run.warmup --print-routes
 
+# test integrations check
+if [ "$HOUSTON_APP_CONTEXT" == 'codex' ]; then
+    # `|| true` is used to ignore integration fail with gitlab
+    coverage run --append `which invoke` codex.integrations.check || true
+fi
+
 # test app.users.*
 echo password | coverage run --append `which invoke` app.users.create-user user@example.org
 echo password | coverage run --append `which invoke` app.users.create-user test@wildme.org

--- a/tasks/codex/integrations.py
+++ b/tasks/codex/integrations.py
@@ -31,6 +31,24 @@ def check_edm(app):
     return True
 
 
+def check_edm_db(app):
+    """Check for connectivity to directly to the EDM database.
+    This connection is used by the indexing procedures.
+
+    """
+    from app.modules.elasticsearch.tasks import create_wildbook_engine
+
+    engine = create_wildbook_engine()
+    try:
+        with engine.connect() as conn:
+            result = conn.execute('SELECT 1')
+            assert result.scalar() == 1
+    except Exception:
+        log.exception('')
+        return False
+    return True
+
+
 def check_gitlab(app):
     """Check the gitlab connection indirectly through the GitlabManager"""
     try:
@@ -61,6 +79,7 @@ def check(context):
         f"db ({app.config['SQLALCHEMY_DATABASE_URI']})": check_db_connection,
         'gitlab': check_gitlab,
         'edm': check_edm,
+        'edm database': check_edm_db,
         'elasticsearch': check_elasticsearch,
         # ...
     }


### PR DESCRIPTION

1. Adds a check for the ability to directly connect to the EDM database. This works as part of the existing `invoke codex.integrations.check` task. 
1. Adds a script to allow the user to run the integrations test of a remote instance without installing the software.
1. Adds the `GET` method to `/logout`. Makes it easy to logout if for some reason the frontend isn't capable of logging the user out.