### PR TITLE
DEX-729: GET /api/v1/users list truncates to only first 20

### DIFF
--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -39,7 +39,9 @@ class Users(Resource):
         },
     )
     @api.response(schemas.UserListSchema(many=True))
-    @api.paginate(parameters.ListUserParameters())
+    # turning off pagination as it defaults to only 20 shown  [DEX-729]
+    # @api.paginate(parameters.ListUserParameters())
+    @api.parameters(parameters.ListUserParameters())
     def get(self, args):
         """
         List of users.


### PR DESCRIPTION
## Pull Request Overview

- Pagination defaults to only showing first 20 items - disabling
