### PR TITLE
Fix version conflict for click and fix start / end date comparion in test_relationship_crud.py

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ WORKDIR /code
 RUN set -ex \
  && pip install -e . \
  #: Install developer tools
- && pip install utool ipython \
+ && pip install -r app/requirements.dev.txt \
  #: Remove pip download cache
  && rm -rf ~/.cache/pip
 

--- a/app/requirements.dev.txt
+++ b/app/requirements.dev.txt
@@ -1,0 +1,4 @@
+# black 22.1.0 requires click>=8.0.0 which is incompatible with our flask and celery
+git+https://github.com/psf/black@21.12b0
+ipython
+utool

--- a/tests/modules/relationships/resources/test_relationship_crud.py
+++ b/tests/modules/relationships/resources/test_relationship_crud.py
@@ -118,4 +118,7 @@ def test_create_read_delete_relationship(
     assert relationship_1.type == 'Family'
 
     # one day time delta for this test
-    assert relationship_1.start_date.day == (relationship_1.end_date.day - 1)
+    assert (
+        relationship_1.start_date.date()
+        == (relationship_1.end_date - timedelta(days=1)).date()
+    )


### PR DESCRIPTION
- Move dev tools requirements from houston Dockerfile to app/requirements.dev.txt

  There is a version conflict for click in the packages we install:
  
  ```
  ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
  flask 1.1.4 requires click<8.0,>=5.1, but you have click 8.0.3 which is incompatible.
  celery 5.1.2 requires click<8.0,>=7.0, but you have click 8.0.3 which is incompatible.
  ```
  
  click 8.0.3 was installed because of ipython which requires black.  The
  latest version of black 22.1.0 requires `click>=8.0.0` which is
  incompatible with our flask and celery versions.
  
  This could be solved by downgrading black but black only has one version
  on pip so the way to solve this is to install an older tag from their
  github repo.  I feel like this is better in a separate requirements file
  since the github url is kind of long.

- Fix start date end date comparison in test_relationship_crud.py

  The original code was:
  
  ```
  assert relationship_1.start_date.day == (relationship_1.end_date.day - 1)
  ```
  
  It breaks when `relationship_1.start_date` is `2022-01-31` and
  `relationship_1.end_date` is `2022-02-01` because
  `relationship_1.end_date.day - 1` would be `0`.
  
  Change it to use timedelta instead:
  
  ```
  assert (
      relationship_1.start_date.date()
      == (relationship_1.end_date - timedelta(days=1)).date()
  )
  ```
  
  This results in `2022-01-31 == 2022-01-31`

