### PR TITLE
732 notif collab resolve

### DIFF
--- a/app/modules/collaborations/models.py
+++ b/app/modules/collaborations/models.py
@@ -102,7 +102,7 @@ class Collaboration(db.Model, HoustonModel):
         db.GUID, db.ForeignKey('notification.guid'), nullable=True
     )
 
-    def __init__(self, members, initiator_user, **kwargs):
+    def __init__(self, members, initiator_user, notify_users=True, **kwargs):
 
         num_users = len(members)
         if num_users != 2:
@@ -140,7 +140,11 @@ class Collaboration(db.Model, HoustonModel):
             else:
                 collab_user_assoc.read_approval_state = CollaborationUserState.PENDING
 
+        if notify_users and not manager_created:
+            self.notify_pending_users()
+
         if manager_created:
+
             # User manager created collaboration, store who the creator was
             collab_creator = CollaborationUserAssociations(
                 collaboration=self, user=initiator_user
@@ -149,13 +153,15 @@ class Collaboration(db.Model, HoustonModel):
 
             collab_creator.read_approval_state = CollaborationUserState.CREATOR
             collab_creator.edit_approval_state = CollaborationUserState.CREATOR
-            for user in members:
-                user_assoc = self._get_association_for_user(user.guid)
-                self._notify_user(
-                    collab_creator, user_assoc, NotificationType.collab_manager_create
-                )
+            if notify_users:
+                for user in members:
+                    user_assoc = self._get_association_for_user(user.guid)
+                    self._notify_user(
+                        collab_creator, user_assoc, NotificationType.collab_manager_create
+                    )
             with db.session.begin(subtransactions=True):
                 db.session.add(collab_creator)
+
 
     def _get_association_for_user(self, user_guid):
         assoc = None
@@ -233,8 +239,7 @@ class Collaboration(db.Model, HoustonModel):
         builder.set_collaboration(self)
         notif = Notification.create(notification_type, receiving_user_assoc.user, builder)
 
-        # in these notification states, every notification is considered to have been read/resolved
-        # if the state is just .collab_approved, edit might be pending so it isn't fully resolved
+        # in these states, every notification is considered to have been read/resolved
         fully_resolved_notification_states = {
             NotificationType.collab_edit_approved,
             NotificationType.collab_edit_revoke,
@@ -242,22 +247,23 @@ class Collaboration(db.Model, HoustonModel):
         }
 
         if notification_type is NotificationType.collab_request:
-            self.read_req_notification_guuid = notif.guid
+            self.init_req_notification_guuid = notif.guid
         elif notification_type is NotificationType.collab_edit_request:
             self.edit_req_notification_guuid = notif.guid
+
         # set necessary notification.is_resolved fields
         elif notification_type is NotificationType.collab_approved:
-            if self.read_req_notification_guuid:
-                self._resolve_notification(self, self.read_req_notification_guuid)
+            if self.init_req_notification_guuid:
+                self._resolve_notification(self.init_req_notification_guuid)
         elif notification_type in fully_resolved_notification_states:
-            if self.read_req_notification_guuid:
-                self._resolve_notification(self, self.read_req_notification_guuid)
+            if self.init_req_notification_guuid:
+                self._resolve_notification(self.init_req_notification_guuid)
             if self.edit_req_notification_guuid:
-                self._resolve_notification(self, self.edit_req_notification_guuid)
+                self._resolve_notification(self.edit_req_notification_guuid)
 
     def _resolve_notification(self, notification_guid):
         from app.modules.notifications.models import Notification
-        notification = Notification.query.get(notifaction_guid)
+        notification = Notification.query.get(notification_guid)
         notification.is_resolved = True
         with db.session.begin():
             db.session.merge(notification)

--- a/app/modules/collaborations/models.py
+++ b/app/modules/collaborations/models.py
@@ -93,13 +93,13 @@ class Collaboration(db.Model, HoustonModel):
         db.GUID, db.ForeignKey('user.guid'), index=True, nullable=False
     )
     init_req_notification_guuid = db.Column(
-        db.GUID, db.ForeignKey('notification.guid'), primary_key=True
+        db.GUID, db.ForeignKey('notification.guid'), nullable=True
     )
     edit_initiator_guid = db.Column(
         db.GUID, db.ForeignKey('user.guid'), index=True, nullable=True
     )
     edit_req_notification_guuid = db.Column(
-        db.GUID, db.ForeignKey('notification.guid'), primary_key=True
+        db.GUID, db.ForeignKey('notification.guid'), nullable=True
     )
 
     def __init__(self, members, initiator_user, **kwargs):

--- a/app/modules/collaborations/models.py
+++ b/app/modules/collaborations/models.py
@@ -162,7 +162,6 @@ class Collaboration(db.Model, HoustonModel):
             with db.session.begin(subtransactions=True):
                 db.session.add(collab_creator)
 
-
     def _get_association_for_user(self, user_guid):
         assoc = None
         for association in self.collaboration_user_associations:
@@ -233,7 +232,11 @@ class Collaboration(db.Model, HoustonModel):
                     )
 
     def _notify_user(self, sending_user_assoc, receiving_user_assoc, notification_type):
-        from app.modules.notifications.models import Notification, NotificationBuilder, NotificationType
+        from app.modules.notifications.models import (
+            Notification,
+            NotificationBuilder,
+            NotificationType,
+        )
 
         builder = NotificationBuilder(sending_user_assoc.user)
         builder.set_collaboration(self)
@@ -263,6 +266,7 @@ class Collaboration(db.Model, HoustonModel):
 
     def _resolve_notification(self, notification_guid):
         from app.modules.notifications.models import Notification
+
         notification = Notification.query.get(notification_guid)
         notification.is_resolved = True
         with db.session.begin():


### PR DESCRIPTION
Collaborations now track two notification guids, one for the initial collaboration request and one for a possible edit request. These notifications are marked as resolved when either are approved. This behavior is tested in the notification PATCH which was already testing collaboration notification reading.

To facilitate this tracking Collab.__init__ will send the initial notification by default unless you pass in `notify_users=False` to the constructor. This is new behavior, previously the init notification had to be manually sent. To keep old notification tests intact (these tests manually created Collaborations and Notifications) some of those tests have been modified to include that notify_users=False flag on their collabs. 