### PR TITLE
DEX-730: merge notifications need allow_multiple=True

### DIFF
--- a/app/modules/elasticsearch/tasks.py
+++ b/app/modules/elasticsearch/tasks.py
@@ -356,6 +356,8 @@ def combine_customfields(result):
         custom_fields = {}
         # [{"5fda2b91-d4aa-4f5e-9479-9845402a9386":"Giraffe"}]
         for field_value_dict in json.loads(result['custom_fields']):
+            if not field_value_dict or not isinstance(field_value_dict, dict):
+                continue
             for field, value in field_value_dict.items():
                 if field in custom_fields:
                     if not isinstance(custom_fields[field], list):

--- a/app/modules/notifications/models.py
+++ b/app/modules/notifications/models.py
@@ -151,6 +151,7 @@ NOTIFICATION_CONFIG = {
             'individual_list',
             'encounter_list',
         },
+        'allow_multiple': True,
     },
     NotificationType.individual_merge_complete: {
         'email_template_name': 'individual_merge_complete',
@@ -160,6 +161,7 @@ NOTIFICATION_CONFIG = {
             'individual_list',
             'encounter_list',
         },
+        'allow_multiple': True,
         'resolve_on_read': True,
     },
     NotificationType.raw: {


### PR DESCRIPTION
## Pull Request Overview

- Quick addition of a couple flags to allow users to have multiple notifications relating to merging
- Bonus bug fix