### PR TITLE
Update Sentry Error Telemetry

### DIFF
--- a/.env
+++ b/.env
@@ -76,3 +76,10 @@ GITLAB_NAMESPACE=TEST
 #: generated and defined by scripts & sourced from ${HOUSTON_DOTENV} in the container
 GITLAB_REMOTE_LOGIN_PAT=
 GIT_SSH_KEY=
+
+# Rich log formatting
+LOG_WIDTH=""
+
+# Sentry error telemetry
+SENTRY_DSN_PRODUCTION=""
+SENTRY_DSN_DEVELOPMENT=""

--- a/app/extensions/sentry/__init__.py
+++ b/app/extensions/sentry/__init__.py
@@ -13,13 +13,23 @@ def init_app(app, **kwargs):
     """
     Sentry extension initialization point.
     """
-    import sentry_sdk
-    from sentry_sdk.integrations.flask import FlaskIntegration
-
-    # if specified, setup sentry for exception reporting and runtime telemetry
-    sentry_dsn = app.config.get('SENTRY_DSN', None)
-    if sentry_dsn is not None:
-        sentry_sdk.init(
-            dsn=sentry_dsn,
-            integrations=[FlaskIntegration()],
-        )
+    try:
+        import sentry_sdk
+        from sentry_sdk.integrations.flask import FlaskIntegration
+    except ImportError:
+        pass
+    else:
+        try:
+            sentry_dsn = app.config.get('SENTRY_DSN', None)
+            if (
+                sentry_dsn is not None
+                and isinstance(sentry_dsn, str)
+                and len(sentry_dsn) > 0
+            ):
+                sentry_sdk.init(
+                    sentry_dsn,
+                    integrations=[FlaskIntegration()],
+                    traces_sample_rate=1.0,
+                )
+        except Exception:
+            pass

--- a/config/codex.py
+++ b/config/codex.py
@@ -41,6 +41,7 @@ class BaseCodexConfig(
         'tus',
         'mail',
         'stripe',
+        'sentry',
     )
 
     ENABLED_MODULES = (
@@ -75,7 +76,6 @@ class BaseCodexConfig(
         'passthroughs',
         'emails',
         'audit_logs',
-        'sentry',
     )
     # fmt: on
 

--- a/config/codex.py
+++ b/config/codex.py
@@ -75,11 +75,14 @@ class BaseCodexConfig(
         'passthroughs',
         'emails',
         'audit_logs',
+        'sentry',
     )
     # fmt: on
 
 
 class ProductionConfig(BaseCodexConfig):
+    TESTING = False
+
     BASE_URL = os.environ.get('HOUSTON_URL')
 
     MAIL_BASE_URL = BASE_URL
@@ -88,7 +91,7 @@ class ProductionConfig(BaseCodexConfig):
         'mail-errors@wildme.org',
     ]
 
-    SENTRY_DSN = os.getenv('SENTRY_DSN')
+    SENTRY_DSN = os.getenv('SENTRY_DSN_PRODUCTION', None)
 
 
 class DevelopmentConfig(BaseCodexConfig):
@@ -105,7 +108,7 @@ class DevelopmentConfig(BaseCodexConfig):
     ]
 
     SECRET_KEY = 'DEVELOPMENT_SECRET_KEY'
-    SENTRY_DSN = None
+    SENTRY_DSN = os.getenv('SENTRY_DSN_DEVELOPMENT', None)
 
 
 class TestingConfig(DevelopmentConfig):

--- a/config/mws.py
+++ b/config/mws.py
@@ -39,6 +39,7 @@ class BaseMWSConfig(
         'tus',
         'mail',
         'gitlab',
+        'sentry',
     )
 
     ENABLED_MODULES = (
@@ -63,7 +64,6 @@ class BaseMWSConfig(
         'api',
         'emails',
         'audit_logs',
-        'sentry',
     )
     # fmt: on
 

--- a/config/mws.py
+++ b/config/mws.py
@@ -63,6 +63,7 @@ class BaseMWSConfig(
         'api',
         'emails',
         'audit_logs',
+        'sentry',
     )
     # fmt: on
 
@@ -75,10 +76,10 @@ class ProductionConfig(BaseMWSConfig):
     MAIL_BASE_URL = BASE_URL
     MAIL_OVERRIDE_RECIPIENTS = None
     MAIL_ERROR_RECIPIENTS = [
-        'parham@wildme.org',
+        'mail-errors@wildme.org',
     ]
 
-    SENTRY_DSN = os.getenv('SENTRY_DSN')
+    SENTRY_DSN = os.getenv('SENTRY_DSN_PRODUCTION', None)
 
 
 class DevelopmentConfig(BaseMWSConfig):
@@ -88,14 +89,14 @@ class DevelopmentConfig(BaseMWSConfig):
 
     MAIL_BASE_URL = BASE_URL
     MAIL_OVERRIDE_RECIPIENTS = [
-        'parham@wildme.org',
+        'testing@wildme.org',
     ]
     MAIL_ERROR_RECIPIENTS = [
-        'parham@wildme.org',
+        'mail-errors@wildme.org',
     ]
 
     SECRET_KEY = 'DEVELOPMENT_SECRET_KEY'
-    SENTRY_DSN = None
+    SENTRY_DSN = os.getenv('SENTRY_DSN_DEVELOPMENT', None)
 
 
 class TestingConfig(DevelopmentConfig):


### PR DESCRIPTION
## Pull Request Overview

- Add new environment variables for `SENTRY_DSN_PRODUCTION` and `SENTRY_DSN_DEVELOPMENT` to configure Sentry's error reporting.
- All error reporting and telemetry is opt-in by default.
- Enable the `sentry` extension for Codex and MWS
- Update the email addresses listed in the MWS config

---

**Review Notes**
- The API keys for `SENTRY_DSN_PRODUCTION` and `SENTRY_DSN_DEVELOPMENT` can be found in Wild Me's Sentry portal or in the password manager.
