### PR TITLE
DEX-741:  migrating users from old-world (edm) should include Roles

### DIFF
--- a/tests/modules/users/test_models.py
+++ b/tests/modules/users/test_models.py
@@ -168,6 +168,7 @@ def test_User_must_have_password():
         print(user)
 
 
+@pytest.mark.skipif(extension_unavailable('edm'), reason='EDM extension disabled')
 def test_edm_migration_roles(user_instance):
     assert not user_instance.is_researcher
     assert not user_instance.is_user_manager

--- a/tests/modules/users/test_models.py
+++ b/tests/modules/users/test_models.py
@@ -5,6 +5,7 @@ import pytest
 
 from app.modules.users import models
 from tests import utils
+from tests.utils import extension_unavailable
 
 
 def test_User_repr(user_instance):

--- a/tests/modules/users/test_models.py
+++ b/tests/modules/users/test_models.py
@@ -166,3 +166,25 @@ def test_User_must_have_password():
     with pytest.raises(ValueError, match='User must have a password'):
         user = models.User(email='user1@localhost', full_name='Lord Lucan')
         print(user)
+
+
+def test_edm_migration_roles(user_instance):
+    assert not user_instance.is_researcher
+    assert not user_instance.is_user_manager
+    assert not user_instance.is_data_manager
+    user_instance._process_edm_user_roles(None)
+    assert not user_instance.is_researcher
+    assert not user_instance.is_user_manager
+    assert not user_instance.is_data_manager
+    user_instance._process_edm_user_roles(['fubar'])
+    assert not user_instance.is_researcher
+    assert not user_instance.is_user_manager
+    assert not user_instance.is_data_manager
+    user_instance._process_edm_user_roles(['researcher'])
+    assert user_instance.is_researcher
+    assert not user_instance.is_user_manager
+    assert not user_instance.is_data_manager
+    user_instance._process_edm_user_roles(['manager'])
+    assert user_instance.is_researcher
+    assert user_instance.is_user_manager
+    assert user_instance.is_data_manager


### PR DESCRIPTION
## Pull Request Overview

- Use old-world User Roles to set proper privileges within Codex when migrating Users
- Requires [current EDM](https://github.com/WildMeOrg/Wildbook/commit/8c251e1c6564d716e92f3328a74cb91eb8171862) updated code
