### PR TITLE
Show all of houston logs if integration tests fail

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -103,7 +103,16 @@ jobs:
         run: |
           docker-compose logs --tail=250
           docker-compose ps
+
+      - name: Show acm logs if failed
+        if: failure()
+        run: |
           docker-compose logs acm
+
+      - name: Show houston logs if failed
+        if: failure()
+        run: |
+          docker-compose logs houston
 
       - name: Upload codex.html and codex.png if failed
         if: failure()


### PR DESCRIPTION
I spent a little bit of time looking into the integration test time out problem (example https://github.com/WildMeOrg/houston/runs/5071637365?check_suite_focus=true#step:13:1719) and I found this:

```
Attempting job completion callback to 'houston+http://houston:5000/api/v1/asset_groups/sighting/bfc3ccb0-2e30-4595-a67e-0deca19b56b4/sage_detected/1a0b21ca-7687-44b0-931c-15ac318dd4c9'
     HTTP Method: 'POST'
     Data Payload: {'jobid': '1a0b21ca-7687-44b0-931c-15ac318dd4c9', 'status': 'completed', 'json_result': {'image_uuid_list': [UUID('91944856-17a3-b9e3-1729-eec3592da484'), UUID('7e9cf7f4-de5f-6927-9a92-ee61ac0c7656')], 'results_list': [[{'id': 5, 'uuid': UUID('c1f72aa7-61d0-477f-a073-0ebd4a221033'), 'xtl': 156, 'ytl': 390, 'left': 156, 'top': 390, 'width': 1664, 'height': 1653, 'theta': 0.0, 'confidence': 0.8976, 'class': 'turtle_sea', 'species': 'turtle_sea', 'viewpoint': None, 'quality': None, 'multiple': False, 'interest': False}], [{'id': 6, 'uuid': UUID('f153b523-0d30-4a36-a411-5c7de305bcb3'), 'xtl': 884, 'ytl': 15, 'left': 884, 'top': 15, 'width': 3704, 'height': 2562, 'theta': 0.0, 'confidence': 0.9455, 'class': 'turtle_sea', 'species': 'turtle_sea', 'viewpoint': None, 'quality': None, 'multiple': False, 'interest': False}]], 'score_list': [0.0, 0.0], 'has_assignments': False}}
Callback FAILED!                                                                                                
on_collect_request action = 'notification', jobid = '1a0b21ca-7687-44b0-931c-15ac318dd4c9', status = 'completed'
Updating jobid = '1a0b21ca-7687-44b0-931c-15ac318dd4c9' status 'publishing' -> 'completed'
Notify {                                                                                                     
    'input': '/data/db/_ibsdb/_ibeis_cache/engine_shelves/1a0b21ca-7687-44b0-931c-15ac318dd4c9.input.shelve',  
    'output': '/data/db/_ibsdb/_ibeis_cache/engine_shelves/1a0b21ca-7687-44b0-931c-15ac318dd4c9.output.shelve',
    'status': 'completed',
}                                                                                                                
[util_path] Deleting path='/data/db/_ibsdb/_ibeis_cache/engine_shelves/1a0b21ca-7687-44b0-931c-15ac318dd4c9.lock'
```

It looks like acm is responding but houston is returning an error causing the callback to fail.  There's no details in the acm logs so we need the houston logs too.