### PR TITLE
Add owner, location_ids and verbatim_localities to the sightings index

### DIFF
--- a/app/modules/elasticsearch/tasks.py
+++ b/app/modules/elasticsearch/tasks.py
@@ -315,13 +315,15 @@ SELECT
     LEFT JOIN "CUSTOMFIELDVALUE" cfv ON cf."ID_EID" = cfv."ID"
    WHERE
     cf."ID_OID" = oc."ID"
-  ) AS custom_fields
+  ) AS custom_fields,
+  (array_agg(DISTINCT hen.owner_guid))[1] AS owner
 FROM
   "OCCURRENCE" oc
   LEFT JOIN "OCCURRENCE_ENCOUNTERS" oe ON oe."ID_OID" = oc."ID"
   LEFT JOIN "ENCOUNTER" en ON en."ID" = oe."ID_EID"
   LEFT JOIN "TAXONOMY" ta ON ta."ID" = en."TAXONOMY_ID_OID"
   JOIN houston.sighting si ON oc."ID" = si.guid::text
+  LEFT JOIN houston.encounter hen ON si.guid = hen.sighting_guid
   LEFT JOIN houston.complex_date_time cdt ON si.time_guid = cdt.guid
 {where_clause}
 GROUP BY id, datetime, timezone, specificity

--- a/app/modules/elasticsearch/tasks.py
+++ b/app/modules/elasticsearch/tasks.py
@@ -287,6 +287,8 @@ SIGHTINGS_INDEX_SQL = """\
 SELECT
   oc."ID" AS id,
   NULLIF((oc."DECIMALLATITUDE"::float || ',' || oc."DECIMALLONGITUDE")::text, ',') AS point,
+  NULLIF(array_agg(DISTINCT en."LOCATIONID"), '{NULL}') AS location_ids,
+  NULLIF(array_agg(DISTINCT en."VERBATIMLOCALITY"), '{NULL}') AS verbatim_localities,
   cdt.datetime AS datetime,
   -- timezone stored as "UTC+0300", change to "+03:00"
   left(right(cdt.timezone, 5), 3) || ':' || right(cdt.timezone, 2) AS timezone,


### PR DESCRIPTION
```
    {
      "_index": "sightings",
      "_type": "_doc",
      "_id": "sighting_00006226-3f11-4711-bebe-c14faf1201d5",
      "_score": 1,
      "_source": {
        "id": "00006226-3f11-4711-bebe-c14faf1201d5",
        "point": "0.042395091740593,36.9557105308591",
        "location_ids": [
          "Ol Pejeta.East"
        ],
        "verbatim_localities": [
          "Zebra Plain"
        ],
        "datetime": "2020-01-17T10:36:00+03:00",
        "time_specificity": "time",
        "taxonomy": "Equus quagga",
        "comments": "None",
        "custom_fields": {
          "c54a17b8-9a58-4834-9947-641235ea9477": "Standing"
        },
        "owner": "1a750458-5d66-41ca-a3f4-aa27c52f21a8"
      }
    },
```
