### PR TITLE
676 social units on indiv get

### DIFF
--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -836,3 +836,15 @@ class Individual(db.Model, FeatherModel):
                 found_edm.update(edm_schema.dump(encounter).data)
 
         return edm_json
+
+    def get_social_groups_json(self):
+        from app.modules.social_groups.schemas import DetailedSocialGroupSchema
+
+        social_groups = {
+            soc_group_memship.social_group for soc_group_memship in self.social_groups
+        }
+        social_group_schema = DetailedSocialGroupSchema()
+        social_groups = [
+            social_group_schema.dump(social_group).data for social_group in social_groups
+        ]
+        return social_groups

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -11,6 +11,7 @@ from .models import Individual
 
 from app.modules.names.schemas import DetailedNameSchema
 from app.modules.encounters.schemas import DetailedEncounterSchema
+from app.modules.social_groups.schemas import DetailedSocialGroupMemberSchema
 
 
 class BaseIndividualSchema(ModelSchema):
@@ -43,6 +44,10 @@ class DetailedIndividualSchema(BaseIndividualSchema):
         attribute='names',
         many=True,
     )
+    social_groups = base_fields.Nested(
+        DetailedSocialGroupMemberSchema,
+        many=True,
+    )
 
     class Meta(BaseIndividualSchema.Meta):
         fields = BaseIndividualSchema.Meta.fields + (
@@ -50,6 +55,7 @@ class DetailedIndividualSchema(BaseIndividualSchema):
             Individual.updated.key,
             'featuredAssetGuid',
             'names',
+            'social_groups',
         )
         dump_only = BaseIndividualSchema.Meta.dump_only + (
             Individual.created.key,

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -11,7 +11,6 @@ from .models import Individual
 
 from app.modules.names.schemas import DetailedNameSchema
 from app.modules.encounters.schemas import DetailedEncounterSchema
-from app.modules.social_groups.schemas import DetailedSocialGroupMemberSchema
 
 
 class BaseIndividualSchema(ModelSchema):

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -44,10 +44,7 @@ class DetailedIndividualSchema(BaseIndividualSchema):
         attribute='names',
         many=True,
     )
-    social_groups = base_fields.Nested(
-        DetailedSocialGroupMemberSchema,
-        many=True,
-    )
+    social_groups = base_fields.Function(Individual.get_social_groups_json)
 
     class Meta(BaseIndividualSchema.Meta):
         fields = BaseIndividualSchema.Meta.fields + (

--- a/app/modules/social_groups/parameters.py
+++ b/app/modules/social_groups/parameters.py
@@ -13,8 +13,8 @@ from . import schemas
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
-class SocialGroupMembers(Parameters, schemas.BaseSocialGroupMemberSchema):
-    class Meta(schemas.BaseSocialGroupMemberSchema.Meta):
+class SocialGroupMembers(Parameters, schemas.SocialGroupMemberSchema):
+    class Meta(schemas.SocialGroupMemberSchema.Meta):
         pass
 
 

--- a/app/modules/social_groups/parameters.py
+++ b/app/modules/social_groups/parameters.py
@@ -13,8 +13,8 @@ from . import schemas
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
-class SocialGroupMembers(Parameters, schemas.SocialGroupMemberSchema):
-    class Meta(schemas.SocialGroupMemberSchema.Meta):
+class SocialGroupMembers(Parameters, schemas.BaseSocialGroupMemberSchema):
+    class Meta(schemas.BaseSocialGroupMemberSchema.Meta):
         pass
 
 

--- a/app/modules/social_groups/schemas.py
+++ b/app/modules/social_groups/schemas.py
@@ -10,16 +10,6 @@ from flask_restx_patched import ModelSchema
 from .models import SocialGroup, SocialGroupIndividualMembership
 
 
-class SocialGroupMemberSchema(ModelSchema):
-    """
-    Data for members in the the SocialGroup
-    """
-
-    class Meta:
-        model = SocialGroupIndividualMembership
-        fields = (SocialGroupIndividualMembership.roles.key,)
-
-
 class BaseSocialGroupSchema(ModelSchema):
     """
     Base SocialGroup schema exposes only the most general fields.
@@ -53,3 +43,31 @@ class DetailedSocialGroupSchema(BaseSocialGroupSchema):
             SocialGroup.updated.key,
             'members',
         )
+
+
+class BaseSocialGroupMemberSchema(ModelSchema):
+    """
+    Data for members in the the SocialGroup
+    """
+
+    class Meta:
+        model = SocialGroupIndividualMembership
+        fields = (SocialGroupIndividualMembership.roles.key,)
+        dump_only = (
+            SocialGroupIndividualMembership.created.key,
+            SocialGroupIndividualMembership.updated.key,
+        )
+
+
+class DetailedSocialGroupMemberSchema(ModelSchema):
+    """
+    Data for members in the the SocialGroup
+    """
+
+    social_group = base_fields.Nested(DetailedSocialGroupSchema)
+
+    class Meta:
+        model = SocialGroupIndividualMembership
+        fields = BaseSocialGroupMemberSchema.Meta.fields + ('social_group',)
+        # you can edit social groups through the social group api, not this one
+        dump_only = BaseSocialGroupMemberSchema.Meta.dump_only + ('social_group',)

--- a/app/modules/social_groups/schemas.py
+++ b/app/modules/social_groups/schemas.py
@@ -10,6 +10,20 @@ from flask_restx_patched import ModelSchema
 from .models import SocialGroup, SocialGroupIndividualMembership
 
 
+class SocialGroupMemberSchema(ModelSchema):
+    """
+    Data for members in the the SocialGroup
+    """
+
+    class Meta:
+        model = SocialGroupIndividualMembership
+        fields = (SocialGroupIndividualMembership.roles.key,)
+        dump_only = (
+            SocialGroupIndividualMembership.created.key,
+            SocialGroupIndividualMembership.updated.key,
+        )
+
+
 class BaseSocialGroupSchema(ModelSchema):
     """
     Base SocialGroup schema exposes only the most general fields.
@@ -43,31 +57,3 @@ class DetailedSocialGroupSchema(BaseSocialGroupSchema):
             SocialGroup.updated.key,
             'members',
         )
-
-
-class BaseSocialGroupMemberSchema(ModelSchema):
-    """
-    Data for members in the the SocialGroup
-    """
-
-    class Meta:
-        model = SocialGroupIndividualMembership
-        fields = (SocialGroupIndividualMembership.roles.key,)
-        dump_only = (
-            SocialGroupIndividualMembership.created.key,
-            SocialGroupIndividualMembership.updated.key,
-        )
-
-
-class DetailedSocialGroupMemberSchema(ModelSchema):
-    """
-    Data for members in the the SocialGroup
-    """
-
-    social_group = base_fields.Nested(DetailedSocialGroupSchema)
-
-    class Meta:
-        model = SocialGroupIndividualMembership
-        fields = BaseSocialGroupMemberSchema.Meta.fields + ('social_group',)
-        # you can edit social groups through the social group api, not this one
-        dump_only = BaseSocialGroupMemberSchema.Meta.dump_only + ('social_group',)

--- a/tests/modules/social_groups/resources/test_social_group.py
+++ b/tests/modules/social_groups/resources/test_social_group.py
@@ -105,6 +105,15 @@ def test_basic_operation(
     assert create_log['module_name'] == 'SocialGroup'
     assert create_log['user_email'] == researcher_1.email
 
+    # validate that the individual GET includes the social group
+    individual_as_res1_json = individual_utils.read_individual(
+        flask_app_client, researcher_1, individuals[0]['id']
+    ).json
+    assert len(individual_as_res1_json['social_groups']) == 1
+    ind_social_group = individual_as_res1_json['social_groups'][0]['social_group']
+    assert individuals[0]['id'] in ind_social_group['members']
+    assert data['name'] == ind_social_group['name']
+
 
 # Test invalid configuration options. The API is via site settings but the validation is in SocialGroup so
 # this is a social group test

--- a/tests/modules/social_groups/resources/test_social_group.py
+++ b/tests/modules/social_groups/resources/test_social_group.py
@@ -110,7 +110,7 @@ def test_basic_operation(
         flask_app_client, researcher_1, individuals[0]['id']
     ).json
     assert len(individual_as_res1_json['social_groups']) == 1
-    ind_social_group = individual_as_res1_json['social_groups'][0]['social_group']
+    ind_social_group = individual_as_res1_json['social_groups'][0]
     assert individuals[0]['id'] in ind_social_group['members']
     assert data['name'] == ind_social_group['name']
 


### PR DESCRIPTION
Includes social groups in the `DetailedIndividualSchema` which is used on the /individuals/<guid> endpoint.

This is done by a new individual method that returns a json/dict list of social groups, called in the individual schema, tested in the social_group tests.

A social group looks like this as part of the returned individual json (here it's individual `4a8d05eb-6b13-4c7c-8c95-d5ebd9a7fc38`):

```
'social_groups': [
  {
    'updated': '2022-02-23T18:32:16.219012+00:00',
    'created': '2022-02-23T18:32:16.218996+00:00',
    'members': {
      '4a8d05eb-6b13-4c7c-8c95-d5ebd9a7fc38': {'roles': ['Matriarch']},
      'c4e2c633-ad62-44e2-9cf7-7464b1a5ef6e': {'roles': None},
      'a45f599c-7e1b-4432-a9f4-61321ddba351': {'roles': ['IrritatingGit']}
    },
    'guid': '4cd0cd78-7d16-4b3d-bf81-276c741dd597',
    'name': 'Disreputable bunch of hooligans'
  }
]
```