### PR TITLE
adds social groups to DetailedIndividualSchema via DetailedSocialGrou…

### DIFF
--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -836,3 +836,15 @@ class Individual(db.Model, FeatherModel):
                 found_edm.update(edm_schema.dump(encounter).data)
 
         return edm_json
+
+    def get_social_groups_json(self):
+        from app.modules.social_groups.schemas import DetailedSocialGroupSchema
+
+        social_groups = {
+            soc_group_memship.social_group for soc_group_memship in self.social_groups
+        }
+        social_group_schema = DetailedSocialGroupSchema()
+        social_groups = [
+            social_group_schema.dump(social_group).data for social_group in social_groups
+        ]
+        return social_groups

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -10,7 +10,6 @@ from flask_marshmallow import base_fields
 from .models import Individual
 
 from app.modules.names.schemas import DetailedNameSchema
-from app.modules.social_groups.schemas import DetailedSocialGroupMemberSchema
 
 
 class BaseIndividualSchema(ModelSchema):
@@ -43,10 +42,7 @@ class DetailedIndividualSchema(BaseIndividualSchema):
         attribute='names',
         many=True,
     )
-    social_groups = base_fields.Nested(
-        DetailedSocialGroupMemberSchema,
-        many=True,
-    )
+    social_groups = base_fields.Function(Individual.get_social_groups_json)
 
     class Meta(BaseIndividualSchema.Meta):
         fields = BaseIndividualSchema.Meta.fields + (

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -10,6 +10,7 @@ from flask_marshmallow import base_fields
 from .models import Individual
 
 from app.modules.names.schemas import DetailedNameSchema
+from app.modules.social_groups.schemas import DetailedSocialGroupMemberSchema
 
 
 class BaseIndividualSchema(ModelSchema):
@@ -42,6 +43,10 @@ class DetailedIndividualSchema(BaseIndividualSchema):
         attribute='names',
         many=True,
     )
+    social_groups = base_fields.Nested(
+        DetailedSocialGroupMemberSchema,
+        many=True,
+    )
 
     class Meta(BaseIndividualSchema.Meta):
         fields = BaseIndividualSchema.Meta.fields + (
@@ -49,6 +54,7 @@ class DetailedIndividualSchema(BaseIndividualSchema):
             Individual.updated.key,
             'featuredAssetGuid',
             'names',
+            'social_groups',
         )
         dump_only = BaseIndividualSchema.Meta.dump_only + (
             Individual.created.key,

--- a/app/modules/social_groups/parameters.py
+++ b/app/modules/social_groups/parameters.py
@@ -13,8 +13,8 @@ from . import schemas
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
-class SocialGroupMembers(Parameters, schemas.BaseSocialGroupMemberSchema):
-    class Meta(schemas.BaseSocialGroupMemberSchema.Meta):
+class SocialGroupMembers(Parameters, schemas.SocialGroupMemberSchema):
+    class Meta(schemas.SocialGroupMemberSchema.Meta):
         pass
 
 

--- a/app/modules/social_groups/parameters.py
+++ b/app/modules/social_groups/parameters.py
@@ -13,8 +13,8 @@ from . import schemas
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
-class SocialGroupMembers(Parameters, schemas.SocialGroupMemberSchema):
-    class Meta(schemas.SocialGroupMemberSchema.Meta):
+class SocialGroupMembers(Parameters, schemas.BaseSocialGroupMemberSchema):
+    class Meta(schemas.BaseSocialGroupMemberSchema.Meta):
         pass
 
 

--- a/app/modules/social_groups/schemas.py
+++ b/app/modules/social_groups/schemas.py
@@ -10,16 +10,6 @@ from flask_restx_patched import ModelSchema
 from .models import SocialGroup, SocialGroupIndividualMembership
 
 
-class SocialGroupMemberSchema(ModelSchema):
-    """
-    Data for members in the the SocialGroup
-    """
-
-    class Meta:
-        model = SocialGroupIndividualMembership
-        fields = (SocialGroupIndividualMembership.roles.key,)
-
-
 class BaseSocialGroupSchema(ModelSchema):
     """
     Base SocialGroup schema exposes only the most general fields.
@@ -53,3 +43,31 @@ class DetailedSocialGroupSchema(BaseSocialGroupSchema):
             SocialGroup.updated.key,
             'members',
         )
+
+
+class BaseSocialGroupMemberSchema(ModelSchema):
+    """
+    Data for members in the the SocialGroup
+    """
+
+    class Meta:
+        model = SocialGroupIndividualMembership
+        fields = (SocialGroupIndividualMembership.roles.key,)
+        dump_only = (
+            SocialGroupIndividualMembership.created.key,
+            SocialGroupIndividualMembership.updated.key,
+        )
+
+
+class DetailedSocialGroupMemberSchema(ModelSchema):
+    """
+    Data for members in the the SocialGroup
+    """
+
+    social_group = base_fields.Nested(DetailedSocialGroupSchema)
+
+    class Meta:
+        model = SocialGroupIndividualMembership
+        fields = BaseSocialGroupMemberSchema.Meta.fields + ('social_group',)
+        # you can edit social groups through the social group api, not this one
+        dump_only = BaseSocialGroupMemberSchema.Meta.dump_only + ('social_group',)

--- a/app/modules/social_groups/schemas.py
+++ b/app/modules/social_groups/schemas.py
@@ -10,6 +10,20 @@ from flask_restx_patched import ModelSchema
 from .models import SocialGroup, SocialGroupIndividualMembership
 
 
+class SocialGroupMemberSchema(ModelSchema):
+    """
+    Data for members in the the SocialGroup
+    """
+
+    class Meta:
+        model = SocialGroupIndividualMembership
+        fields = (SocialGroupIndividualMembership.roles.key,)
+        dump_only = (
+            SocialGroupIndividualMembership.created.key,
+            SocialGroupIndividualMembership.updated.key,
+        )
+
+
 class BaseSocialGroupSchema(ModelSchema):
     """
     Base SocialGroup schema exposes only the most general fields.
@@ -43,31 +57,3 @@ class DetailedSocialGroupSchema(BaseSocialGroupSchema):
             SocialGroup.updated.key,
             'members',
         )
-
-
-class BaseSocialGroupMemberSchema(ModelSchema):
-    """
-    Data for members in the the SocialGroup
-    """
-
-    class Meta:
-        model = SocialGroupIndividualMembership
-        fields = (SocialGroupIndividualMembership.roles.key,)
-        dump_only = (
-            SocialGroupIndividualMembership.created.key,
-            SocialGroupIndividualMembership.updated.key,
-        )
-
-
-class DetailedSocialGroupMemberSchema(ModelSchema):
-    """
-    Data for members in the the SocialGroup
-    """
-
-    social_group = base_fields.Nested(DetailedSocialGroupSchema)
-
-    class Meta:
-        model = SocialGroupIndividualMembership
-        fields = BaseSocialGroupMemberSchema.Meta.fields + ('social_group',)
-        # you can edit social groups through the social group api, not this one
-        dump_only = BaseSocialGroupMemberSchema.Meta.dump_only + ('social_group',)

--- a/tests/modules/social_groups/resources/test_social_group.py
+++ b/tests/modules/social_groups/resources/test_social_group.py
@@ -105,6 +105,15 @@ def test_basic_operation(
     assert create_log['module_name'] == 'SocialGroup'
     assert create_log['user_email'] == researcher_1.email
 
+    # validate that the individual GET includes the social group
+    individual_as_res1_json = individual_utils.read_individual(
+        flask_app_client, researcher_1, individuals[0]['id']
+    ).json
+    assert len(individual_as_res1_json['social_groups']) == 1
+    ind_social_group = individual_as_res1_json['social_groups'][0]['social_group']
+    assert individuals[0]['id'] in ind_social_group['members']
+    assert data['name'] == ind_social_group['name']
+
 
 # Test invalid configuration options. The API is via site settings but the validation is in SocialGroup so
 # this is a social group test

--- a/tests/modules/social_groups/resources/test_social_group.py
+++ b/tests/modules/social_groups/resources/test_social_group.py
@@ -110,7 +110,7 @@ def test_basic_operation(
         flask_app_client, researcher_1, individuals[0]['id']
     ).json
     assert len(individual_as_res1_json['social_groups']) == 1
-    ind_social_group = individual_as_res1_json['social_groups'][0]['social_group']
+    ind_social_group = individual_as_res1_json['social_groups'][0]
     assert individuals[0]['id'] in ind_social_group['members']
     assert data['name'] == ind_social_group['name']
 


### PR DESCRIPTION
Making this a draft for easy reference:

The current social group on an individual (here individual d8bb82b9-186d-4863-b511-fd9a271be245) looks like this:

```
 'social_groups': [
   {'social_group': {
      'updated': '2022-02-23T17:41:38.790969+00:00',
      'created': '2022-02-23T17:41:38.790959+00:00',
      'name': 'Disreputable bunch of hooligans',
      'guid': 'f5c9155c-5b7f-448a-a05b-12ddf6226ee9',
      'members': {
         'd8bb82b9-186d-4863-b511-fd9a271be245': {'roles': ['Matriarch']},
         'b8222af7-da70-468b-a3f3-9b017593599e': {'roles': None},
         'cf2debb5-b336-417b-80f2-120578494ebd': {'roles': ['IrritatingGit']}
      }
   },
   'roles': ['Matriarch']}
],
```

I am debating if it's worth the effort to resolve this redundancy in the schema. Current state is because an individual isn't directly linked to a social group, but a list of SocialGroupMemberships, which list is called `social_groups`. So each item in that list now has it's own `social_group` field which contains the actual data we want.