### PR TITLE
740 individual merge name

### DIFF
--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -131,6 +131,10 @@ class Individual(db.Model, FeatherModel):
     def get_names(self):
         return self.names
 
+    def get_primary_name(self):
+        # Placeholder, first created name to make sure it's always the same one
+        return self.names.query.order_by(Name.created).first() if self.names else None
+
     # should be only one of these
     def get_name_for_context(self, context):
         return Name.query.filter_by(individual_guid=self.guid, context=context).first()

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -132,8 +132,12 @@ class Individual(db.Model, FeatherModel):
         return self.names
 
     def get_primary_name(self):
-        # Placeholder, first created name to make sure it's always the same one
-        return self.names.query.order_by(Name.created).first() if self.names else None
+        if self.names:
+            # Placeholder, first created name to make sure it's always the same one
+            ordered_names = sorted(self.names, key=lambda name: name.created)
+            return ordered_names[0].value
+        else:
+            return None
 
     # should be only one of these
     def get_name_for_context(self, context):

--- a/app/modules/notifications/models.py
+++ b/app/modules/notifications/models.py
@@ -186,7 +186,8 @@ class NotificationBuilder(object):
     def set_individual_merge(self, individuals, encounters, request_data):
         self.data['individual_list'] = []
         for indiv in individuals:
-            self.data['individual_list'].append(indiv.guid)
+            ind_data = {'guid': indiv.guid, 'primaryName': indiv.get_primary_name()}
+            self.data['individual_list'].append(ind_data)
         self.data['encounter_list'] = []
         for enc in encounters:
             self.data['encounter_list'].append(enc.guid)

--- a/app/modules/notifications/models.py
+++ b/app/modules/notifications/models.py
@@ -301,10 +301,8 @@ class Notification(db.Model, HoustonModel):
 
         assert set(data.keys()) >= set(config['mandatory_fields'])
 
-        from app.modules.users.models import User
-
         sender_guid = None
-        if isinstance(builder.sender, User):
+        if builder.sender and not builder.sender.is_anonymous:
             sender_guid = builder.sender.guid
 
         # prevent creation of a new notification if there is already an unread one

--- a/tests/modules/individuals/resources/test_merge.py
+++ b/tests/modules/individuals/resources/test_merge.py
@@ -226,6 +226,9 @@ def test_get_data_and_voting(
             'blocking_encounters',
         },
     )
+    # from tests.modules.notifications.resources import utils as notif_utils
+    # res1_notifs = notif_utils.read_all_notifications(flask_app_client, researcher_1)
+    # breakpoint()
     assert response['merge_request']
     assert response['blocking_encounters'] == [encounter1_id]
     request_id = response.get('request_id')

--- a/tests/modules/individuals/resources/test_merge.py
+++ b/tests/modules/individuals/resources/test_merge.py
@@ -187,11 +187,14 @@ def test_get_data_and_voting(
     )
 
     # now we need real data
+    ind1_name = 'Archibald'
+    ind1_data = {'names': [{'context': 'Top', 'value': ind1_name}]}
     individual1_uuids = individual_utils.create_individual_and_sighting(
         flask_app_client,
         researcher_1,
         request,
         test_root,
+        individual_data=ind1_data
     )
     # Second one owned by different researcher
     individual2_uuids = individual_utils.create_individual_and_sighting(
@@ -212,6 +215,9 @@ def test_get_data_and_voting(
     #    )
     # )
 
+    from tests.modules.notifications.resources import utils as notif_utils
+    notif_utils.mark_all_notifications_as_read(flask_app_client, researcher_1)
+
     # this tests as researcher_2, which should trigger a merge-request (owns just 1 encounter)
     data_in = [individual2_id]
     response = individual_utils.merge_individuals(
@@ -226,13 +232,24 @@ def test_get_data_and_voting(
             'blocking_encounters',
         },
     )
-    # from tests.modules.notifications.resources import utils as notif_utils
-    # res1_notifs = notif_utils.read_all_notifications(flask_app_client, researcher_1)
-    # breakpoint()
+
     assert response['merge_request']
     assert response['blocking_encounters'] == [encounter1_id]
     request_id = response.get('request_id')
     assert request_id
+
+    # Researcher 1 should have been notified
+    from tests.modules.notifications.resources import utils as notif_utils
+    res1_notifs = notif_utils.read_all_notifications(flask_app_client, researcher_1)
+    assert len(res1_notifs.json) == 1
+    notif_message = res1_notifs.json[0]
+    assert str(researcher_2.guid) == notif_message['sender_guid']
+    assert 'individual_merge_request' == notif_message['message_type']
+    assert len(notif_message['message_values']['individual_list']) == 1
+    individual_notif = notif_message['message_values']['individual_list'][0]
+    assert individual_notif['guid'] == individual1_id
+    assert individual_notif['primaryName'] == ind1_name
+
     # we should have a valid merge request now to test against
     #   also should have 1 auto-vote by researcher_2
     voters = IndividualMergeRequestVote.get_voters(request_id)


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Notification requests include the name of the individual
- Bug fixed in notificatioon code. Sender now being populated

---

**REST API Updates**

The user notification for the merge request (and complete) will now look like this

```
[
    {
        "created": "2022-02-11T09:22:53.421836+00:00",
        "guid": "be45b47a-9a07-43e4-83e3-eac79a95290a",
        "is_read": false,
        "message_type": "individual_merge_request",
        "message_values": {
            "encounter_list": [
                "49a66c9b-5fd3-4ff9-a0c4-17de9c796847"
            ],
            "individual_list": [
                {
                    "guid": "c8e7641a-7391-4757-bfff-33d065ab2b9f",
                    "primaryName": "Archibald"
                }
            ],
            "request_id": "4ef7b038-e2fe-44c0-a78a-6622f205252b"
        },
        "sender_guid": "82a8fddd-0ed6-4fac-89ad-1d259bf2398c",
        "sender_name": "First Middle Last"
    }
]

```

