### PR TITLE
Use SERVER_NAME and PREFERRED_URL_SCHEME in the composition

### DIFF
--- a/.dockerfiles/docker-healthcheck.sh
+++ b/.dockerfiles/docker-healthcheck.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+
+curl -f "http://0.0.0.0:5000/api/v1/site-settings/heartbeat" -H "Host: $SERVER_NAME"

--- a/.env
+++ b/.env
@@ -41,8 +41,10 @@ WBIA_DB_DIR=/data/db
 HOUSTON_DB_NAME=houston
 HOUSTON_DB_USER=houston
 HOUSTON_DB_PASSWORD=development
-HOUSTON_URL=http://houston:5000/
+HOUSTON_URL=http://localhost/
 WILDBOOK_DB_HOST=db
+SERVER_NAME=localhost
+PREFERRED_URL_SCHEME=http
 
 #: i.e. postgresql://${HOUSTON_DB_USER}:${HOUSTON_DB_PASSWORD}@db/${HOUSTON_DB_NAME}
 SQLALCHEMY_DATABASE_URI=postgresql://houston:development@db/houston

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -79,12 +79,12 @@ jobs:
               exit 1
             fi
             # Wait for houston to be ready
-            wget --tries=1 -O - http://localhost:83/api/v1/users/admin_user_initialized && break
+            wget --tries=1 -O - --header='Host: localhost' http://127.0.0.1:83/api/v1/users/admin_user_initialized && break
           done
           # Wait for frontend to be ready
           while sleep 10
           do
-            wget --tries=1 -O - http://localhost:84/ && break
+            wget --tries=1 -O - http://localhost/ && break
           done
           # Wait for acm to be ready
           while sleep 10

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -107,7 +107,7 @@ jobs:
             then
               exit 1
             fi
-            wget --tries=1 -O - http://localhost:83/houston/ && break
+            wget --tries=1 -O - --header="Host: localhost" http://localhost:83/houston/ && break
           done
 
       - name: Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,7 @@ VOLUME [ "${DATA_VOLUME}" ]
 ENV HOUSTON_DOTENV ${DATA_ROOT}/.env
 
 COPY ./.dockerfiles/docker-entrypoint.sh /docker-entrypoint.sh
+COPY ./.dockerfiles/docker-healthcheck.sh /docker-healthcheck.sh
 
 COPY ./.dockerfiles/embed.sh /bin/embed
 

--- a/docker-compose.codex.yml
+++ b/docker-compose.codex.yml
@@ -49,7 +49,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+      test: ["CMD-SHELL", "curl --silent --fail 127.0.0.1:9200/_cluster/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -94,7 +94,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/dbconnections.jsp"]
+      test: [ "CMD", "curl", "-f", "http://127.0.0.1:8080/dbconnections.jsp"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -129,7 +129,7 @@ services:
       elasticsearch:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:5000/api/v1/site-settings/heartbeat"]
+      test: ['CMD', '/docker-healthcheck.sh']
       interval: 10s
       timeout: 5s
       retries: 60
@@ -137,6 +137,7 @@ services:
       - houston-var:/data
       # These are added for development. Do not mount these in production.
       - .dockerfiles/docker-entrypoint.sh:/docker-entrypoint.sh
+      - .dockerfiles/docker-healthcheck.sh:/docker-healthcheck.sh
       - .dockerfiles/docker-entrypoint-init.d.codex:/docker-entrypoint-init.d
       - .dockerfiles/docker-entrypoint-always-init.d:/docker-entrypoint-always-init.d
       # FIXME: pull in development code while working on bringing up the container
@@ -149,6 +150,9 @@ services:
       - "83:5000"
     environment: &houston-environment
       HOUSTON_APP_CONTEXT: codex
+      # exposed service is 'localhost' using default port 80
+      SERVER_NAME: "${SERVER_NAME}"
+      PREFERRED_URL_SCHEME: "${PREFERRED_URL_SCHEME}"
       FLASK_ENV: development
       SQLALCHEMY_DATABASE_URI: "${SQLALCHEMY_DATABASE_URI}"
       TEST_DATABASE_URI: "${TEST_DATABASE_URI}"
@@ -219,7 +223,7 @@ services:
     working_dir: /code
     entrypoint: "/docker-entrypoint.sh"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:3000/"]
+      test: [ "CMD", "curl", "-f", "http://127.0.0.1:3000/"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -233,7 +237,7 @@ services:
       HOST: "0.0.0.0"
       PORT: "84"
 
-  www:
+  localhost:
     image: nginx:latest
     depends_on:
       edm:
@@ -255,6 +259,8 @@ services:
       - intranet
       - frontend
     ports:
+      - "80:80"
+      # BBB deprecated in favor or port 80, remains for backward compat
       - "84:80"
 
 networks:

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -15,7 +15,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 TIMEOUT = int(os.getenv('TIMEOUT', 20))
 POLL_FREQUENCY = int(os.getenv('POLL_FREQUENCY', 1))
-CODEX_URL = os.getenv('CODEX_URL', 'http://localhost:84/')
+CODEX_URL = os.getenv('CODEX_URL', 'http://localhost/')
 ADMIN_EMAIL = os.getenv('ADMIN_EMAIL', 'root@example.org')
 ADMIN_PASSWORD = os.getenv('ADMIN_PASSWORD', 'password')
 ADMIN_NAME = os.getenv('ADMIN_NAME', 'Test admin')

--- a/tests/modules/asset_groups/resources/test_create_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_create_asset_group.py
@@ -488,7 +488,7 @@ def test_create_asset_group_repeat_detection(
             'labeler_model_tag',
         }
         assert params['image_uuid_list'] == json.dumps(
-            [f'houston+http://houston:5000/api/v1/assets/src_raw/{asset_guid}']
+            [f'houston+http://localhost/api/v1/assets/src_raw/{asset_guid}']
         )
         job_uuid = params['jobid']
         assert ags1.stage == AssetGroupSightingStage.detection

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -455,13 +455,13 @@ def create_asset_group_sim_sage_init_resp(
             assert params['endpoint'] == '/api/engine/detect/cnn/lightnet/'
             assert re.match('[a-f0-9-]{36}', params['jobid'])
             assert re.match(
-                r'houston\+http://houston:5000/api/v1/asset_groups/sighting/[a-f0-9-]{36}/sage_detected/'
+                r'houston\+http://localhost/api/v1/asset_groups/sighting/[a-f0-9-]{36}/sage_detected/'
                 + params['jobid'],
                 params['callback_url'],
             )
             assert all(
                 re.match(
-                    r'houston\+http://houston:5000/api/v1/assets/src_raw/[a-f0-9-]{36}',
+                    r'houston\+http://localhost/api/v1/assets/src_raw/[a-f0-9-]{36}',
                     uri,
                 )
                 for uri in json.loads(params['image_uuid_list'])


### PR DESCRIPTION
## Description

This attempts to use the `SERVER_NAME` and `PREFERRED_URL_SCHEME`
environment variables. This is a move towards deprecating the
`HOUSTON_URL` environment variable that sets the `BASE_URL`
configuration setting. See also
[DEX-695 Obsolete the BASE_URL configuration
setting](https://wildme.atlassian.net/browse/DEX-695)

One downside of this change is that `SERVER_NAME` setting has special
behavior within Werkzeug. The server, much like nginx or any other
server, will only serve for the given name; so the `Host:
$SERVER_NAME` request header must be supplied when making requests
within the houston container if trying to directly contact the service
without the reverse proxy.

On the upside, because we tell Werkzeug to serve under this name,
we must also be able to actual server under the name and share it with
other services (i.e. ACM in the callback url). To do this I've worked
around the issue by utilizing the name `localhost` for both internal
(to the composition's network) and external usage. For example,
requesting `http://localhost/api/v1/users/me` will work both inside the
container and outside of it.

Using this change will mean the composition is serving very similar to
how it would be served in production (or at least how Flask likes to
be served in production). And thus no workaround, other than the
service named `localhost` added in this change, will need to be
present. That means cleaner code with less special snowflakes! Yay!

---

## Direct changes to the development workflow

The `www` service is now `localhost`. This satisfies Werkzeug and provides us with a way to easily contact the server. However, you'll now need to use http://localhost/ when contacting the site. For examlple, using http://localhost:84/ or http://127.0.0.1 won't work unless you also pass the `Host: localhost` header.

