### PR TITLE
Small adjustments for debugging sage detection failure

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -107,12 +107,12 @@ jobs:
       - name: Show acm logs if failed
         if: failure()
         run: |
-          docker-compose logs acm
+          docker-compose logs --no-color acm
 
       - name: Show houston logs if failed
         if: failure()
         run: |
-          docker-compose logs houston
+          docker-compose logs --no-color houston | sed -e 's/\x1b\[[0-9;]*m//g' -e 's/\x1b\[[0-9;]*m//g' -e 's/\x1b\]8;\(id=[0-9]*\)\?;//g' -e 's/\x1b\\//g'
 
       - name: Upload codex.html and codex.png if failed
         if: failure()

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -572,7 +572,9 @@ class AssetGroupSighting(db.Model, HoustonModel):
 
         job = self.jobs.get(str(job_id))
         if job is None:
-            raise HoustonException(log, f'job_id {job_id} not found')
+            raise HoustonException(
+                log, f'job_id {job_id} not found, self.jobs={self.jobs}'
+            )
 
         status = response.get('status')
         if not status:


### PR DESCRIPTION
- Add jobs to exception message when job id returned by sage not found

  When acm posted to
  `/api/v1/asset_groups/sighting/73073790-d50a-4ec3-8423-ca3fb77e896d/sage_detected/cfc78415-f70e-4d7b-b647-0d3026165418`
  there's a houston exception:
  
  ```
  HoustonException: job_id cfc78415-f70e-4d7b-b647-0d3026165418 not found
  ```
  
  Even though the asset group sighting json contains the job id:
  
  ```
  {'asset_group_guid': '9255a0a8-5d47-4cbb-9eab-70f7e157c1f9',
   'assets': [{'annotations': [],
               'created': '2022-02-10T02:30:37.579296+00:00',
               'dimensions': {'height': 664, 'width': 1000},
               'filename': 'zebra.jpg',
               'guid': '4562023a-33f8-4f48-b287-302aaf596eb0',
               'src': '/api/v1/assets/src/4562023a-33f8-4f48-b287-302aaf596eb0',
               'updated': '2022-02-10T02:30:37.579350+00:00'}],
   'completion': 0,
   'config': {'assetReferences': ['zebra.jpg'],
              'encounters': [{'guid': '118eb634-b9a2-4c2c-8a62-410652b0887b'}],
              'idConfigs': [{'algorithms': ['hotspotter_nosv'],
                             'matchingSetDataOwners': 'all'}],
              'locationId': 'Tiddleywink',
              'time': '2000-01-01T01:01:01+00:00',
              'timeSpecificity': 'time'},
   'creator': {'full_name': 'Test admin',
               'guid': '03b86a93-3112-4507-8b60-659705509469',
               'profile_fileupload': None},
   'curation_start_time': None,
   'detection_start_time': '2022-02-10T02:30:37.671355Z',
   'guid': '73073790-d50a-4ec3-8423-ca3fb77e896d',
   'jobs': [{'active': True,
             'asset_ids': ['4562023a-33f8-4f48-b287-302aaf596eb0'],
             'job_id': 'cfc78415-f70e-4d7b-b647-0d3026165418',
             'model': 'african_terrestrial',
             'start': '2022-02-10T02:30:47+00:00'}],
   'sighting_guid': None,
   'stage': 'detection'}
  ```
  
  So we should probably print out what `self.jobs` is

- Remove color from houston and acm logs when integration tests fail

  It's hard to look at the raw logs when there's lots of control
  characters, for example:
  
  ```
  2022-02-10T02:42:46.1310636Z ^[[36mhouston_1        |^[[0m ^[[37m           ^[[0m         ^[[31m│^[[0m ^[[33m│^[[0m      job = ^[[94mNone^[[0m                                                                                                                                     ^[[33m│^[[0m         ^[[31m│^[[0m ^[[2m                ^[[0m
  2022-02-10T02:42:46.1391610Z ^[[36mhouston_1        |^[[0m ^[[37m           ^[[0m         ^[[31m│^[[0m ^[[33m│^[[0m   job_id = ^[[1;35mUUID^[[0m^[[1m(^[[0m^[[33m'64210885-f576-4a0c-80fe-9e78a5bc034b'^[[0m^[[1m)^[[0m                                                                                             ^[[33m│^[[0m         ^[[31m│^[[0m ^[[2m                ^[[0m
  2022-02-10T02:42:46.1392223Z ^[[36mhouston_1        |^[[0m ^[[37m           ^[[0m         ^[[31m│^[[0m ^[[33m│^[[0m response = ^[[1m{^[[0m                                                                                                                                        ^[[33m│^[[0m         ^[[31m│^[[0m ^[[2m                ^[[0m
  2022-02-10T02:42:46.1392952Z ^[[36mhouston_1        |^[[0m ^[[37m           ^[[0m         ^[[31m│^[[0m ^[[33m│^[[0m            ^[[2m│   ^[[0m^[[33m'jobid'^[[0m: ^[[33m'64210885-f576-4a0c-80fe-9e78a5bc034b'^[[0m,                                                                                     ^[[33m│^[[0m         ^[[31m│^[[0m ^[[2m                ^[[0m
  ```
