### PR TITLE
DEX-706: AssetGroup metadata.json concurrency problems

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -1003,12 +1003,6 @@ class AssetGroup(db.Model, HoustonModel):
             with open(metadata_path, 'w') as metatdata_file:
                 json.dump({}, metatdata_file)
 
-        with open(metadata_path, 'r') as metatdata_file:
-            group_metadata = json.load(metatdata_file)
-
-        with open(metadata_path, 'w') as metatdata_file:
-            json.dump(group_metadata, metatdata_file)
-
         return repo
 
     def git_write_upload_file(self, upload_file):


### PR DESCRIPTION
## Pull Request Overview

- Some unnecessary code was causing a _race condition_ (and subsequent JSON-parsing error) when multiple hits on the same Asset API endpoint happened in close succession