### PR TITLE
714 remove the unused response fields and standardise on status and m…

### DIFF
--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -281,11 +281,7 @@ class AssetGroupByID(Resource):
             try:
                 asset_group.delete()
             except HoustonException as ex:
-                abort(
-                    ex.status_code,
-                    ex.message,
-                    edm_status_code=ex.get_val('edm_status_code', None),
-                )
+                abort(ex.status_code, ex.message)
         else:
             from .tasks import delete_remote
 
@@ -388,10 +384,8 @@ class AssetGroupSightingByID(Resource):
                     args, asset_group_sighting
                 )
             except AssetGroupMetadataError as error:
-                abort(
-                    passed_message=error.message,
-                    code=error.status_code,
-                )
+                abort(error.status_code, error.message)
+
             db.session.merge(asset_group_sighting)
         AuditLog.patch_object(log, asset_group_sighting, args, duration=timer.elapsed())
         return asset_group_sighting
@@ -451,10 +445,7 @@ class AssetGroupSightingAsSighting(Resource):
                     args, asset_group_sighting
                 )
             except AssetGroupMetadataError as error:
-                abort(
-                    passed_message=error.message,
-                    code=error.status_code,
-                )
+                abort(error.status_code, error.message)
             db.session.merge(asset_group_sighting)
         AuditLog.patch_object(log, asset_group_sighting, args, duration=timer.elapsed())
         return asset_group_sighting
@@ -477,11 +468,7 @@ class AssetGroupSightingAsSighting(Resource):
             try:
                 asset_group.delete()
             except HoustonException as ex:
-                abort(
-                    ex.status_code,
-                    ex.message,
-                    edm_status_code=ex.get_val('edm_status_code', None),
-                )
+                abort(ex.status_code, ex.message)
         else:
             asset_group.delete_asset_group_sighting(asset_group_sighting)
 
@@ -524,10 +511,7 @@ class AssetGroupSightingEncounterByID(Resource):
                     state={'encounter_uuid': encounter_guid},
                 )
             except AssetGroupMetadataError as error:
-                abort(
-                    passed_message=error.message,
-                    code=error.status_code,
-                )
+                abort(error.status_code, error.message)
             db.session.merge(asset_group_sighting)
         AuditLog.patch_object(log, asset_group_sighting, args, duration=timer.elapsed())
         return asset_group_sighting
@@ -572,10 +556,7 @@ class AssetGroupSightingAsSightingEncounterByID(Resource):
                     state={'encounter_uuid': encounter_guid},
                 )
             except AssetGroupMetadataError as error:
-                abort(
-                    passed_message=error.message,
-                    code=error.status_code,
-                )
+                abort(error.status_code, error.message)
             db.session.merge(asset_group_sighting)
         AuditLog.patch_object(log, asset_group_sighting, args, duration=timer.elapsed())
         schema = schemas.AssetGroupSightingEncounterSchema()

--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -144,7 +144,6 @@ class EncounterByID(Resource):
                     ex.status_code,
                     ex.message,
                     error=ex.get_val('error', 'Error'),
-                    edm_status_code=ex.get_val('edm_status_code', None),
                 )
         else:
             # this mimics output format of edm-patching
@@ -162,10 +161,7 @@ class EncounterByID(Resource):
                         houston_args, encounter
                     )
                 except HoustonException as ex:
-                    abort(
-                        ex.status_code,
-                        ex.message,
-                    )
+                    abort(ex.status_code, ex.message)
                 db.session.merge(encounter)
 
             schema = schemas.AugmentedEdmEncounterSchema()
@@ -214,13 +210,7 @@ class EncounterByID(Resource):
             log.warning(
                 f'Encounter.delete {encounter.guid} failed: ({ex.status_code} / edm={edm_status_code}) {ex.message}'
             )
-            abort(
-                success=False,
-                edm_status_code=edm_status_code,
-                passed_message='Delete failed',
-                message='Error',
-                code=400,
-            )
+            abort(400, 'Delete failed')
 
         # we have to roll our own response here (to return) as it seems the only way we can add a header
         #   (which we are using to denote the encounter DELETE also triggered a sighting DELETE, since
@@ -240,11 +230,7 @@ class EncounterByID(Resource):
                 log.error(
                     f'deletion of {encounter} triggered deletion of sighting {sighting_id}; but this was not found!'
                 )
-                abort(
-                    success=False,
-                    message=f'Cascade-deleted Sighting not found id={sighting_id}',
-                    code=400,
-                )
+                abort(400, f'Cascade-deleted Sighting not found id={sighting_id}')
             else:
                 log.warning(  # TODO future audit log here
                     f'EDM triggered self-deletion of {sighting} result={result}'

--- a/app/modules/missions/resources.py
+++ b/app/modules/missions/resources.py
@@ -520,11 +520,7 @@ class MissionCollectionByID(Resource):
             try:
                 mission_collection.delete()
             except HoustonException as ex:
-                abort(
-                    ex.status_code,
-                    ex.message,
-                    edm_status_code=ex.get_val('edm_status_code', None),
-                )
+                abort(ex.status_code, ex.message)
         else:
             from .tasks import delete_remote
 

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -58,11 +58,9 @@ class SightingCleanup(object):
             self.asset_group.delete()
             self.asset_group = None
         abort(
-            success=False,
-            passed_message=message,
-            message='Error',
+            status_code,
+            message,
             errorFields=error_fields,
-            code=status_code,
         )
 
 
@@ -501,13 +499,7 @@ class SightingByID(Resource):
                     request_headers=request.headers,
                 )
             except HoustonException as ex:
-                edm_status_code = ex.get_val('edm_status_code', 400)
-                abort(
-                    success=False,
-                    passed_message=ex.message,
-                    code=ex.status_code,
-                    edm_status_code=edm_status_code,
-                )
+                abort(ex.status_code, ex.message)
 
             if 'deletedSighting' in result:
                 log.warning(f'EDM triggered self-deletion of {sighting} result={result}')
@@ -591,13 +583,7 @@ class SightingByID(Resource):
             log.warning(
                 f'Sighting.delete {sighting.guid} failed: ({ex.status_code} / edm={edm_status_code}) {ex.message}'
             )
-            abort(
-                success=False,
-                edm_status_code=edm_status_code,
-                passed_message='Delete failed',
-                message='Error',
-                code=400,
-            )
+            abort(400, 'Delete failed')
 
         # we have to roll our own response here (to return) as it seems the only way we can add a header
         #   (which we are using to denote the encounter DELETE also triggered a individual DELETE, since

--- a/app/modules/site_settings/resources.py
+++ b/app/modules/site_settings/resources.py
@@ -326,7 +326,7 @@ class MainConfiguration(Resource):
             log.warning(
                 f'blocked configuration {path} private=true for unauthorized user'
             )
-            abort(code=HTTPStatus.FORBIDDEN, message='unavailable', success=False)
+            abort(HTTPStatus.FORBIDDEN, 'unavailable')
 
         return data
 
@@ -360,11 +360,7 @@ class MainConfiguration(Resource):
                 return resp
 
         except HoustonException as ex:
-            abort(
-                ex.status_code,
-                ex.message,
-                success=False,
-            )
+            abort(ex.status_code, ex.message)
 
         passthrough_kwargs = {'data': data}
 

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -206,9 +206,9 @@ def patch_asset_group_sighting(
         test_utils.validate_dict_response(response, 200, {'guid', 'stage', 'config'})
     elif expected_status_code == 400:
         test_utils.validate_dict_response(
-            response, expected_status_code, {'status', 'message', 'passed_message'}
+            response, expected_status_code, {'status', 'message'}
         )
-        assert response.json['passed_message'] == expected_resp
+        assert response.json['message'] == expected_resp
     else:
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message'}
@@ -245,7 +245,7 @@ def patch_asset_group_sighting_as_sighting(
         test_utils.validate_dict_response(response, 200, response_200)
     elif expected_status_code == 400:
         test_utils.validate_dict_response(
-            response, expected_status_code, {'status', 'message', 'passed_message'}
+            response, expected_status_code, {'status', 'message'}
         )
     else:
         test_utils.validate_dict_response(

--- a/tests/modules/encounters/resources/test_delete_encounter.py
+++ b/tests/modules/encounters/resources/test_delete_encounter.py
@@ -78,14 +78,12 @@ def test_delete_method(
     )
     ct = test_utils.all_count(db)
     assert ct['Encounter'] == orig_ct['Encounter'] + 1
-    assert response.json['edm_status_code'] == 604
 
     # this will fail cuz it *only* allows sighting-cascade and we need individual also
     headers = (('x-allow-delete-cascade-sighting', True),)
     response = enc_utils.delete_encounter(
         flask_app_client, staff_user, enc1_id, headers=headers, expected_status_code=400
     )
-    assert response.json['edm_status_code'] == 605
 
     # now this should work but take the sighting and individual with it as well
     headers = (

--- a/tests/modules/individuals/resources/utils.py
+++ b/tests/modules/individuals/resources/utils.py
@@ -25,7 +25,7 @@ def create_individual(flask_app_client, user, expected_status_code=200, data_in=
     assert isinstance(response.json, dict)
     assert response.status_code == expected_status_code, response.status_code
     if response.status_code == 200:
-        test_utils.validate_dict_response(response, 200, {'success', 'result'})
+        test_utils.validate_dict_response(response, 200, {'result'})
 
     return response
 

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -272,7 +272,6 @@ def test_create_and_modify_and_delete_sighting(
         ],
         expected_status_code=400,
     )
-    assert response.json['edm_status_code'] == 602, response.json
     # should still have same number encounters as above here
     ct = test_utils.all_count(db)
     assert ct['Encounter'] == orig_ct['Encounter'] + 1

--- a/tests/modules/sightings/resources/test_delete_cascade.py
+++ b/tests/modules/sightings/resources/test_delete_cascade.py
@@ -67,8 +67,6 @@ def test_sighting_cascade(flask_app_client, test_root, researcher_1, request, db
     response = encounter_utils.delete_encounter(
         flask_app_client, researcher_1, enc1_id, expected_status_code=400
     )
-    # 604 is the sighting-specific block from edm
-    assert response.json.get('edm_status_code') == 604
 
     # now it should work, taking the sighting with it
     headers = (('x-allow-delete-cascade-sighting', True),)
@@ -115,8 +113,6 @@ def test_individual_cascade(flask_app_client, test_root, researcher_1, request, 
     response = encounter_utils.delete_encounter(
         flask_app_client, researcher_1, encounter1_id, expected_status_code=400
     )
-    # 605 is the individual-specific block from edm
-    assert response.json.get('edm_status_code') == 605
 
     # now it should be okay
     headers = (('x-allow-delete-cascade-individual', True),)
@@ -203,8 +199,6 @@ def test_multi_cascade(flask_app_client, test_root, researcher_1, request, db):
     response = sighting_utils.delete_sighting(
         flask_app_client, researcher_1, sighting_id, expected_status_code=400
     )
-    # 605 means individual-delete-cascade is blocking
-    assert response.json.get('edm_status_code') == 605
 
     # lets say we are okay - should delete *two* individuals
     headers = (('x-allow-delete-cascade-individual', True),)

--- a/tests/modules/sightings/resources/utils.py
+++ b/tests/modules/sightings/resources/utils.py
@@ -52,7 +52,7 @@ def create_old_sighting(
     expected_status_code=200,
     expected_error=None,
 ):
-    response = test_utils.post_via_flask(
+    return test_utils.post_via_flask(
         flask_app_client,
         user,
         scopes='',
@@ -60,14 +60,8 @@ def create_old_sighting(
         data=data_in,
         expected_status_code=expected_status_code,
         response_200={'success'},
+        expected_error=expected_error,
     )
-
-    if expected_status_code == 200:
-        assert response.json['success']
-    else:
-        assert response.json['message'] == expected_error
-
-    return response
 
 
 def create_sighting(
@@ -326,10 +320,7 @@ def patch_sighting(
         if 'version' in response.json.keys():
             assert response.json.keys() >= EXPECTED_FIELDS
         else:
-            assert response.json.keys() >= {'result', 'success'}
-            assert response.json['success']
-    elif expected_status_code != 401 and expected_status_code != 409:
-        assert not response.json['success']
+            assert response.json.keys() >= {'result'}
 
     return response
 

--- a/tests/modules/site_settings/resources/utils.py
+++ b/tests/modules/site_settings/resources/utils.py
@@ -5,7 +5,7 @@ Configuration resources utils
 """
 from tests import utils as test_utils
 
-EXPECTED_KEYS = {'response', 'success'}
+EXPECTED_KEYS = {'response'}
 SETTING_PATH = '/api/v1/site-settings'
 
 
@@ -22,12 +22,8 @@ def _read_settings(
         path=conf_path,
         expected_status_code=expected_status_code,
         response_200=EXPECTED_KEYS,
-        response_error={'success', 'message'},
+        response_error={'message'},
     )
-    if expected_status_code == 200:
-        assert res.json['success']
-    elif expected_status_code:
-        assert not res.json['success']
     return res
 
 


### PR DESCRIPTION
…essge in all errors

<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Remove the usused fields in the response messages to the frontend
-

---

**Review Notes**
-  Frontend has removed all the checking of 'success' and 'passed_message' as of https://github.com/WildMeOrg/codex-frontend/pull/252 so this removes their population