### PR TITLE
MWS Mission Tasks from Assets

### DIFF
--- a/app/modules/annotations/parameters.py
+++ b/app/modules/annotations/parameters.py
@@ -112,8 +112,10 @@ class PatchAnnotationDetailsParameters(PatchJSONParameters):
         if field == 'keywords':
             keyword = cls._check_keyword_value(obj, field, value, state, create=False)
 
-            obj.add_keyword(keyword)
+            if keyword is None:
+                return False
 
+            obj.add_keyword(keyword)
             return True
 
         # otherwise, add and replace are the same operation so reuse the one method

--- a/app/modules/app_ui.py
+++ b/app/modules/app_ui.py
@@ -76,14 +76,6 @@ def admin_required(func):
     return decorated_function
 
 
-# @backend_blueprint.before_app_request
-# def before_app_request():
-#     import utool as ut
-#     ut.embed()
-#     if not current_user and not User.admin_user_initialized():
-#         return redirect(url_for('backend.admin_init'))
-
-
 @backend_blueprint.route('/', methods=['GET'])
 @ensure_admin_exists
 def home(*args, **kwargs):

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -170,6 +170,14 @@ class Asset(db.Model, HoustonModel):
     def annotation_count(self):
         return -1 if self.annotations is None else len(self.annotations)
 
+    @property
+    @module_required('missions', resolve='warn', default=[])
+    def tasks(self):
+        return [
+            participation.mission_task
+            for participation in self.mission_task_participations
+        ]
+
     @module_required('sightings', resolve='warn', default=[])
     def get_asset_sightings(self):
         return self.asset_sightings
@@ -345,7 +353,8 @@ class Asset(db.Model, HoustonModel):
         source_path = self.get_symlink()
         if not source_path.exists():
             raise HoustonException(
-                log, 'Asset does not have a valid path, needs to be within an AssetGroup'
+                log,
+                'Asset does not have a valid path, needs to be within an AssetGroup',
             )
         target_path = self.get_derived_path('master')
         target_path.parent.mkdir(parents=True, exist_ok=True)

--- a/app/modules/assets/parameters.py
+++ b/app/modules/assets/parameters.py
@@ -78,8 +78,10 @@ class PatchAssetParameters(PatchJSONParameters):
         if field == 'tags':
             tag = cls._check_tag_value(obj, field, value, state, create=False)
 
-            obj.add_tag(tag)
+            if tag is None:
+                return False
 
+            obj.add_tag(tag)
             return True
 
         # otherwise, add and replace are the same operation so reuse the one method

--- a/app/modules/assets/resources.py
+++ b/app/modules/assets/resources.py
@@ -127,30 +127,6 @@ class AssetByID(Resource):
             db.session.merge(asset)
         return asset
 
-    # @api.permission_required(
-    #     permissions.ObjectAccessPermission,
-    #     kwargs_on_request=lambda kwargs: {
-    #         'obj': kwargs['asset'],
-    #         'action': AccessOperation.WRITE,
-    #     },
-    # )
-    # @api.login_required(oauth_scopes=['assets:write'])
-    # @api.response(code=HTTPStatus.CONFLICT)
-    # @api.response(code=HTTPStatus.NO_CONTENT)
-    # def delete(self, asset):
-    #     """
-    #     Delete a Asset by ID.
-    #     """
-    #     import utool as ut
-    #     ut.embed()
-    #     context = api.commit_or_abort(
-    #         db.session,
-    #         default_error_message="Failed to delete the Asset."
-    #     )
-    #     with context:
-    #         db.session.delete(asset)
-    #     return None
-
 
 @api.route('/src/<uuid:asset_guid>', defaults={'format': 'master'}, doc=False)
 @api.route('/src/<string:format>/<uuid:asset_guid>')

--- a/app/modules/assets/schemas.py
+++ b/app/modules/assets/schemas.py
@@ -38,6 +38,11 @@ class DetailedAssetTableSchema(BaseAssetSchema):
         many=True,
     )
 
+    tasks = base_fields.Nested(
+        'BaseMissionTaskTableSchema',
+        many=True,
+    )
+
     class Meta(BaseAssetSchema.Meta):
         fields = BaseAssetSchema.Meta.fields + (
             Asset.created.key,
@@ -47,6 +52,7 @@ class DetailedAssetTableSchema(BaseAssetSchema):
             'annotation_count',
             'classifications',
             'tags',
+            'tasks',
         )
 
         dump_only = BaseAssetSchema.Meta.dump_only + (

--- a/app/modules/elasticsearch/tasks.py
+++ b/app/modules/elasticsearch/tasks.py
@@ -261,7 +261,7 @@ def load_sightings_index(
 ):
     if catchup_index_before:
         where_clause = f"WHERE si.updated < '{catchup_index_before}' AND si.guid > '{catchup_index_mark}'"
-        order_clause = f"ORDER BY id LIMIT {catchup_index_batch_size}"
+        order_clause = f'ORDER BY id LIMIT {catchup_index_batch_size}'
     else:
         cutoff = update_incremental_cutoff('sighting')
         where_clause = f"WHERE si.updated >= '{cutoff}'"

--- a/app/modules/fileuploads/models.py
+++ b/app/modules/fileuploads/models.py
@@ -93,8 +93,10 @@ class FileUpload(db.Model, HoustonModel):
         return fups
 
     @classmethod
-    # default behavior is to *move*
     def create_fileupload_from_path(cls, source_path, copy=False):
+        """
+        default behavior is to *move*
+        """
         assert source_path is not None
         fup = FileUpload()
         if copy:

--- a/app/modules/missions/schemas.py
+++ b/app/modules/missions/schemas.py
@@ -21,7 +21,7 @@ class BaseMissionSchema(ModelSchema):
         fields = (
             Mission.guid.key,
             Mission.title.key,
-            'created',
+            Mission.created.key,
         )
         dump_only = (Mission.guid.key,)
 
@@ -33,6 +33,7 @@ class CreationMissionSchema(BaseMissionSchema):
 
     class Meta(BaseMissionSchema.Meta):
         fields = BaseMissionSchema.Meta.fields + (
+            Mission.updated.key,
             Mission.title.key,
             Mission.options.key,
             Mission.classifications.key,
@@ -52,11 +53,15 @@ class DetailedMissionSchema(CreationMissionSchema):
 
     collections = base_fields.Nested('BaseMissionCollectionSchema', many=True)
 
+    tasks = base_fields.Nested('BaseMissionTaskTableSchema', many=True)
+
     class Meta(CreationMissionSchema.Meta):
         fields = CreationMissionSchema.Meta.fields + (
             'owner',
             'assigned_users',
             'collections',
+            'tasks',
+            'asset_count',
         )
         dump_only = CreationMissionSchema.Meta.dump_only
 
@@ -81,6 +86,7 @@ class BaseMissionCollectionSchema(ModelSchema):
             MissionCollection.commit.key,
             MissionCollection.major_type.key,
             MissionCollection.description.key,
+            'asset_count',
         )
         dump_only = (
             MissionCollection.guid.key,
@@ -136,9 +142,23 @@ class BaseMissionTaskSchema(ModelSchema):
         # pylint: disable=missing-docstring
         model = MissionTask
         fields = (
+            MissionTask.created.key,
             MissionTask.guid.key,
             MissionTask.title.key,
             'mission',
+        )
+        dump_only = (MissionTask.guid.key,)
+
+
+class BaseMissionTaskTableSchema(ModelSchema):
+    class Meta:
+        # pylint: disable=missing-docstring
+        model = MissionTask
+        fields = (
+            MissionTask.created.key,
+            MissionTask.guid.key,
+            MissionTask.title.key,
+            'asset_count',
         )
         dump_only = (MissionTask.guid.key,)
 
@@ -148,6 +168,28 @@ class DetailedMissionTaskSchema(BaseMissionTaskSchema):
     Detailed MissionTask schema exposes all useful fields.
     """
 
+    owner = base_fields.Nested('PublicUserSchema', many=False)
+
+    assigned_users = base_fields.Nested('PublicUserSchema', many=True)
+
+    assets = base_fields.Nested(
+        'BaseAssetSchema',
+        many=True,
+    )
+
+    annotations = base_fields.Nested(
+        'BaseAnnotationSchema',
+        many=True,
+    )
+
     class Meta(BaseMissionTaskSchema.Meta):
-        fields = BaseMissionTaskSchema.Meta.fields
+        fields = BaseMissionTaskSchema.Meta.fields + (
+            MissionTask.updated.key,
+            MissionTask.type.key,
+            'owner',
+            'assigned_users',
+            'assets',
+            'annotations',
+            MissionTask.notes.key,
+        )
         dump_only = BaseMissionTaskSchema.Meta.dump_only

--- a/app/modules/notifications/models.py
+++ b/app/modules/notifications/models.py
@@ -226,14 +226,19 @@ class Notification(db.Model, HoustonModel):
     def owner(self):
         return self.recipient
 
+    @property
+    def sender_name(self):
+        return self.get_sender_name()
+
     def get_sender_name(self):
         from app.modules.users.models import User
 
-        user = User.query.get(self.sender_guid)
-        if user:
-            return user.full_name
-        else:
-            return 'N/A'
+        if self.sender_guid is not None:
+            user = User.query.get(self.sender_guid)
+            if user:
+                return user.full_name
+
+        return 'N/A'
 
     def get_sender_email(self):
         from app.modules.users.models import User

--- a/app/modules/notifications/resources.py
+++ b/app/modules/notifications/resources.py
@@ -58,9 +58,9 @@ class Notifications(Resource):
         Returns a list of Notification starting from ``offset`` limited by ``limit``
         parameter.
         """
-        all_notifications = Notification.query.all()
+
         if current_user.is_user_manager:
-            returned_notifications = all_notifications
+            returned_notifications = Notification.query.all()
         else:
             preferences = UserNotificationPreferences.get_user_preferences(current_user)
             returned_notifications = [

--- a/app/modules/notifications/schemas.py
+++ b/app/modules/notifications/schemas.py
@@ -32,7 +32,6 @@ class BaseNotificationSchema(ModelSchema):
     Base Notification schema exposes only the most general fields.
     """
 
-    sender_name = base_fields.Function(Notification.get_sender_name)
     created = base_fields.DateTime()
 
     class Meta:

--- a/app/modules/social_groups/models.py
+++ b/app/modules/social_groups/models.py
@@ -158,7 +158,7 @@ class SocialGroup(db.Model, HoustonModel):
                 )
             if item['label'] in labels:
                 raise HoustonException(log, f'can only have {item["label"]} once')
-            labels.append(item["label"])
+            labels.append(item['label'])
 
     def get_member_data_as_json(self):
         individual_data = {}

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -46,6 +46,7 @@ python-gitlab
 python-magic
 
 #Flask-Tus-Cont
+randomname
 redis
 
 scikit-build

--- a/flask_restx_patched/__init__.py
+++ b/flask_restx_patched/__init__.py
@@ -16,6 +16,10 @@ from .namespace import (  # NOQA
     module_required,  # NOQA
 )  # NOQA
 from .parameters import Parameters, PostFormParameters  # NOQA
-from .parameters import PatchJSONParameters, PatchJSONParametersWithPassword  # NOQA
+from .parameters import (  # NOQA
+    PatchJSONParameters,  # NOQA
+    PatchJSONParametersWithPassword,  # NOQA
+    SetOperationsJSONParameters,  # NOQA
+)  # NOQA
 from .swagger import Swagger  # NOQA
 from .resource import Resource  # NOQA

--- a/flask_restx_patched/parameters.py
+++ b/flask_restx_patched/parameters.py
@@ -398,8 +398,8 @@ class SetOperationsJSONParameters(Parameters):
     This implementation is designed to mirror the PATCH arguments according to RFC 6902.
     """
 
-    OP_UNION = ['union', 'and', '&']
-    OP_INTERSECTION = ['intersection', 'intersect', 'or', '|']
+    OP_UNION = ['union', 'or', '|']
+    OP_INTERSECTION = ['intersection', 'intersect', 'and', '&']
     OP_DIFFERENCE = ['difference', 'diff', '-', '->']
     OP_MIRRORED_DIFFERENCE = ['mirrored_difference', 'mirdiff', '--', '<-']
     OP_SYMMETRIC_DIFFERENCE = ['symmetric_difference', 'symmetric', 'symdiff', 'sym', '^']

--- a/tests/modules/missions/resources/test_create_mission.py
+++ b/tests/modules/missions/resources/test_create_mission.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
+from tests import utils
 from tests.modules.missions.resources import utils as mission_utils
+from tests.utils import random_nonce, random_guid
+import tests.extensions.tus.utils as tus_utils
 import pytest
 
 from tests.utils import module_unavailable
@@ -82,3 +85,114 @@ def test_mission_permission(
 
     # delete it
     mission_utils.delete_mission(flask_app_client, data_manager_1, mission_guid)
+
+
+@pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')
+def test_delete_mission_cleanup(flask_app_client, data_manager_1, test_root):
+    from app.modules.missions.models import (
+        Mission,
+        MissionCollection,
+        MissionTask,
+    )
+
+    transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
+    transaction_ids = []
+    transaction_ids.append(transaction_id)
+    mission_guid = None
+
+    try:
+        response = mission_utils.create_mission(
+            flask_app_client, data_manager_1, 'This is a test mission, please ignore'
+        )
+        mission_guid = response.json['guid']
+        temp_mission = Mission.query.get(mission_guid)
+
+        previous_list = mission_utils.read_all_mission_collections(
+            flask_app_client, data_manager_1
+        )
+
+        previous_list = mission_utils.read_all_mission_tasks(
+            flask_app_client, data_manager_1
+        )
+
+        new_mission_collections = []
+        for index in range(3):
+            transaction_id = str(random_guid())
+            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id)
+            transaction_ids.append(transaction_id)
+
+            nonce = random_nonce(8)
+            description = 'This is a test mission collection (%s), please ignore' % (
+                nonce,
+            )
+            response = mission_utils.create_mission_collection_with_tus(
+                flask_app_client,
+                data_manager_1,
+                description,
+                transaction_id,
+                temp_mission.guid,
+            )
+            mission_collection_guid = response.json['guid']
+            temp_mission_collection = MissionCollection.query.get(mission_collection_guid)
+
+            new_mission_collections.append((nonce, temp_mission_collection))
+
+        current_list = mission_utils.read_all_mission_collections(
+            flask_app_client, data_manager_1
+        )
+        assert len(previous_list.json) + len(new_mission_collections) == len(
+            current_list.json
+        )
+
+        nonce, new_mission_collection1 = new_mission_collections[0]
+        nonce, new_mission_collection2 = new_mission_collections[1]
+        data = [
+            utils.set_union_op('search', 'does-not-work'),
+            utils.set_difference_op('collections', [str(new_mission_collection1.guid)]),
+            utils.set_difference_op(
+                'assets', [str(new_mission_collection2.assets[0].guid)]
+            ),
+        ]
+
+        new_mission_tasks = []
+        for index in range(3):
+            response = mission_utils.create_mission_task(
+                flask_app_client, data_manager_1, mission_guid, data
+            )
+            mission_task_guid = response.json['guid']
+            temp_mission_task = MissionTask.query.get(mission_task_guid)
+
+            new_mission_tasks.append(temp_mission_task)
+
+        current_list = mission_utils.read_all_mission_tasks(
+            flask_app_client, data_manager_1
+        )
+        assert len(previous_list.json) + len(new_mission_tasks) == len(current_list.json)
+
+        # Check if the mission is showing the correct number of tasks
+        assert len(temp_mission.tasks) == len(new_mission_tasks)
+
+        # Check that the API for a mission's tasks agrees
+        response = mission_utils.read_mission_tasks_for_mission(
+            flask_app_client, data_manager_1, temp_mission.guid
+        )
+        assert len(response.json) == 3
+
+        missions = Mission.query.all()
+        mission_collections = MissionCollection.query.all()
+        mission_tasks = MissionTask.query.all()
+        assert len(missions) == 1
+        assert len(mission_collections) == 3
+        assert len(mission_tasks) == 3
+    finally:
+        if mission_guid:
+            mission_utils.delete_mission(flask_app_client, data_manager_1, mission_guid)
+        for transaction_id in transaction_ids:
+            tus_utils.cleanup_tus_dir(transaction_id)
+
+        missions = Mission.query.all()
+        mission_collections = MissionCollection.query.all()
+        mission_tasks = MissionTask.query.all()
+        assert len(missions) == 0
+        assert len(mission_collections) == 0
+        assert len(mission_tasks) == 0

--- a/tests/modules/missions/resources/test_create_task.py
+++ b/tests/modules/missions/resources/test_create_task.py
@@ -1,114 +1,243 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
+from tests import utils
 from tests.modules.missions.resources import utils as mission_utils
+from tests.utils import random_nonce, random_guid
+import tests.extensions.tus.utils as tus_utils
 import pytest
 
 from tests.utils import module_unavailable
 
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')
-def test_create_and_delete_mission_task(flask_app_client, data_manager_1):
+def test_create_and_delete_mission_task(flask_app_client, data_manager_1, test_root):
     # pylint: disable=invalid-name
     from app.modules.missions.models import (
+        Mission,
+        MissionCollection,
         MissionTask,
         MissionTaskUserAssignment,
         MissionTaskAssetParticipation,
     )
 
-    response = mission_utils.create_mission(
-        flask_app_client, data_manager_1, 'This is a test mission, please ignore'
-    )
-    mission_guid = response.json['guid']
+    transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
+    mission_guid, mission_collection_guid = None, None
 
-    response = mission_utils.create_mission_task(
-        flask_app_client,
-        data_manager_1,
-        'This is a test task, please ignore',
-        mission_guid,
-    )
+    try:
+        response = mission_utils.create_mission(
+            flask_app_client, data_manager_1, 'This is a test mission, please ignore'
+        )
+        mission_guid = response.json['guid']
+        temp_mission = Mission.query.get(mission_guid)
 
-    mission_task_guid = response.json['guid']
-    read_mission_task = MissionTask.query.get(response.json['guid'])
-    assert read_mission_task.title == 'This is a test task, please ignore'
-    assert read_mission_task.owner == data_manager_1
+        previous_list = mission_utils.read_all_mission_collections(
+            flask_app_client, data_manager_1
+        )
 
-    # Try reading it back
-    mission_utils.read_mission_task(flask_app_client, data_manager_1, mission_task_guid)
+        new_mission_collections = []
+        for index in range(3):
+            transaction_id = str(random_guid())
+            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id)
 
-    # And deleting it
-    mission_utils.delete_mission_task(flask_app_client, data_manager_1, mission_task_guid)
+            nonce = random_nonce(8)
+            description = 'This is a test mission collection (%s), please ignore' % (
+                nonce,
+            )
+            response = mission_utils.create_mission_collection_with_tus(
+                flask_app_client,
+                data_manager_1,
+                description,
+                transaction_id,
+                temp_mission.guid,
+            )
+            mission_collection_guid = response.json['guid']
+            temp_mission_collection = MissionCollection.query.get(mission_collection_guid)
 
-    read_mission_task = MissionTask.query.get(mission_task_guid)
-    assert read_mission_task is None
+            new_mission_collections.append((nonce, temp_mission_collection))
 
-    read_mission_task = MissionTaskUserAssignment.query.filter_by(
-        mission_task_guid=mission_task_guid
-    ).all()
-    assert len(read_mission_task) == 0
+        current_list = mission_utils.read_all_mission_collections(
+            flask_app_client, data_manager_1
+        )
+        assert len(previous_list.json) + len(new_mission_collections) == len(
+            current_list.json
+        )
 
-    read_mission_task = MissionTaskAssetParticipation.query.filter_by(
-        mission_task_guid=mission_task_guid
-    ).all()
-    assert len(read_mission_task) == 0
+        nonce, new_mission_collection1 = new_mission_collections[0]
+        nonce, new_mission_collection2 = new_mission_collections[1]
+        data = [
+            utils.set_union_op('search', 'does-not-work'),
+            utils.set_difference_op('collections', [str(new_mission_collection1.guid)]),
+            utils.set_difference_op(
+                'assets', [str(new_mission_collection2.assets[0].guid)]
+            ),
+        ]
 
-    mission_utils.delete_mission(flask_app_client, data_manager_1, mission_guid)
+        response = mission_utils.create_mission_task(
+            flask_app_client, data_manager_1, mission_guid, data
+        )
+
+        mission_task_guid = response.json['guid']
+        read_mission_task = MissionTask.query.get(response.json['guid'])
+        assert 'New Task: ' in read_mission_task.title
+        assert read_mission_task.owner == data_manager_1
+        mission_task_assets = read_mission_task.get_assets()
+        assert len(mission_task_assets) == 1
+        nonce, new_mission_collection3 = new_mission_collections[2]
+        assert mission_task_assets[0].git_store == new_mission_collection3
+
+        # Try reading it back
+        mission_utils.read_mission_task(
+            flask_app_client, data_manager_1, mission_task_guid
+        )
+
+        # And deleting it
+        mission_utils.delete_mission_task(
+            flask_app_client, data_manager_1, mission_task_guid
+        )
+
+        read_mission_task = MissionTask.query.get(mission_task_guid)
+        assert read_mission_task is None
+
+        read_mission_task = MissionTaskUserAssignment.query.filter_by(
+            mission_task_guid=mission_task_guid
+        ).all()
+        assert len(read_mission_task) == 0
+
+        read_mission_task = MissionTaskAssetParticipation.query.filter_by(
+            mission_task_guid=mission_task_guid
+        ).all()
+        assert len(read_mission_task) == 0
+    finally:
+        if mission_collection_guid:
+            mission_utils.delete_mission_collection(
+                flask_app_client, data_manager_1, mission_collection_guid
+            )
+        if mission_guid:
+            mission_utils.delete_mission(flask_app_client, data_manager_1, mission_guid)
+        tus_utils.cleanup_tus_dir(transaction_id)
 
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')
 def test_mission_task_permission(
-    flask_app_client, admin_user, staff_user, regular_user, data_manager_1, data_manager_2
+    flask_app_client,
+    admin_user,
+    staff_user,
+    regular_user,
+    data_manager_1,
+    data_manager_2,
+    test_root,
 ):
-    # Before we create any MissionTasks, find out how many are there already
-    previous_list = mission_utils.read_all_mission_tasks(flask_app_client, staff_user)
-
-    response = mission_utils.create_mission(
-        flask_app_client, data_manager_1, 'This is a test mission, please ignore'
-    )
-    mission_guid = response.json['guid']
-
-    response = mission_utils.create_mission_task(
-        flask_app_client,
-        data_manager_1,
-        'This is a test task, please ignore',
-        mission_guid,
+    from app.modules.missions.models import (
+        Mission,
+        MissionCollection,
     )
 
-    mission_task_guid = response.json['guid']
+    transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
+    mission_guid, mission_collection_guid = None, None
 
-    # staff user should be able to read anything
-    mission_utils.read_mission_task(flask_app_client, staff_user, mission_task_guid)
-    mission_utils.read_all_mission_tasks(flask_app_client, staff_user)
+    try:
+        response = mission_utils.create_mission(
+            flask_app_client, data_manager_1, 'This is a test mission, please ignore'
+        )
+        mission_guid = response.json['guid']
+        temp_mission = Mission.query.get(mission_guid)
 
-    # admin user should be able to read any tasks as well
-    mission_utils.read_mission_task(flask_app_client, admin_user, mission_task_guid)
-    mission_utils.read_all_mission_tasks(flask_app_client, admin_user)
+        previous_list = mission_utils.read_all_mission_collections(
+            flask_app_client, data_manager_1
+        )
 
-    # user that created task can read it back plus the list
-    mission_utils.read_mission_task(flask_app_client, data_manager_1, mission_task_guid)
-    list_response = mission_utils.read_all_mission_tasks(flask_app_client, data_manager_1)
+        new_mission_collections = []
+        for index in range(3):
+            transaction_id = str(random_guid())
+            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id)
 
-    # due to the way the tests are run, there may be tasks left lying about,
-    # don't rely on there only being one
-    assert len(list_response.json) == len(previous_list.json) + 1
-    mission_task_present = False
-    for task in list_response.json:
-        if task['guid'] == mission_task_guid:
-            mission_task_present = True
-            break
-    assert mission_task_present
+            nonce = random_nonce(8)
+            description = 'This is a test mission collection (%s), please ignore' % (
+                nonce,
+            )
+            response = mission_utils.create_mission_collection_with_tus(
+                flask_app_client,
+                data_manager_1,
+                description,
+                transaction_id,
+                temp_mission.guid,
+            )
+            mission_collection_guid = response.json['guid']
+            temp_mission_collection = MissionCollection.query.get(mission_collection_guid)
 
-    # a different data manager should also be able to read the task
-    mission_utils.read_mission_task(flask_app_client, data_manager_2, mission_task_guid)
-    mission_utils.read_all_mission_tasks(flask_app_client, data_manager_2)
+            new_mission_collections.append((nonce, temp_mission_collection))
 
-    # but a regular user should not be able to read the list or the task
-    mission_utils.read_mission_task(
-        flask_app_client, regular_user, mission_task_guid, 403
-    )
-    mission_utils.read_all_mission_tasks(flask_app_client, regular_user, 403)
+        current_list = mission_utils.read_all_mission_collections(
+            flask_app_client, data_manager_1
+        )
+        assert len(previous_list.json) + len(new_mission_collections) == len(
+            current_list.json
+        )
 
-    # delete it
-    mission_utils.delete_mission_task(flask_app_client, data_manager_1, mission_task_guid)
+        nonce, new_mission_collection1 = new_mission_collections[0]
+        nonce, new_mission_collection2 = new_mission_collections[1]
+        data = [
+            utils.set_union_op('search', 'does-not-work'),
+            utils.set_difference_op('collections', [str(new_mission_collection1.guid)]),
+            utils.set_difference_op(
+                'assets', [str(new_mission_collection2.assets[0].guid)]
+            ),
+        ]
 
-    mission_utils.delete_mission(flask_app_client, data_manager_1, mission_guid)
+        response = mission_utils.create_mission_task(
+            flask_app_client, data_manager_1, mission_guid, data
+        )
+
+        mission_task_guid = response.json['guid']
+
+        # staff user should be able to read anything
+        mission_utils.read_mission_task(flask_app_client, staff_user, mission_task_guid)
+        mission_utils.read_all_mission_tasks(flask_app_client, staff_user)
+
+        # admin user should be able to read any tasks as well
+        mission_utils.read_mission_task(flask_app_client, admin_user, mission_task_guid)
+        mission_utils.read_all_mission_tasks(flask_app_client, admin_user)
+
+        # user that created task can read it back plus the list
+        mission_utils.read_mission_task(
+            flask_app_client, data_manager_1, mission_task_guid
+        )
+        list_response = mission_utils.read_all_mission_tasks(
+            flask_app_client, data_manager_1
+        )
+
+        # due to the way the tests are run, there may be tasks left lying about,
+        # don't rely on there only being one
+        assert len(list_response.json) == len(previous_list.json) + 1
+        mission_task_present = False
+        for task in list_response.json:
+            if task['guid'] == mission_task_guid:
+                mission_task_present = True
+                break
+        assert mission_task_present
+
+        # a different data manager should also be able to read the task
+        mission_utils.read_mission_task(
+            flask_app_client, data_manager_2, mission_task_guid
+        )
+        mission_utils.read_all_mission_tasks(flask_app_client, data_manager_2)
+
+        # but a regular user should not be able to read the list or the task
+        mission_utils.read_mission_task(
+            flask_app_client, regular_user, mission_task_guid, 403
+        )
+        mission_utils.read_all_mission_tasks(flask_app_client, regular_user, 403)
+
+        # delete it
+        mission_utils.delete_mission_task(
+            flask_app_client, data_manager_1, mission_task_guid
+        )
+    finally:
+        if mission_collection_guid:
+            mission_utils.delete_mission_collection(
+                flask_app_client, data_manager_1, mission_collection_guid
+            )
+        if mission_guid:
+            mission_utils.delete_mission(flask_app_client, data_manager_1, mission_guid)
+        tus_utils.cleanup_tus_dir(transaction_id)

--- a/tests/modules/missions/resources/test_get_collection.py
+++ b/tests/modules/missions/resources/test_get_collection.py
@@ -28,10 +28,12 @@ def test_get_mission_collection_by_search(flask_app_client, data_manager_1, test
         flask_app_client, data_manager_1
     )
 
+    transaction_ids = []
     new_mission_collections = []
     for index in range(3):
         transaction_id = str(random_guid())
         tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id)
+        transaction_ids.append(transaction_id)
 
         nonce = random_nonce(8)
         description = 'This is a test mission collection (%s), please ignore' % (nonce,)
@@ -124,3 +126,6 @@ def test_get_mission_collection_by_search(flask_app_client, data_manager_1, test
 
     # Delete mission
     mission_utils.delete_mission(flask_app_client, data_manager_1, temp_mission.guid)
+
+    for transaction_id in transaction_ids:
+        tus_utils.cleanup_tus_dir(transaction_id)

--- a/tests/modules/missions/resources/test_get_task.py
+++ b/tests/modules/missions/resources/test_get_task.py
@@ -23,7 +23,9 @@ def test_get_mission_task_by_search(flask_app_client, data_manager_1, test_root)
     )
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
-    mission_guid, mission_collection_guid = None, None
+    transaction_ids = []
+    transaction_ids.append(transaction_id)
+    mission_guid = None
 
     try:
         response = mission_utils.create_mission(
@@ -44,6 +46,7 @@ def test_get_mission_task_by_search(flask_app_client, data_manager_1, test_root)
         for index in range(3):
             transaction_id = str(random_guid())
             tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id)
+            transaction_ids.append(transaction_id)
 
             nonce = random_nonce(8)
             description = 'This is a test mission collection (%s), please ignore' % (
@@ -151,10 +154,8 @@ def test_get_mission_task_by_search(flask_app_client, data_manager_1, test_root)
                 flask_app_client, data_manager_1, new_mission_task.guid
             )
     finally:
-        if mission_collection_guid:
-            mission_utils.delete_mission_collection(
-                flask_app_client, data_manager_1, mission_collection_guid
-            )
         if mission_guid:
             mission_utils.delete_mission(flask_app_client, data_manager_1, mission_guid)
-        tus_utils.cleanup_tus_dir(transaction_id)
+
+        for transaction_id in transaction_ids:
+            tus_utils.cleanup_tus_dir(transaction_id)

--- a/tests/modules/missions/resources/test_get_task.py
+++ b/tests/modules/missions/resources/test_get_task.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from tests.utils import module_unavailable, random_nonce
+from tests import utils
+from tests.utils import module_unavailable, random_nonce, random_guid
 from tests.modules.missions.resources import utils as mission_utils
+import tests.extensions.tus.utils as tus_utils
 
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')
@@ -14,98 +16,145 @@ def test_get_mission_task_not_found(flask_app_client):
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')
 def test_get_mission_task_by_search(flask_app_client, data_manager_1, test_root):
-    from app.modules.missions.models import Mission, MissionTask
-
-    response = mission_utils.create_mission(
-        flask_app_client, data_manager_1, 'This is a test mission, please ignore'
+    from app.modules.missions.models import (
+        Mission,
+        MissionCollection,
+        MissionTask,
     )
-    mission_guid = response.json['guid']
-    temp_mission = Mission.query.get(mission_guid)
-    assert len(temp_mission.tasks) == 0
 
-    previous_list = mission_utils.read_all_mission_tasks(flask_app_client, data_manager_1)
+    transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
+    mission_guid, mission_collection_guid = None, None
 
-    new_mission_tasks = []
-    for index in range(3):
-        nonce = random_nonce(8)
-        title = 'This is a test task (%s), please ignore' % (nonce,)
-        response = mission_utils.create_mission_task(
-            flask_app_client, data_manager_1, title, temp_mission.guid
+    try:
+        response = mission_utils.create_mission(
+            flask_app_client, data_manager_1, 'This is a test mission, please ignore'
         )
-        mission_task_guid = response.json['guid']
-        temp_mission_task = MissionTask.query.get(mission_task_guid)
+        mission_guid = response.json['guid']
+        temp_mission = Mission.query.get(mission_guid)
 
-        new_mission_tasks.append((nonce, temp_mission_task))
-
-    current_list = mission_utils.read_all_mission_tasks(flask_app_client, data_manager_1)
-    assert len(previous_list.json) + len(new_mission_tasks) == len(current_list.json)
-
-    # Check if the mission is showing the correct number of tasks
-    assert len(temp_mission.tasks) == len(new_mission_tasks)
-
-    # Check that the API for a mission's tasks agrees
-    response = mission_utils.read_mission_tasks_for_mission(
-        flask_app_client, data_manager_1, temp_mission.guid
-    )
-    assert len(response.json) == 3
-
-    # Search mission tasks by title segment
-    nonce, new_mission_task = new_mission_tasks[0]
-    current_list = mission_utils.read_all_mission_tasks(
-        flask_app_client, data_manager_1, search=nonce
-    )
-    assert len(current_list.json) == 1
-    response = current_list.json[0]
-    assert response['title'] == new_mission_task.title
-
-    # Search mission tasks by GUID segment
-    nonce, new_mission_task = new_mission_tasks[1]
-    guid_str = str(new_mission_task.guid)
-    guid_segment = guid_str.split('-')[-1]
-    current_list = mission_utils.read_all_mission_tasks(
-        flask_app_client, data_manager_1, search=guid_segment
-    )
-    assert len(current_list.json) == 1
-    response = current_list.json[0]
-    assert response['title'] == new_mission_task.title
-
-    # Search mission tasks by owner GUID segment
-    nonce, new_mission_task = new_mission_tasks[2]
-    assert new_mission_task.owner == data_manager_1
-    guid_str = str(new_mission_task.owner_guid)
-    guid_segment = guid_str.split('-')[-1]
-    current_list = mission_utils.read_all_mission_tasks(
-        flask_app_client, data_manager_1, search=guid_segment
-    )
-    assert len(current_list.json) == len(new_mission_tasks)
-
-    # Search mission tasks by mission GUID segment
-    nonce, new_mission_task = new_mission_tasks[2]
-    assert new_mission_task.mission == temp_mission
-    guid_str = str(new_mission_task.mission_guid)
-    guid_segment = guid_str.split('-')[-1]
-    current_list = mission_utils.read_all_mission_tasks(
-        flask_app_client, data_manager_1, search=guid_segment
-    )
-    assert len(current_list.json) == len(new_mission_tasks)
-
-    # Limit responses
-    limited_list = mission_utils.read_all_mission_tasks(
-        flask_app_client, data_manager_1, search=guid_segment, limit=2
-    )
-    assert len(current_list.json[:2]) == len(limited_list.json)
-
-    # Limit responses (with offset)
-    limited_list = mission_utils.read_all_mission_tasks(
-        flask_app_client, data_manager_1, search=guid_segment, offset=1, limit=2
-    )
-    assert len(current_list.json[1:3]) == len(limited_list.json)
-
-    # Delete mission tasks
-    for nonce, new_mission_task in new_mission_tasks:
-        mission_utils.delete_mission_task(
-            flask_app_client, data_manager_1, new_mission_task.guid
+        previous_list = mission_utils.read_all_mission_collections(
+            flask_app_client, data_manager_1
         )
 
-    # Delete mission
-    mission_utils.delete_mission(flask_app_client, data_manager_1, temp_mission.guid)
+        previous_list = mission_utils.read_all_mission_tasks(
+            flask_app_client, data_manager_1
+        )
+
+        new_mission_collections = []
+        for index in range(3):
+            transaction_id = str(random_guid())
+            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id)
+
+            nonce = random_nonce(8)
+            description = 'This is a test mission collection (%s), please ignore' % (
+                nonce,
+            )
+            response = mission_utils.create_mission_collection_with_tus(
+                flask_app_client,
+                data_manager_1,
+                description,
+                transaction_id,
+                temp_mission.guid,
+            )
+            mission_collection_guid = response.json['guid']
+            temp_mission_collection = MissionCollection.query.get(mission_collection_guid)
+
+            new_mission_collections.append((nonce, temp_mission_collection))
+
+        current_list = mission_utils.read_all_mission_collections(
+            flask_app_client, data_manager_1
+        )
+        assert len(previous_list.json) + len(new_mission_collections) == len(
+            current_list.json
+        )
+
+        nonce, new_mission_collection1 = new_mission_collections[0]
+        nonce, new_mission_collection2 = new_mission_collections[1]
+        data = [
+            utils.set_union_op('search', 'does-not-work'),
+            utils.set_difference_op('collections', [str(new_mission_collection1.guid)]),
+            utils.set_difference_op(
+                'assets', [str(new_mission_collection2.assets[0].guid)]
+            ),
+        ]
+
+        new_mission_tasks = []
+        for index in range(3):
+            response = mission_utils.create_mission_task(
+                flask_app_client, data_manager_1, mission_guid, data
+            )
+            mission_task_guid = response.json['guid']
+            temp_mission_task = MissionTask.query.get(mission_task_guid)
+
+            new_mission_tasks.append(temp_mission_task)
+
+        current_list = mission_utils.read_all_mission_tasks(
+            flask_app_client, data_manager_1
+        )
+        assert len(previous_list.json) + len(new_mission_tasks) == len(current_list.json)
+
+        # Check if the mission is showing the correct number of tasks
+        assert len(temp_mission.tasks) == len(new_mission_tasks)
+
+        # Check that the API for a mission's tasks agrees
+        response = mission_utils.read_mission_tasks_for_mission(
+            flask_app_client, data_manager_1, temp_mission.guid
+        )
+        assert len(response.json) == 3
+
+        # Search mission tasks by GUID segment
+        new_mission_task = new_mission_tasks[1]
+        guid_str = str(new_mission_task.guid)
+        guid_segment = guid_str.split('-')[-1]
+        current_list = mission_utils.read_all_mission_tasks(
+            flask_app_client, data_manager_1, search=guid_segment
+        )
+        assert len(current_list.json) == 1
+        response = current_list.json[0]
+        assert response['title'] == new_mission_task.title
+
+        # Search mission tasks by owner GUID segment
+        new_mission_task = new_mission_tasks[2]
+        assert new_mission_task.owner == data_manager_1
+        guid_str = str(new_mission_task.owner_guid)
+        guid_segment = guid_str.split('-')[-1]
+        current_list = mission_utils.read_all_mission_tasks(
+            flask_app_client, data_manager_1, search=guid_segment
+        )
+        assert len(current_list.json) == len(new_mission_tasks)
+
+        # Search mission tasks by mission GUID segment
+        new_mission_task = new_mission_tasks[2]
+        assert new_mission_task.mission == temp_mission
+        guid_str = str(new_mission_task.mission_guid)
+        guid_segment = guid_str.split('-')[-1]
+        current_list = mission_utils.read_all_mission_tasks(
+            flask_app_client, data_manager_1, search=guid_segment
+        )
+        assert len(current_list.json) == len(new_mission_tasks)
+
+        # Limit responses
+        limited_list = mission_utils.read_all_mission_tasks(
+            flask_app_client, data_manager_1, search=guid_segment, limit=2
+        )
+        assert len(current_list.json[:2]) == len(limited_list.json)
+
+        # Limit responses (with offset)
+        limited_list = mission_utils.read_all_mission_tasks(
+            flask_app_client, data_manager_1, search=guid_segment, offset=1, limit=2
+        )
+        assert len(current_list.json[1:3]) == len(limited_list.json)
+
+        # Delete mission tasks
+        for new_mission_task in new_mission_tasks:
+            mission_utils.delete_mission_task(
+                flask_app_client, data_manager_1, new_mission_task.guid
+            )
+    finally:
+        if mission_collection_guid:
+            mission_utils.delete_mission_collection(
+                flask_app_client, data_manager_1, mission_collection_guid
+            )
+        if mission_guid:
+            mission_utils.delete_mission(flask_app_client, data_manager_1, mission_guid)
+        tus_utils.cleanup_tus_dir(transaction_id)

--- a/tests/modules/missions/resources/test_modify_collection.py
+++ b/tests/modules/missions/resources/test_modify_collection.py
@@ -20,6 +20,8 @@ def test_create_patch_mission_collection(
     # pylint: disable=invalid-name
     mission_guid, mission_collection_guid = None, None
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
+    transaction_ids = []
+    transaction_ids.append(transaction_id)
     try:
         temp_mission = Mission(
             title='Temp Mission',
@@ -41,6 +43,7 @@ def test_create_patch_mission_collection(
 
         # test with explicit paths (should succeed)
         tid, valid_file = tus_utils.prep_tus_dir(test_root)
+        transaction_ids.append(tid)
         temp_mission_collection = MissionCollection.create_from_tus(
             'PYTEST', data_manager_1, tid, mission=temp_mission, paths={valid_file}
         )
@@ -82,8 +85,6 @@ def test_create_patch_mission_collection(
         # temp_mission_collection should be already deleted on gitlab
         assert not MissionCollection.is_on_remote(str(temp_mission_collection.guid))
     finally:
-        tus_utils.cleanup_tus_dir(transaction_id)
-
         # Restore original state
         temp_mission_collection = MissionCollection.query.get(mission_collection_guid)
         if temp_mission_collection is not None:
@@ -95,3 +96,6 @@ def test_create_patch_mission_collection(
         temp_mission = Mission.query.get(mission_guid)
         if temp_mission is not None:
             temp_mission.delete()
+
+        for transaction_id in transaction_ids:
+            tus_utils.cleanup_tus_dir(transaction_id)

--- a/tests/modules/missions/resources/test_modify_task.py
+++ b/tests/modules/missions/resources/test_modify_task.py
@@ -3,118 +3,233 @@
 
 from tests import utils
 from tests.modules.missions.resources import utils as mission_utils
+from tests.utils import random_nonce, random_guid
+import tests.extensions.tus.utils as tus_utils
 import pytest
 
 from tests.utils import module_unavailable
 
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')
-def test_modify_mission_task_users(db, flask_app_client, data_manager_1, data_manager_2):
-
+def test_modify_mission_task_users(
+    db, flask_app_client, data_manager_1, data_manager_2, test_root
+):
     # pylint: disable=invalid-name
-    from app.modules.missions.models import MissionTask
-
-    response = mission_utils.create_mission(
-        flask_app_client, data_manager_1, 'This is a test mission, please ignore'
+    from app.modules.missions.models import (
+        Mission,
+        MissionCollection,
+        MissionTask,
     )
-    mission_guid = response.json['guid']
 
-    response = mission_utils.create_mission_task(
-        flask_app_client,
-        data_manager_1,
-        'This is a test task, please ignore',
-        mission_guid,
-    )
-    mission_task_guid = response.json['guid']
+    transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
+    mission_guid, mission_collection_guid = None, None
 
-    mission_task = MissionTask.query.get(mission_task_guid)
-    assert len(mission_task.get_members()) == 1
+    try:
+        response = mission_utils.create_mission(
+            flask_app_client, data_manager_1, 'This is a test mission, please ignore'
+        )
+        mission_guid = response.json['guid']
+        temp_mission = Mission.query.get(mission_guid)
 
-    data = [
-        utils.patch_test_op(data_manager_1.password_secret),
-        utils.patch_add_op('user', '%s' % data_manager_2.guid),
-    ]
-    mission_utils.patch_mission_task(
-        flask_app_client, mission_task_guid, data_manager_1, data
-    )
-    assert len(mission_task.get_members()) == 2
+        previous_list = mission_utils.read_all_mission_collections(
+            flask_app_client, data_manager_1
+        )
 
-    data = [
-        utils.patch_test_op(data_manager_1.password_secret),
-        utils.patch_remove_op('user', '%s' % data_manager_2.guid),
-    ]
-    mission_utils.patch_mission_task(
-        flask_app_client, mission_task_guid, data_manager_1, data
-    )
-    assert len(mission_task.get_members()) == 1
+        new_mission_collections = []
+        for index in range(3):
+            transaction_id = str(random_guid())
+            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id)
 
-    mission_utils.delete_mission_task(flask_app_client, data_manager_1, mission_task_guid)
+            nonce = random_nonce(8)
+            description = 'This is a test mission collection (%s), please ignore' % (
+                nonce,
+            )
+            response = mission_utils.create_mission_collection_with_tus(
+                flask_app_client,
+                data_manager_1,
+                description,
+                transaction_id,
+                temp_mission.guid,
+            )
+            mission_collection_guid = response.json['guid']
+            temp_mission_collection = MissionCollection.query.get(mission_collection_guid)
 
-    mission_utils.delete_mission(flask_app_client, data_manager_1, mission_guid)
+            new_mission_collections.append((nonce, temp_mission_collection))
+
+        current_list = mission_utils.read_all_mission_collections(
+            flask_app_client, data_manager_1
+        )
+        assert len(previous_list.json) + len(new_mission_collections) == len(
+            current_list.json
+        )
+
+        nonce, new_mission_collection1 = new_mission_collections[0]
+        nonce, new_mission_collection2 = new_mission_collections[1]
+        data = [
+            utils.set_union_op('search', 'does-not-work'),
+            utils.set_difference_op('collections', [str(new_mission_collection1.guid)]),
+            utils.set_difference_op(
+                'assets', [str(new_mission_collection2.assets[0].guid)]
+            ),
+        ]
+
+        response = mission_utils.create_mission_task(
+            flask_app_client, data_manager_1, mission_guid, data
+        )
+        mission_task_guid = response.json['guid']
+
+        mission_task = MissionTask.query.get(mission_task_guid)
+        assert len(mission_task.get_members()) == 1
+
+        data = [
+            utils.patch_test_op(data_manager_1.password_secret),
+            utils.patch_add_op('user', '%s' % data_manager_2.guid),
+        ]
+        mission_utils.patch_mission_task(
+            flask_app_client, mission_task_guid, data_manager_1, data
+        )
+        assert len(mission_task.get_members()) == 2
+
+        data = [
+            utils.patch_test_op(data_manager_1.password_secret),
+            utils.patch_remove_op('user', '%s' % data_manager_2.guid),
+        ]
+        mission_utils.patch_mission_task(
+            flask_app_client, mission_task_guid, data_manager_1, data
+        )
+        assert len(mission_task.get_members()) == 1
+
+        mission_utils.delete_mission_task(
+            flask_app_client, data_manager_1, mission_task_guid
+        )
+    finally:
+        if mission_collection_guid:
+            mission_utils.delete_mission_collection(
+                flask_app_client, data_manager_1, mission_collection_guid
+            )
+        if mission_guid:
+            mission_utils.delete_mission(flask_app_client, data_manager_1, mission_guid)
+        tus_utils.cleanup_tus_dir(transaction_id)
 
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')
-def test_owner_permission(flask_app_client, data_manager_1, data_manager_2):
-
-    response = mission_utils.create_mission(
-        flask_app_client, data_manager_1, 'This is a test mission, please ignore'
-    )
-    mission_guid = response.json['guid']
-
-    response = mission_utils.create_mission_task(
-        flask_app_client,
-        data_manager_1,
-        'This is a test task, please ignore',
-        mission_guid,
-    )
-    mission_task_guid = response.json['guid']
-
-    # another user cannot update the title
-    data = [
-        utils.patch_test_op(data_manager_2.password_secret),
-        utils.patch_add_op('title', 'Invalid update'),
-    ]
-    mission_utils.patch_mission_task(
-        flask_app_client, mission_task_guid, data_manager_2, data, 409
+def test_owner_permission(flask_app_client, data_manager_1, data_manager_2, test_root):
+    from app.modules.missions.models import (
+        Mission,
+        MissionCollection,
     )
 
-    # Owner can do that
-    data = [
-        utils.patch_test_op(data_manager_1.password_secret),
-        utils.patch_add_op('title', 'An owner modified test task, please ignore'),
-    ]
-    response = mission_utils.patch_mission_task(
-        flask_app_client, mission_task_guid, data_manager_1, data
-    )
-    assert response.json['title'] == 'An owner modified test task, please ignore'
+    transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
+    mission_guid, mission_collection_guid = None, None
 
-    # add data manager 2 user to the task
-    data = [
-        utils.patch_test_op(data_manager_1.password_secret),
-        utils.patch_add_op('user', '%s' % data_manager_2.guid),
-    ]
-    mission_utils.patch_mission_task(
-        flask_app_client, mission_task_guid, data_manager_1, data
-    )
+    try:
+        response = mission_utils.create_mission(
+            flask_app_client, data_manager_1, 'This is a test mission, please ignore'
+        )
+        mission_guid = response.json['guid']
+        temp_mission = Mission.query.get(mission_guid)
 
-    # make them the owner
-    data = [
-        utils.patch_test_op(data_manager_1.password_secret),
-        utils.patch_add_op('owner', '%s' % data_manager_2.guid),
-    ]
-    mission_utils.patch_mission_task(
-        flask_app_client, mission_task_guid, data_manager_1, data
-    )
+        previous_list = mission_utils.read_all_mission_collections(
+            flask_app_client, data_manager_1
+        )
 
-    # try to remove a user as data manager 1, no longer owner, should fail
-    data = [
-        utils.patch_test_op(data_manager_1.password_secret),
-        utils.patch_remove_op('user', '%s' % data_manager_2.guid),
-    ]
-    mission_utils.patch_mission_task(
-        flask_app_client, mission_task_guid, data_manager_1, data, 409
-    )
+        new_mission_collections = []
+        for index in range(3):
+            transaction_id = str(random_guid())
+            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id)
 
-    mission_utils.delete_mission_task(flask_app_client, data_manager_1, mission_task_guid)
+            nonce = random_nonce(8)
+            description = 'This is a test mission collection (%s), please ignore' % (
+                nonce,
+            )
+            response = mission_utils.create_mission_collection_with_tus(
+                flask_app_client,
+                data_manager_1,
+                description,
+                transaction_id,
+                temp_mission.guid,
+            )
+            mission_collection_guid = response.json['guid']
+            temp_mission_collection = MissionCollection.query.get(mission_collection_guid)
 
-    mission_utils.delete_mission(flask_app_client, data_manager_1, mission_guid)
+            new_mission_collections.append((nonce, temp_mission_collection))
+
+        current_list = mission_utils.read_all_mission_collections(
+            flask_app_client, data_manager_1
+        )
+        assert len(previous_list.json) + len(new_mission_collections) == len(
+            current_list.json
+        )
+
+        nonce, new_mission_collection1 = new_mission_collections[0]
+        nonce, new_mission_collection2 = new_mission_collections[1]
+        data = [
+            utils.set_union_op('search', 'does-not-work'),
+            utils.set_difference_op('collections', [str(new_mission_collection1.guid)]),
+            utils.set_difference_op(
+                'assets', [str(new_mission_collection2.assets[0].guid)]
+            ),
+        ]
+
+        response = mission_utils.create_mission_task(
+            flask_app_client, data_manager_1, mission_guid, data
+        )
+        mission_task_guid = response.json['guid']
+
+        # another user cannot update the title
+        data = [
+            utils.patch_test_op(data_manager_2.password_secret),
+            utils.patch_add_op('title', 'Invalid update'),
+        ]
+        mission_utils.patch_mission_task(
+            flask_app_client, mission_task_guid, data_manager_2, data, 409
+        )
+
+        # Owner can do that
+        data = [
+            utils.patch_test_op(data_manager_1.password_secret),
+            utils.patch_add_op('title', 'An owner modified test task, please ignore'),
+        ]
+        response = mission_utils.patch_mission_task(
+            flask_app_client, mission_task_guid, data_manager_1, data
+        )
+        assert response.json['title'] == 'An owner modified test task, please ignore'
+
+        # add data manager 2 user to the task
+        data = [
+            utils.patch_test_op(data_manager_1.password_secret),
+            utils.patch_add_op('user', '%s' % data_manager_2.guid),
+        ]
+        mission_utils.patch_mission_task(
+            flask_app_client, mission_task_guid, data_manager_1, data
+        )
+
+        # make them the owner
+        data = [
+            utils.patch_test_op(data_manager_1.password_secret),
+            utils.patch_add_op('owner', '%s' % data_manager_2.guid),
+        ]
+        mission_utils.patch_mission_task(
+            flask_app_client, mission_task_guid, data_manager_1, data
+        )
+
+        # try to remove a user as data manager 1, no longer owner, should fail
+        data = [
+            utils.patch_test_op(data_manager_1.password_secret),
+            utils.patch_remove_op('user', '%s' % data_manager_2.guid),
+        ]
+        mission_utils.patch_mission_task(
+            flask_app_client, mission_task_guid, data_manager_1, data, 409
+        )
+
+        mission_utils.delete_mission_task(
+            flask_app_client, data_manager_1, mission_task_guid
+        )
+    finally:
+        if mission_collection_guid:
+            mission_utils.delete_mission_collection(
+                flask_app_client, data_manager_1, mission_collection_guid
+            )
+        if mission_guid:
+            mission_utils.delete_mission(flask_app_client, data_manager_1, mission_guid)
+        tus_utils.cleanup_tus_dir(transaction_id)

--- a/tests/modules/missions/resources/utils.py
+++ b/tests/modules/missions/resources/utils.py
@@ -236,6 +236,25 @@ def create_mission_task(
     return response
 
 
+def update_mission_task(
+    flask_app_client, user, mission_task_guid, data, expected_status_code=200
+):
+    with flask_app_client.login(user, auth_scopes=('missions:write',)):
+        response = flask_app_client.post(
+            '%s%s' % (PATH_MISSION_TASKS, mission_task_guid),
+            content_type='application/json',
+            data=json.dumps(data),
+        )
+
+    if expected_status_code == 200:
+        test_utils.validate_dict_response(response, 200, {'guid', 'title'})
+    else:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+    return response
+
+
 def patch_mission_task(
     flask_app_client, mission_task_guid, user, data, expected_status_code=200
 ):

--- a/tests/modules/missions/resources/utils.py
+++ b/tests/modules/missions/resources/utils.py
@@ -218,18 +218,17 @@ def delete_mission_collection(
 
 
 def create_mission_task(
-    flask_app_client, user, title, mission_guid, expected_status_code=200
+    flask_app_client, user, mission_guid, data, expected_status_code=200
 ):
     with flask_app_client.login(user, auth_scopes=('missions:write',)):
         response = flask_app_client.post(
             PATH_MISSION_TASKS_FOR_MISSION % (mission_guid,),
             content_type='application/json',
-            data=json.dumps({'title': title}),
+            data=json.dumps(data),
         )
 
     if expected_status_code == 200:
         test_utils.validate_dict_response(response, 200, {'guid', 'title'})
-        assert response.json['title'] == title
     else:
         test_utils.validate_dict_response(
             response, expected_status_code, {'status', 'message'}

--- a/tests/tasks/test_utils.py
+++ b/tests/tasks/test_utils.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 from tasks.utils import download_file
 import os
-from os.path import abspath
+from os.path import abspath, exists
 import hashlib
 
 
 def test_download_file():
+    actual_local_filepath = None
     try:
         requested_local_filepath = 'icon.png'
         actual_local_filepath = download_file(
@@ -23,4 +24,6 @@ def test_download_file():
     except Exception as ex:
         raise ex
     finally:
-        os.remove(actual_local_filepath)
+        actual_local_filepath = abspath(actual_local_filepath)
+        if actual_local_filepath is not None and exists(actual_local_filepath):
+            os.remove(actual_local_filepath)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -432,6 +432,41 @@ def patch_replace_op(path, value, guid=None):
     return operation
 
 
+def set_union_op(path, value):
+    operation = {
+        'op': 'union',
+        'path': '/%s' % (path,),
+        'value': value,
+    }
+    return operation
+
+
+def set_intersection_op(path, value):
+    operation = {
+        'op': 'intersection',
+        'path': '/%s' % (path,),
+        'value': value,
+    }
+    return operation
+
+
+def set_difference_op(path, value):
+    operation = {
+        'op': 'difference',
+        'path': '/%s' % (path,),
+        'value': value,
+    }
+    return operation
+
+
+def set_or_op(*args, **kwargs):
+    return set_union_op(*args, **kwargs)
+
+
+def set_and_op(*args, **kwargs):
+    return set_intersection_op(*args, **kwargs)
+
+
 def all_count(db):
     from app.modules import is_module_enabled
 


### PR DESCRIPTION
## Pull Request Overview

- Add `flask_restx_patched.parameters.SetOperationsJSONParameters` to mirror the RFC 6902 PATCH operations list.  The set operation parameter specification will iterate through a list of set-based operations (union, intersection, difference, symmetric difference) to create a final set of objects for a given class.  This API parameter spec is used for `MissionTask` creation, were a list of set operations can be used to create the list of Assets to construct the MissionTask with.
- MissionTask names are no longer sequential counters and are based on Docker-like namings with the `randomname` Python package.  The global `USE_GLOBALLY_UNIQUE_MISSION_TASK_NAMES` can be used to enforce globally-unique task names or simply unique within each Mission (enforced by DB constraint)
- Fix the cascade delete for Missions, including the deletion of MissionCollections and MissionTasks.
- Add helper functions to the Mission and MissionCollection models to get the number of `Assets` and `Annotations`
- Update the Notification schema to migrate `sender_name = base_fields.Function(Notification.get_sender_name)` to an `@property` function for the Notification model.
- Update the Mission, MissionCollection, and MissionTask schemas to return more information
- Update the tests to support MissionTask creation with SetOperations and the tests utilities for set operation helper functions.
- Add tasks to the base Asset schema
- Remove old code that has been commented out
- Fix tests warnings on DB query with None primary key
- Linting and clean up updates
- bump MWS Frontend

---

### Supported Set Operations

- Union
  - `union`
  - `or`
  - `|`
- Intersection
  - `intersection`
  - `intersect`
  - `and`
  - `&`
- Difference 
  - `difference`
  - `diff`
  - `-`
  - `->`
- Mirrored Difference
  - `mirrored_difference`
  - `mirdiff`
  - `--`
  - `<-`
- Symmetric Difference
  - `symmetric_difference`
  - `symmetric`
  - `symdiff`
  - `sym`
  - `^`

### Example Set Operations list on MissionTask creation

``` JSON
[
    {
        "op": "union",
        "path": "/search",
        "value": "assets.confidence > 0.9"
    },
    {
        "op": "difference",
        "path": "/collections",
        "value": [
            "<mission_collection_guid>"
        ]
    },
    {
        "op": "difference",
        "path": "/assets",
        "value": [
            "<asset_guid>"
        ]
    },
    {
        "op": "or",
        "path": "/tasks",
        "value": [
            "<mission_task_guid_1>"
        ]
    },
    {
        "op": "^",
        "path": "/search",
        "value": [
            "assets.annotations > 0"
        ]
    },
    {
        "op": "diff",
        "path": "/tasks",
        "value": [
            "<mission_task_guid_2>"
        ]
    }
]
```