### PR TITLE
641: adds api endpoint for IA classes

### DIFF
--- a/app/modules/ia_config_reader.py
+++ b/app/modules/ia_config_reader.py
@@ -116,6 +116,15 @@ class IaConfig:
         ia_classes = [key for key in self.get(species_key) if not key.startswith('_')]
         return ia_classes
 
+    def get_all_ia_classes(self):
+        all_species = self.get_configured_species()
+        all_ia_classes = set()
+        for specie in all_species:
+            all_ia_classes = all_ia_classes | set(self.get_supported_ia_classes(specie))
+        all_ia_classes = list(all_ia_classes)
+        all_ia_classes.sort()
+        return all_ia_classes
+
     def get_supported_id_algos(self, genus_species, ia_classes=None):
         if ia_classes is None:
             ia_classes = self.get_supported_ia_classes(genus_species)

--- a/app/modules/site_settings/resources.py
+++ b/app/modules/site_settings/resources.py
@@ -525,6 +525,25 @@ class DetectionConfigs(Resource):
         return response
 
 
+@detection_api.route('/ia_classes')
+class IaClassConfigs(Resource):
+    """
+    Configured IA classes
+    """
+
+    def get(self):
+        """
+        Returns a json describing the available detectors for the frontend to
+        provide users with options
+        """
+        ia_config_reader = IaConfig()
+        ia_classes = ia_config_reader.get_all_ia_classes()
+        success = ia_classes is not None
+        response = {'ia_classes': ia_classes, 'success': success}
+
+        return response
+
+
 @api.route('/site-info/')
 class SiteInfo(Resource):
     def get(self):

--- a/app/modules/site_settings/resources.py
+++ b/app/modules/site_settings/resources.py
@@ -525,7 +525,7 @@ class DetectionConfigs(Resource):
         return response
 
 
-@detection_api.route('/ia_classes')
+@api.route('/ia_classes')
 class IaClassConfigs(Resource):
     """
     Configured IA classes
@@ -536,6 +536,8 @@ class IaClassConfigs(Resource):
         Returns a json describing the available detectors for the frontend to
         provide users with options
         """
+        from app.modules.ia_config_reader import IaConfig
+
         ia_config_reader = IaConfig()
         ia_classes = ia_config_reader.get_all_ia_classes()
         success = ia_classes is not None

--- a/tests/modules/site_settings/resources/test_ia_class_config.py
+++ b/tests/modules/site_settings/resources/test_ia_class_config.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+
+
+def test_get_ia_class_config(flask_app_client):
+
+    path = '/api/v1/site-settings/ia_classes'
+    response = flask_app_client.get(path)
+    response_data = response.json
+    assert 'success' in response_data and response_data['success'] is True


### PR DESCRIPTION
Adds a method to the IaConfig class (`app/modules/ia_config_reader.py`) to return a list of available IA classes.

Adds an api endpoint under site-settings to read that (`app/modules/site-settings/resources.py:IaClassConfigs`), sitting at endpoint `.../site-settings/ia_classes/`

Adds a simple test that the endpoint is working (`tests/modules/site_settings/resources/test_ia_class_config.py`).