### PR TITLE
Idempotent Keywords with Test Patch Operations

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -387,10 +387,10 @@ def delete_via_flask(
             assert response.json['message'] == expected_error, response.json['message']
 
 
-def patch_test_op(value, guid=None):
+def patch_test_op(value, path='current_password', guid=None):
     operation = {
         'op': 'test',
-        'path': '/current_password',
+        'path': '/%s' % (path,),
         'value': value,
     }
     if guid is not None:


### PR DESCRIPTION
## Pull Request Overview

- Updates the patch API for annotation keywords and asset tags to allow for idempotent addition and deletion.  For example, a keyword may be added to an annotation that already does or does not already have the keyword assigned to it.  Likewise, a keyword can be removed from an annotation regardless of if the annotation had that keyword assigned to it.
- The implicit creation of keywords has been expanded and added as a `test` patch operation.  The test patch operation should be considered as "ensure that this keyword exists".   Keywords can be ensured (via a test OP) via a GUID, a dictionary with `{'value', 'source'}` keys, or as a simple value string.  If the keyword is not found by GUID, it is created instead.
- Add and remove operations may refer to a given keyword via a GUID, dictionary, and value.   If the operation list has any test OPs, an add/remove operation may also use a formatted string for list indexing to reference a previous test.   
- Bump MWS frontend

---

For example:

```
[
    {
        "op": "add",
        "path": "/keywords",
        "value": {
            "value": "TEST_KEYWORD_VALUE_2",
            "source": "user"
        }
    }
]
```

is equivalent to 

```
[
    {
        "op": "test",
        "path": "/keywords",
        "value": {
            "value": "TEST_KEYWORD_VALUE_2",
            "source": "user"
        }
    },
    {
        "op": "add",
        "path": "/keywords",
        "value": "[0]"
    }
]
```

---

For example:

```
[
    {
        "op": "add",
        "path": "/keywords",
        "value":  "a97bc456-81b5-4209-804f-4cc0915f504f-does-not-exist"
    }
]
```

the above will fail since the GUID does not exist, but...

```
[
    {
        "op": "test",
        "path": "/keywords",
        "value": "a97bc456-81b5-4209-804f-4cc0915f504f-does-not-exist"
    },
    {
        "op": "add",
        "path": "/keywords",
        "value": "[0]"
    }
]
```

will create a new `Keyword(value="a97bc456-81b5-4209-804f-4cc0915f504f-does-not-exist")` and assign it to the annotation.

---

Below is a perfectly valid patch operation for an annotation.

```
[PATCH] /api/v1/annotations/

[
    {
        "op": "test",
        "path": "/keywords",
        "value": "a97bc456-81b5-4209-804f-4cc0915f504f"
    },
    {
        "op": "test",
        "path": "/keywords",
        "value": {
            "value": "TEST_KEYWORD_VALUE_2",
            "source": "user"
        }
    },
    {
        "op": "test",
        "path": "/keywords",
        "value": "TEST_KEYWORD_VALUE_3"
    },
    {
        "op": "add",
        "path": "/keywords",
        "value": "a97bc456-81b5-4209-804f-4cc0915f504f"
    },
    {
        "op": "add",
        "path": "/keywords",
        "value": "TEST_KEYWORD_VALUE_3"
    },
    {
        "op": "add",
        "path": "/keywords",
        "value": "[0]"
    },
    {
        "op": "add",
        "path": "/keywords",
        "value": "[1]"
    },
    {
        "op": "add",
        "path": "/keywords",
        "value": "[2]"
    },
    {
        "op": "add",
        "path": "/keywords",
        "value": "[0]"
    },
    {
        "op": "test",
        "path": "/keywords",
        "value": "TEST_KEYWORD_VALUE_5"
    },
    {
        "op": "add",
        "path": "/keywords",
        "value": {
            "value": "TEST_KEYWORD_VALUE_4",
            "source": "user"
        }
    },
    {
        "op": "add",
        "path": "/keywords",
        "value": "[3]"
    }
]
```
