### PR TITLE
Security Fixes for Tus Uploads

### DIFF
--- a/app/extensions/tus/__init__.py
+++ b/app/extensions/tus/__init__.py
@@ -10,6 +10,7 @@ import shutil
 from flask import current_app
 
 from flask_restx_patched import is_extension_enabled
+from werkzeug.utils import secure_filename
 
 if not is_extension_enabled('tus'):
     raise RuntimeError('Tus is not enabled')
@@ -103,8 +104,9 @@ def _tus_filepaths_from(
     else:
         if len(paths) < 1:
             return None
-        for path in paths:
-            want_path = os.path.join(upload_dir, path)
+        for insecure_path in paths:
+            secure_path = secure_filename(insecure_path)
+            want_path = os.path.join(upload_dir, secure_path)
             assert os.path.exists(want_path), f'{want_path} does not exist'
             filepaths.append(want_path)
 

--- a/app/extensions/tus/__init__.py
+++ b/app/extensions/tus/__init__.py
@@ -68,6 +68,8 @@ def _tus_file_handler(upload_file_path, filename, req, app):
     log.info('Tus finished uploading: %r in dir %r.' % (filename, dir))
     os.rename(upload_file_path, os.path.join(dir, filename))
 
+    return filename
+
 
 def tus_upload_dir(app, git_store_guid=None, transaction_id=None, session_id=None):
     """Returns the location to an upload directory"""

--- a/app/modules/app_ui.py
+++ b/app/modules/app_ui.py
@@ -122,6 +122,7 @@ def user_login(email=None, password=None, remember=None, refer=None, *args, **kw
 
     if refer is not None:
         if not _is_safe_url(refer):
+            log.error('User gave insecure next URL: %r' % (refer,))
             refer = None
 
     failure_refer = 'backend.home'


### PR DESCRIPTION
## Pull Request Overview

- This PR updates how Tus filenames and paths are manipulated.  The Github CodeQL code scanning flagged this as a security problem, and we were indeed failing to properly sanitize any user-provided paths.
- Adds `werkzeug.utils.secure_filename` to eliminate the possibility of a path inection.
- The issue was introduced in `4f292f0` on Nov 28, 2021.