### PR TITLE
688 encassets on individual

### DIFF
--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -122,6 +122,7 @@ class Annotation(db.Model, HoustonModel):
         else:
             # Annotation created but not curated into an AGS
             from .schemas import DetailedAnnotationSchema
+
             schema = DetailedAnnotationSchema()
             return schema.dump(self).data
 
@@ -173,6 +174,12 @@ class Annotation(db.Model, HoustonModel):
         if self.encounter and self.encounter.individual:
             individual = self.encounter.individual
         return individual
+
+    def get_asset_src(self):
+        assset_src = None
+        if self.asset and self.asset.src:
+            assset_src = self.asset.src
+        return assset_src
 
     def delete(self):
         with db.session.begin(subtransactions=True):

--- a/app/modules/annotations/schemas.py
+++ b/app/modules/annotations/schemas.py
@@ -39,6 +39,7 @@ class DetailedAnnotationSchema(BaseAnnotationSchema):
         'BaseKeywordSchema',
         many=True,
     )
+    asset_src = base_fields.Function(Annotation.get_asset_src)
 
     class Meta(BaseAnnotationSchema.Meta):
         fields = BaseAnnotationSchema.Meta.fields + (
@@ -46,8 +47,10 @@ class DetailedAnnotationSchema(BaseAnnotationSchema):
             Annotation.updated.key,
             Annotation.bounds.key,
             'keywords',
+            'asset_src',
         )
         dump_only = BaseAnnotationSchema.Meta.dump_only + (
             Annotation.created.key,
             Annotation.updated.key,
+            'asset_src',
         )

--- a/app/modules/encounters/schemas.py
+++ b/app/modules/encounters/schemas.py
@@ -79,10 +79,12 @@ class AugmentedIndividualApiEncounterSchema(BaseEncounterSchema):
     owner = base_fields.Nested('PublicUserSchema', many=False)
 
     encounters = base_fields.Nested('AugmentedSightingApiEncounterSchema', many=True)
+    annotations = base_fields.Nested('DetailedAnnotationSchema', many=True)
 
     class Meta(BaseEncounterSchema.Meta):
         fields = BaseEncounterSchema.Meta.fields + (
             Encounter.sighting.key,
+            'annotations',
             'submitter',
             'owner',
             'hasView',

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -167,7 +167,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
                 'annotations': [
                     {
                         'asset_guid': assets[0]['guid'],
-                        'asset_src': annots_0['asset_src'],
+                        'asset_src': annots_0[0]['asset_src'],
                         'encounter_guid': None,
                         'guid': annots_0[0]['guid'],
                         'ia_class': 'zebra',

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -167,6 +167,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
                 'annotations': [
                     {
                         'asset_guid': assets[0]['guid'],
+                        'asset_src': annots_0['asset_src'],
                         'encounter_guid': None,
                         'guid': annots_0[0]['guid'],
                         'ia_class': 'zebra',

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -222,7 +222,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
                 'annotations': [
                     {
                         'asset_guid': assets[0]['guid'],
-                        'asset_src': annots[0]['asset_src'],
+                        'asset_src': annots_0[0]['asset_src'],
                         'encounter_guid': None,
                         'guid': annots_0[0]['guid'],
                         'ia_class': 'zebra',

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -109,7 +109,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
                         'updated': annots_0[0]['updated'],
                         'keywords': [],
                         'asset_guid': assets[0]['guid'],
-                        'asset_src': annots_0['asset_src'],
+                        'asset_src': annots_0[0]['asset_src'],
                         'encounter_guid': None,
                         'ia_class': 'zebra',
                         'viewpoint': 'right',

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -221,6 +221,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
                 'annotations': [
                     {
                         'asset_guid': assets[0]['guid'],
+                        'asset_src': annots[0]['asset_src'],
                         'encounter_guid': None,
                         'guid': annots_0[0]['guid'],
                         'ia_class': 'zebra',

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -67,6 +67,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
             'uploadType': 'form',
         },
     )
+
     assert response.status_code == 200
     asset_group_guid = response.json()['guid']
     ags_guids = [s['guid'] for s in response.json()['asset_group_sightings']]

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -109,6 +109,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
                         'updated': annots_0[0]['updated'],
                         'keywords': [],
                         'asset_guid': assets[0]['guid'],
+                        'asset_src': annots_0['asset_src'],
                         'encounter_guid': None,
                         'ia_class': 'zebra',
                         'viewpoint': 'right',


### PR DESCRIPTION
Adds annotations to the `AugmentedIndividualApiEncounterSchema`. This schema is meant for the frontend, and the frontend wants to show some pictures on the individual page.

Additionally, adds an `asset_src` field to the `DetailedAnnotationSchema`. This field is basically redundant to the `asset_guid`, but it saves the frontend a path-construction step when displaying the asset.