### PR TITLE
735 prevent admin user from escalating user to staff or internal

### DIFF
--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -921,5 +921,5 @@ class User(db.Model, FeatherModel, UserEDMMixin):
 USER_ROLES = [
     role.value[-1]
     for role in User.StaticRoles.__members__.values()
-    if role.value[-1] not in ('in_setup', 'in_reset')
+    if role.value[-1] not in ('in_setup', 'in_reset', 'is_internal', 'is_staff')
 ]

--- a/app/modules/users/parameters.py
+++ b/app/modules/users/parameters.py
@@ -145,8 +145,6 @@ class PatchUserDetailsParameters(PatchJSONParameters):
         User.notification_preferences.key,
         User.is_active.fget.__name__,
         User.is_exporter.fget.__name__,
-        User.is_internal.fget.__name__,
-        User.is_staff.fget.__name__,
         User.is_admin.fget.__name__,
         User.is_user_manager.fget.__name__,
         User.is_researcher.fget.__name__,
@@ -163,8 +161,6 @@ class PatchUserDetailsParameters(PatchJSONParameters):
     PRIVILEGED_FIELDS = (
         User.is_active.fget.__name__,
         User.is_exporter.fget.__name__,
-        User.is_internal.fget.__name__,
-        User.is_staff.fget.__name__,
         User.is_admin.fget.__name__,
         User.is_user_manager.fget.__name__,
         User.is_researcher.fget.__name__,

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -95,7 +95,14 @@ class Users(Resource):
                 code=HTTPStatus.FORBIDDEN,
                 message='You must be an admin, user manager or privileged to set roles for a new user',
             )
+
         for role in roles:
+            if role == 'is_staff' or role == 'is_internal':
+                abort(
+                    HTTPStatus.FORBIDDEN,
+                    f'Not permitted to set {role} role for a new user',
+                )
+
             args[role] = True
 
         if user is not None:

--- a/tests/modules/notifications/resources/test_notifications.py
+++ b/tests/modules/notifications/resources/test_notifications.py
@@ -198,7 +198,7 @@ def test_notification_preferences(
         ),
     ]
 
-    resp = user_utils.patch_user(flask_app_client, researcher_2, data)
+    resp = user_utils.patch_user(flask_app_client, researcher_2, researcher_2, data)
     assert set(resp.json['notification_preferences']) >= set(
         {'raw': {'restAPI': True, 'email': True}}
     )
@@ -220,7 +220,7 @@ def test_notification_preferences(
             'notification_preferences', {'all': {'restAPI': False, 'email': False}}
         )
     ]
-    user_utils.patch_user(flask_app_client, researcher_2, data)
+    user_utils.patch_user(flask_app_client, researcher_2, researcher_2, data)
     researcher_2_notifs = notif_utils.read_all_notifications(
         flask_app_client, researcher_2
     )
@@ -239,7 +239,7 @@ def test_notification_preferences(
             'notification_preferences', {'all': {'restAPI': True, 'email': False}}
         ),
     ]
-    user_utils.patch_user(flask_app_client, researcher_2, data)
+    user_utils.patch_user(flask_app_client, researcher_2, researcher_2, data)
     researcher_2_notifs = notif_utils.read_all_notifications(
         flask_app_client, researcher_2
     )

--- a/tests/modules/users/resources/test_signup.py
+++ b/tests/modules/users/resources/test_signup.py
@@ -228,12 +228,24 @@ def test_new_user_creation_roles_admin(flask_app_client, admin_user, db):
             must_succeed=False,
         )
 
+    valid_roles = (
+        'is_interpreter, is_data_manager, is_user_manager, '
+        'is_contributor, is_researcher, is_exporter, is_admin, is_active, in_alpha, in_beta'
+    )
     assert response.status_code == 422
     assert response.content_type == 'application/json'
     assert response.json == {
         'status': 422,
-        'message': 'invalid roles: is_researcher2.  Valid roles are is_interpreter, is_data_manager, is_user_manager, is_contributor, is_researcher, is_exporter, is_internal, is_admin, is_staff, is_active, in_alpha, in_beta',
+        'message': f'invalid roles: is_researcher2.  Valid roles are {valid_roles}',
     }
+
+    data = {
+        'email': 'user1@localhost',
+        'password': 'password',
+        'roles': ['in_alpha', 'is_admin', 'is_researcher', 'is_staff'],
+    }
+    error = f'invalid roles: is_staff.  Valid roles are {valid_roles}'
+    user_utils.create_user(flask_app_client, admin_user, data, 422, error)
 
     with flask_app_client.login(admin_user):
         response = create_new_user(

--- a/tests/modules/users/resources/utils.py
+++ b/tests/modules/users/resources/utils.py
@@ -49,14 +49,15 @@ def read_user_path(flask_app_client, user, sub_path, expected_status_code=200):
 
 def patch_user(
     flask_app_client,
-    user,
+    running_user,
+    user_modified,
     data,
     expected_status_code=200,
     expected_error='',
 ):
-    with flask_app_client.login(user, auth_scopes=('users:write',)):
+    with flask_app_client.login(running_user, auth_scopes=('users:write',)):
         response = flask_app_client.patch(
-            '%s%s' % (PATH, user.guid),
+            '%s%s' % (PATH, user_modified.guid),
             content_type='application/json',
             data=json.dumps(data),
         )


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Admin user can no longer create staff or internal user or promote existing user to staff or internal
- tweacked user patch test util to separate out the user who is running the operation from the user it's being done to

---
