### PR TITLE
Downgrade MarkupSafe<2.1.0 in app/requirements.txt

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -30,6 +30,7 @@ gumby @ git+https://github.com/WildMeOrg/gumby.git
 
 jsonschema==3.2.0
 
+MarkupSafe<2.1.0
 marshmallow>=2.13.5,<3
 marshmallow-sqlalchemy>=0.12,<0.13
 


### PR DESCRIPTION
MarkupSafe 2.1.0 removed a deprecated function `soft_unicode` which
jinja2 imports, causing the houston service to not be able to start up.

```
Traceback (most recent call last):
  File "/usr/local/bin/invoke", line 8, in <module>
    sys.exit(program.run())
  File "/usr/local/lib/python3.9/site-packages/invoke/program.py", line 373, in run
    self.parse_collection()
  File "/usr/local/lib/python3.9/site-packages/invoke/program.py", line 465, in parse_collection
    self.load_collection()
  File "/usr/local/lib/python3.9/site-packages/invoke/program.py", line 696, in load_collection
    module, parent = loader.load(coll_name)
  File "/usr/local/lib/python3.9/site-packages/invoke/loader.py", line 76, in load
    module = imp.load_module(name, fd, path, desc)
  File "/usr/local/lib/python3.9/imp.py", line 244, in load_module
    return load_package(name, filename)
  File "/usr/local/lib/python3.9/imp.py", line 216, in load_package
    return _load(spec)
  File "<frozen importlib._bootstrap>", line 711, in _load
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 790, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/code/tasks/__init__.py", line 67, in <module>
    from tasks import app as app_tasks  # NOQA
  File "/code/tasks/app/__init__.py", line 10, in <module>
    from tasks.app import (
  File "/code/tasks/app/db.py", line 15, in <module>
    from flask import current_app
  File "/usr/local/lib/python3.9/site-packages/flask/__init__.py", line 14, in <module>
    from jinja2 import escape
  File "/usr/local/lib/python3.9/site-packages/jinja2/__init__.py", line 12, in <module>
    from .environment import Environment
  File "/usr/local/lib/python3.9/site-packages/jinja2/environment.py", line 25, in <module>
    from .defaults import BLOCK_END_STRING
  File "/usr/local/lib/python3.9/site-packages/jinja2/defaults.py", line 3, in <module>
    from .filters import FILTERS as DEFAULT_FILTERS  # noqa: F401
  File "/usr/local/lib/python3.9/site-packages/jinja2/filters.py", line 13, in <module>
    from markupsafe import soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/local/lib/python3.9/site-packages/markupsafe/__init__.py)
```

