### PR TITLE
675 removed cruft left by 674

### DIFF
--- a/app/modules/site_settings/__init__.py
+++ b/app/modules/site_settings/__init__.py
@@ -28,7 +28,3 @@ def init_app(app, **kwargs):
     from . import models, resources  # NOQA
 
     api_v1.add_namespace(resources.api)
-
-    # TODO remove DEX 675
-    api_v1.add_namespace(resources.configuration)
-    api_v1.add_namespace(resources.configurationDefinition)

--- a/app/modules/site_settings/resources.py
+++ b/app/modules/site_settings/resources.py
@@ -32,16 +32,6 @@ api = Namespace(
     'site-settings', description='Site Settings'
 )  # pylint: disable=invalid-name
 
-# TODO remove DEX 675
-configuration = Namespace(
-    'configuration', description='System Configuration'
-)  # pylint: disable=invalid-name
-
-# TODO remove DEX 675
-configurationDefinition = Namespace(
-    'configurationDefinition', description='System Configuration Definition'
-)  # pylint: disable=invalid-name
-
 
 @api.route('/file')
 @api.login_required(oauth_scopes=['site-settings:read'])
@@ -182,8 +172,6 @@ class SiteSettingFileByKey(Resource):
         return None
 
 
-# TODO remove DEX 675
-@configurationDefinition.route('/default/<path:path>')
 @api.route('/definition/main/<path:path>')
 class MainConfigurationDefinition(Resource):
     """
@@ -240,9 +228,6 @@ class MainConfigurationDefinition(Resource):
         return data
 
 
-# TODO Remove DEX 675
-@configuration.route('/default/<path:path>')
-@configuration.route('/default', defaults={'path': ''}, doc=False)
 @api.route('/main/<path:path>')
 @api.route('/main', defaults={'path': ''}, doc=False)
 class MainConfiguration(Resource):

--- a/tests/test_openapi_spec_validity.py
+++ b/tests/test_openapi_spec_validity.py
@@ -6,8 +6,7 @@ from jsonschema import RefResolver
 from swagger_spec_validator import validator20
 
 
-# TODO restore DEX 675
-def disabled_test_openapi_spec_validity(flask_app_client):
+def test_openapi_spec_validity(flask_app_client):
     raw_openapi_spec = flask_app_client.get('/api/v1/swagger.json').data
     deserialized_openapi_spec = json.loads(raw_openapi_spec.decode('utf-8'))
     assert isinstance(validator20.validate_spec(deserialized_openapi_spec), RefResolver)


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Old APIs removed as no longer used by frontend
- validity test restored
---

**Review Notes**
- a few nasties had been left in t allow both the old and new APIs towork in 674 so that the integ tests would pass before the frontend was updated. 
- Frontend is now updated so these nasties need to be removed