### PR TITLE
733: Merge request notification resolution

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -91,7 +91,7 @@ jobs:
         if: matrix.app-context == 'codex'
         run: |
           set -ex
-          docker-compose up -d db redis elasticsearch acm edm houston
+          docker-compose up -d db redis elasticsearch acm edm houston celery_worker
 
       - name: Check docker-compose status
         run: |

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -477,7 +477,6 @@ class Individual(db.Model, FeatherModel):
     # scrubs notifications etc, once a merge has completed
     @classmethod
     def merge_request_cleanup(cls, req_id):
-        print(f'merge_request_cleanup called on {req_id}')
         IndividualMergeRequestVote.resolve_sent_notifications(req_id)
         log.debug(
             f'[{req_id}] merge_request_cleanup (notifications, etc) not yet fully implemented'

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ single-quotes = true
 
 [tool:pytest]
 minversion = 5.4
-addopts = -v -p no:doctest --xdoctest --xdoctest-style=google --random-order --random-order-bucket=global --cov=./ --cov-report html -m "not separate"
+addopts = -v -p no:doctest --xdoctest --xdoctest-style=google --random-order --random-order-bucket=global --cov=./ --cov-report html -m "not separate" -rs
 testpaths =
     app
     tests

--- a/tests/modules/individuals/resources/test_merge.py
+++ b/tests/modules/individuals/resources/test_merge.py
@@ -191,11 +191,7 @@ def test_get_data_and_voting(
     ind1_name = 'Archibald'
     ind1_data = {'names': [{'context': 'Top', 'value': ind1_name}]}
     individual1_uuids = individual_utils.create_individual_and_sighting(
-        flask_app_client,
-        researcher_1,
-        request,
-        test_root,
-        individual_data=ind1_data
+        flask_app_client, researcher_1, request, test_root, individual_data=ind1_data
     )
     # Second one owned by different researcher
     individual2_uuids = individual_utils.create_individual_and_sighting(
@@ -217,6 +213,7 @@ def test_get_data_and_voting(
     # )
 
     from tests.modules.notifications.resources import utils as notif_utils
+
     notif_utils.mark_all_notifications_as_read(flask_app_client, researcher_1)
 
     # this tests as researcher_2, which should trigger a merge-request (owns just 1 encounter)
@@ -241,6 +238,7 @@ def test_get_data_and_voting(
 
     # Researcher 1 should have been notified
     from tests.modules.notifications.resources import utils as notif_utils
+
     # to check that reading does not resolve the merge request notif
     notif_utils.mark_all_notifications_as_read(flask_app_client, researcher_1)
     res1_notifs = notif_utils.read_all_notifications(flask_app_client, researcher_1)

--- a/tests/modules/individuals/resources/test_merge.py
+++ b/tests/modules/individuals/resources/test_merge.py
@@ -161,6 +161,7 @@ def test_get_data_and_voting(
     test_root,
 ):
     from app.modules.individuals.models import Individual, IndividualMergeRequestVote
+    from app.modules.notifications.models import NotificationType
 
     bad_id = '00000000-0000-0000-0000-000000002170'
     # first anon permission check (401)
@@ -240,9 +241,13 @@ def test_get_data_and_voting(
 
     # Researcher 1 should have been notified
     from tests.modules.notifications.resources import utils as notif_utils
+    # to check that reading does not resolve the merge request notif
+    notif_utils.mark_all_notifications_as_read(flask_app_client, researcher_1)
     res1_notifs = notif_utils.read_all_notifications(flask_app_client, researcher_1)
     assert len(res1_notifs.json) == 1
     notif_message = res1_notifs.json[0]
+    assert notif_message['is_read']
+    assert not notif_message['is_resolved']
     assert str(researcher_2.guid) == notif_message['sender_guid']
     assert 'individual_merge_request' == notif_message['message_type']
     assert len(notif_message['message_values']['individual_list']) == 1
@@ -307,4 +312,26 @@ def test_get_data_and_voting(
     voters = IndividualMergeRequestVote.get_voters(request_id)
     assert len(voters) == 2
     assert set(voters) == set([researcher_1, researcher_2])
+
+    # test the is_resolved field on merge notifications
+    res1_notifs = notif_utils.read_all_notifications(flask_app_client, researcher_1)
+    assert len(res1_notifs.json) == 2
+    merge_req_notif = notif_utils.filter_notif_type(
+        res1_notifs.json, NotificationType.individual_merge_request
+    )[0]
+    merge_approved_notif = notif_utils.filter_notif_type(
+        res1_notifs.json, NotificationType.individual_merge_complete
+    )[0]
+    # request is resolved now that the merge has occurred
+    assert merge_req_notif.get('is_resolved')
+    assert not merge_approved_notif.get('is_read')
+    assert not merge_approved_notif.get('is_resolved')
+    notif_utils.mark_all_notifications_as_read(flask_app_client, researcher_1)
+    res1_notifs = notif_utils.read_all_notifications(flask_app_client, researcher_1)
+    merge_approved_notif = notif_utils.filter_notif_type(
+        res1_notifs.json, NotificationType.individual_merge_complete
+    )[0]
+    assert merge_approved_notif.get('is_read')
+    assert merge_approved_notif.get('is_resolved')
+
     IndividualMergeRequestVote.query.delete()

--- a/tests/modules/notifications/resources/utils.py
+++ b/tests/modules/notifications/resources/utils.py
@@ -103,6 +103,13 @@ def read_all_notifications(flask_app_client, user, expected_status_code=200):
     )
 
 
+def filter_notif_type(list_of_notif_dicts, notification_type):
+    return [
+        notif for notif in list_of_notif_dicts
+        if notif['message_type'] == notification_type
+    ]
+
+
 def read_all_unread_notifications(flask_app_client, user, expected_status_code=200):
     return test_utils.get_list_via_flask(
         flask_app_client,

--- a/tests/modules/notifications/resources/utils.py
+++ b/tests/modules/notifications/resources/utils.py
@@ -105,7 +105,8 @@ def read_all_notifications(flask_app_client, user, expected_status_code=200):
 
 def filter_notif_type(list_of_notif_dicts, notification_type):
     return [
-        notif for notif in list_of_notif_dicts
+        notif
+        for notif in list_of_notif_dicts
         if notif['message_type'] == notification_type
     ]
 


### PR DESCRIPTION
Pretty simple PR. Sets any merge request notifications to `is_resolved=True` when that request is approved/denied. Implemented via the handy pre-existing method `merge_request_cleanup` and a new class method on IndividualMergeRequestVote. Test coverage handles both merge requests and merge complete notifications.

No database or API changes, just an iteration over pending merge request notifications whenever one is resolved (which shouldn't be terribly often). That iteration happens because the data we want to filter on notification objects is inside the `message_values` dict.
