### PR TITLE
Mount all of the repo into the dev-frontend service

### DIFF
--- a/.dockerfiles/dev-frontend/docker-entrypoint.sh
+++ b/.dockerfiles/dev-frontend/docker-entrypoint.sh
@@ -2,6 +2,7 @@
 
 set -ex
 
+cd /code/_frontend.${HOUSTON_APP_CONTEXT}
 npm install --legacy-peer-deps
 export NODE_ENV=development
 npx webpack serve --config ./config/webpack/webpack.common.js --host $HOST --public ${HOST}:${PORT} --env=houston=relative

--- a/.dockerfiles/dev-frontend/docker-entrypoint.sh
+++ b/.dockerfiles/dev-frontend/docker-entrypoint.sh
@@ -2,7 +2,11 @@
 
 set -ex
 
-cd /code/_frontend.${HOUSTON_APP_CONTEXT}
+# If the submodule directory name exists, move to it.
+# Otherwise assume the frontend is the current working directory
+if [ -d "_frontend.${HOUSTON_APP_CONTEXT}" ]; then
+    cd /code/_frontend.${HOUSTON_APP_CONTEXT}
+fi
 npm install --legacy-peer-deps
 export NODE_ENV=development
 npx webpack serve --config ./config/webpack/webpack.common.js --host $HOST --public ${HOST}:${PORT} --env=houston=relative

--- a/docker-compose.codex.yml
+++ b/docker-compose.codex.yml
@@ -225,10 +225,11 @@ services:
       retries: 60
     volumes:
       - .dockerfiles/dev-frontend/docker-entrypoint.sh:/docker-entrypoint.sh
-      - ./_frontend.codex:/code
+      - ./:/code
     networks:
       - intranet
     environment:
+      HOUSTON_APP_CONTEXT: codex
       # See port served by 'www' component (i.e. the reverse proxy)
       HOST: "0.0.0.0"
       PORT: "84"

--- a/docker-compose.mws.yml
+++ b/docker-compose.mws.yml
@@ -191,10 +191,11 @@ services:
       retries: 60
     volumes:
       - .dockerfiles/dev-frontend/docker-entrypoint.sh:/docker-entrypoint.sh
-      - ./_frontend.mws:/code
+      - ./:/code
     networks:
       - intranet
     environment:
+      HOUSTON_APP_CONTEXT: mws
       # See port served by 'www' component (i.e. the reverse proxy)
       HOST: "0.0.0.0"
       PORT: "84"


### PR DESCRIPTION
In order to get the git information from the frontend code (e.g. run
`git` commands in the `_frontend.codex` directory) the parent project
must be accessible. This is only a problem because the `_frontend.*`
repos are submodules; and thus not actually git repos
themselves (i.e. it's complicated). This solves `fatal: No names
found, cannot describe anything.` when running git commands within the
submodule.

This change is being made, because additions are being made to the
frontend that require git info. The frontend build code discovers its
own version information for display in the server-status page. This
fix is required to enable that feature.

No developer changes required.
