### PR TITLE
elasticsearch tweaks (around indexing)

### DIFF
--- a/app/modules/elasticsearch/tasks.py
+++ b/app/modules/elasticsearch/tasks.py
@@ -263,14 +263,17 @@ def load_sightings_index(
     catchup_index_before=None, catchup_index_batch_size=0, catchup_index_mark=None
 ):
     if catchup_index_before:
-        where_clause = f"WHERE si.updated < '{catchup_index_before}' AND si.guid > '{catchup_index_mark}' ORDER BY si.guid LIMIT {catchup_index_batch_size}"
+        where_clause = f"WHERE si.updated < '{catchup_index_before}' AND si.guid > '{catchup_index_mark}'"
+        order_clause = f"ORDER BY id LIMIT {catchup_index_batch_size}"
     else:
         cutoff = update_incremental_cutoff('sighting')
         where_clause = f"WHERE si.updated >= '{cutoff}'"
+        order_clause = ''
     wb_engine = create_wildbook_engine()
     with wb_engine.connect() as wb_conn:
         sql = SIGHTINGS_INDEX_SQL
         sql = sql.replace('{where_clause}', where_clause)
+        sql = sql.replace('{order_clause}', order_clause)
         results = wb_conn.execute(text(sql))
         for i, row in enumerate(results):
             result = combine_datetime(row)
@@ -325,6 +328,7 @@ FROM
   LEFT JOIN houston.complex_date_time cdt ON si.time_guid = cdt.guid
 {where_clause}
 GROUP BY id, datetime, timezone, specificity
+{order_clause}
 """
 
 

--- a/app/modules/elasticsearch/tasks.py
+++ b/app/modules/elasticsearch/tasks.py
@@ -341,7 +341,7 @@ def update_incremental_cutoff(key_prefix):
             f"SELECT value_datetime FROM elasticsearch_metadata WHERE key='{inc_key}'"
         )
         if res.rowcount > 0:
-            cutoff = res.first()[0]
+            cutoff = res.first()[0].strftime('%Y-%m-%d %H:%M:%S')
             h_conn.execute(
                 f"UPDATE elasticsearch_metadata SET value_datetime='{dt_now}' WHERE key='{inc_key}'"
             )

--- a/app/modules/elasticsearch/tasks.py
+++ b/app/modules/elasticsearch/tasks.py
@@ -17,10 +17,7 @@ log = logging.getLogger(__name__)
 @celery.on_after_configure.connect
 def setup_periodic_tasks(sender, **kwargs):
     sender.add_periodic_task(
-        # 10.0 * 60, load_codex_indexes.s(), name='Load Elasticsearch Indexes'
-        0.5 * 60,
-        load_codex_indexes.s(),
-        name='Load Elasticsearch Indexes',
+        10.0 * 60, load_codex_indexes.s(), name='Load Elasticsearch Indexes'
     )
 
 

--- a/tasks/codex/__init__.py
+++ b/tasks/codex/__init__.py
@@ -18,6 +18,7 @@ from tasks.codex import (
     organizations,
     collaborations,
     projects,
+    elasticsearch,
     sightings,
 )
 
@@ -32,6 +33,7 @@ namespace = Collection(
     organizations,
     collaborations,
     projects,
+    elasticsearch,
     sightings,
     run,
 )

--- a/tasks/codex/elasticsearch.py
+++ b/tasks/codex/elasticsearch.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""
+Application Users management related tasks for Invoke.
+"""
+
+from tasks.utils import app_context_task
+from datetime import datetime, timedelta
+from app.modules.elasticsearch.tasks import (
+    catchup_index_get,
+    catchup_index_set,
+    catchup_index_start,
+    catchup_index_reset,
+)
+
+
+@app_context_task(
+    help={
+        'before': 'YYYY-MM-DD hh:mm:ss - index when modified before this date',
+        'batch-size': 'how many to index each batch',
+        'batch-pause': 'seconds to pause between batches',
+    }
+)
+def catchup_index(context, before, batch_size=100, batch_pause=3):
+    """
+    Start indexing historic data before a certain date, in batches.
+    """
+    # from app.modules.individuals.tasks import execute_merge_request
+    # async_res = execute_merge_request.apply_async(args, eta=deadline)
+    conf = {
+        'before': datetime.fromisoformat(before),
+        'batch_size': int(batch_size),
+        'batch_pause': int(batch_pause),
+    }
+    catchup_index_set(conf)
+    _kickoff()
+
+
+@app_context_task()
+def catchup_index_continue(context):
+    conf = catchup_index_get()
+    if not conf:
+        print(
+            'No previous settings to continue.  Use app.codex.elasticsearch.catchup-index instead.'
+        )
+    _kickoff()
+
+
+@app_context_task()
+def catchup_index_cancel(context):
+    catchup_index_reset()
+    print(
+        'Reset catchup-index configuration.  If running, will stop after current batch.'
+    )
+    return
+
+
+def _kickoff():
+    start_pause = 10
+    start_time = datetime.utcnow() + timedelta(seconds=start_pause)
+    async_res = catchup_index_start.apply_async(eta=start_time)
+    print(
+        f'Starting background catchup-indexing in {start_pause} seconds  [{async_res}].'
+    )

--- a/tasks/codex/elasticsearch.py
+++ b/tasks/codex/elasticsearch.py
@@ -5,12 +5,6 @@ Application Users management related tasks for Invoke.
 
 from tasks.utils import app_context_task
 from datetime import datetime, timedelta
-from app.modules.elasticsearch.tasks import (
-    catchup_index_get,
-    catchup_index_set,
-    catchup_index_start,
-    catchup_index_reset,
-)
 
 
 @app_context_task(
@@ -21,6 +15,8 @@ from app.modules.elasticsearch.tasks import (
     }
 )
 def catchup_index(context, before, batch_size=100, batch_pause=3):
+    from app.modules.elasticsearch.tasks import catchup_index_set
+
     """
     Start indexing historic data before a certain date, in batches.
     """
@@ -37,6 +33,8 @@ def catchup_index(context, before, batch_size=100, batch_pause=3):
 
 @app_context_task()
 def catchup_index_continue(context):
+    from app.modules.elasticsearch.tasks import catchup_index_get
+
     conf = catchup_index_get()
     if not conf:
         print(
@@ -47,6 +45,8 @@ def catchup_index_continue(context):
 
 @app_context_task()
 def catchup_index_cancel(context):
+    from app.modules.elasticsearch.tasks import catchup_index_reset
+
     catchup_index_reset()
     print(
         'Reset catchup-index configuration.  If running, will stop after current batch.'
@@ -55,6 +55,8 @@ def catchup_index_cancel(context):
 
 
 def _kickoff():
+    from app.modules.elasticsearch.tasks import catchup_index_start
+
     start_pause = 10
     start_time = datetime.utcnow() + timedelta(seconds=start_pause)
     async_res = catchup_index_start.apply_async(eta=start_time)

--- a/tasks/codex/elasticsearch.py
+++ b/tasks/codex/elasticsearch.py
@@ -27,7 +27,7 @@ def catchup_index(context, before, batch_size=100, batch_pause=3):
     # from app.modules.individuals.tasks import execute_merge_request
     # async_res = execute_merge_request.apply_async(args, eta=deadline)
     conf = {
-        'before': datetime.fromisoformat(before),
+        'before': datetime.fromisoformat(before).strftime('%Y-%m-%d %H:%M:%S'),
         'batch_size': int(batch_size),
         'batch_pause': int(batch_pause),
     }

--- a/tests/modules/elasticsearch/test_tasks.py
+++ b/tests/modules/elasticsearch/test_tasks.py
@@ -250,6 +250,7 @@ def test_catchup_indexing():
     assert conf['encounter_mark'] == '00000000-0000-0000-0000-000000000000'
     assert conf['individual_mark'] == '00000000-0000-0000-0000-000000000000'
 
+    tasks.set_up_houston_tables()
     rtn = tasks.load_sightings_index(
         catchup_index_before=conf['before'],
         catchup_index_batch_size=conf['batch_size'],

--- a/tests/modules/elasticsearch/test_tasks.py
+++ b/tests/modules/elasticsearch/test_tasks.py
@@ -228,9 +228,12 @@ def test_load_codex_indexes(monkeypatch, flask_app):
         '9acc33ef-caa1-4341-b475-9a5d762cd243': ['Grazing', 'A second value'],
     }
 
+    # rtn = tasks.load_individual_index()
+
 
 def test_catchup_indexing():
     from app.modules.elasticsearch import tasks
+
     conf = {}
     rtn = tasks.catchup_index_set(conf)  # fail due to bad conf
     assert not rtn
@@ -249,26 +252,6 @@ def test_catchup_indexing():
     assert conf['sighting_mark'] == '00000000-0000-0000-0000-000000000000'
     assert conf['encounter_mark'] == '00000000-0000-0000-0000-000000000000'
     assert conf['individual_mark'] == '00000000-0000-0000-0000-000000000000'
-
-    tasks.set_up_houston_tables()
-    rtn = tasks.load_sightings_index(
-        catchup_index_before=conf['before'],
-        catchup_index_batch_size=conf['batch_size'],
-        catchup_index_mark=conf['sighting_mark'],
-    )
-    assert not rtn
-    rtn = tasks.load_encounters_index(
-        catchup_index_before=conf['before'],
-        catchup_index_batch_size=conf['batch_size'],
-        catchup_index_mark=conf['encounter_mark'],
-    )
-    assert not rtn
-    rtn = tasks.load_individuals_index(
-        catchup_index_before=conf['before'],
-        catchup_index_batch_size=conf['batch_size'],
-        catchup_index_mark=conf['individual_mark'],
-    )
-    assert not rtn
 
     # now blow away conf data
     tasks.catchup_index_reset()

--- a/tests/modules/elasticsearch/test_tasks.py
+++ b/tests/modules/elasticsearch/test_tasks.py
@@ -227,3 +227,49 @@ def test_load_codex_indexes(monkeypatch, flask_app):
         '2fe1c780-983c-41b9-9974-44d77a9a9035': 'no wind',
         '9acc33ef-caa1-4341-b475-9a5d762cd243': ['Grazing', 'A second value'],
     }
+
+
+def test_catchup_indexing():
+    from app.modules.elasticsearch import tasks
+    conf = {}
+    rtn = tasks.catchup_index_set(conf)  # fail due to bad conf
+    assert not rtn
+    rtn = tasks.catchup_index_get()
+    assert not rtn
+
+    bdate = '1900-01-01 00:11:22'
+    conf = {'before': bdate}
+    tasks.catchup_index_set(conf)
+    conf = tasks.catchup_index_get()
+    assert conf
+    assert 'before' in conf
+    assert conf['before'] == bdate
+    assert 'batch_size' in conf
+    assert conf['batch_size'] == 250
+    assert conf['sighting_mark'] == '00000000-0000-0000-0000-000000000000'
+    assert conf['encounter_mark'] == '00000000-0000-0000-0000-000000000000'
+    assert conf['individual_mark'] == '00000000-0000-0000-0000-000000000000'
+
+    rtn = tasks.load_sightings_index(
+        catchup_index_before=conf['before'],
+        catchup_index_batch_size=conf['batch_size'],
+        catchup_index_mark=conf['sighting_mark'],
+    )
+    assert not rtn
+    rtn = tasks.load_encounters_index(
+        catchup_index_before=conf['before'],
+        catchup_index_batch_size=conf['batch_size'],
+        catchup_index_mark=conf['encounter_mark'],
+    )
+    assert not rtn
+    rtn = tasks.load_individuals_index(
+        catchup_index_before=conf['before'],
+        catchup_index_batch_size=conf['batch_size'],
+        catchup_index_mark=conf['individual_mark'],
+    )
+    assert not rtn
+
+    # now blow away conf data
+    tasks.catchup_index_reset()
+    rtn = tasks.catchup_index_get()
+    assert not rtn

--- a/tests/modules/site_settings/resources/test_file_operations.py
+++ b/tests/modules/site_settings/resources/test_file_operations.py
@@ -48,6 +48,9 @@ def test_file_settings(admin_user, flask_app_client, flask_app, db, request, tes
         site_setting = resp.json
         assert site_setting['key'] == 'footer_image'
 
+        # this is to test that GET /api/v1/site-settings/file is *truly* only getting file-type values
+        SiteSetting.set('foo', string='bar')
+
         # List site settings
         resp = flask_app_client.get('/api/v1/site-settings/file')
         assert resp.status_code == 200


### PR DESCRIPTION
## Pull Request Overview

- Alters background (celery) indexing to use `object.updated` field to only index what has changed since last indexing
- Introduces _catchup-indexing_ which allows indexing of older objects (presumed migrated and un-indexed) in small batches in the background.  (This is started by an invoke-task; see below.)

---

**Invoke CLI Updates**
```
invoke codex.elasticsearch.catchup-index  --before='2000-01-01 12:00:00'  [--batch-size=100]  [--batch-pause=3]
invoke codex.elasticsearch.catchup-index-continue   (pick up where left off, after houston restart)
invoke codex.elasticsearch.catchup-index-cancel     (forget settings, stop after current batch is done)
```