### PR TITLE
Add default version if none exists in sighting model

### DIFF
--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -544,7 +544,7 @@ class Sighting(db.Model, FeatherModel):
                     log.info(f'houston Encounter {enc.guid} removed')
                     enc.delete_cascade()
                 else:
-                    if edm_map[str(enc.guid)]['version'] > enc.version:
+                    if edm_map[str(enc.guid)].get('version', 0) > enc.version:
                         log.debug(
                             f'houston Encounter {enc.guid} VERSION UPDATED {edm_map[str(enc.guid)]} > {enc.version}'
                         )


### PR DESCRIPTION
## Pull Request Overview

- Provides a default version of 0 in the event that edm_map[str(enc.guid)] doesn't get one. Fixes a 500 error the response of a sighting patch call.
- Discussed with JVO on 24 Feb., 2022