### PR TITLE
Update email templates

### DIFF
--- a/app/extensions/email/__init__.py
+++ b/app/extensions/email/__init__.py
@@ -131,6 +131,7 @@ class Email(Message):
             'site_url_prefix': site_url_prefix(),
             'year': now.year,
             'transaction_id': self._transaction_id,
+            # some of these are leftover from PR512 and may need cleanup later
             'header_image_url': SiteSetting.get_value('email_header_image_url'),
             'h1': SiteSetting.get_value('email_title_greeting'),
             'secondary_title': SiteSetting.get_value('email_secondary_title'),

--- a/app/modules/collaborations/models.py
+++ b/app/modules/collaborations/models.py
@@ -186,11 +186,10 @@ class Collaboration(db.Model, HoustonModel):
     # note: returns manager *of this collaboration* (if applicable).  this user
     #   may no longer be an active manager (role).
     def get_manager(self):
-        if self.initiator_guid in self.user_guids():
-            return None
-        from app.modules.users.models import User
-
-        return User.query.get(self.initiator_guid)
+        for association in self.collaboration_user_associations:
+            if association.read_approval_state == CollaborationUserState.CREATOR:
+                return association.user
+        return None
 
     def get_users(self):
         users = []

--- a/app/modules/collaborations/models.py
+++ b/app/modules/collaborations/models.py
@@ -183,6 +183,15 @@ class Collaboration(db.Model, HoustonModel):
             assoc = self._get_association_for_user(other_user_guids[0])
         return assoc
 
+    # note: returns manager *of this collaboration* (if applicable).  this user
+    #   may no longer be an active manager (role).
+    def get_manager(self):
+        if self.initiator_guid in self.user_guids():
+            return None
+        from app.modules.users.models import User
+
+        return User.query.get(self.initiator_guid)
+
     def get_users(self):
         users = []
         for association in self.collaboration_user_associations:

--- a/app/templates/email/en_us/notifications/base-example.jinja2
+++ b/app/templates/email/en_us/notifications/base-example.jinja2
@@ -1,0 +1,12 @@
+<!--
+      this file is just a note/placeholder of the (proposed) usage of base.jinja2
+      this was created as part of PR512, but then over-ruled by PR518.   so it is
+      being saved for prosperity here.
+-->
+{% extends 'email/en_us/base.jinja2' %}
+{% block title %}Collaboration Approved, {{ site_name }}{% endblock %}
+{% block main %}
+<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">Your collaboration request on {{ context_name }} was approved by {{ sender_name }}.</p>
+
+<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">{{ sender_link }}</p>
+{% endblock %}

--- a/app/templates/email/en_us/notifications/collaboration_approved.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_approved.jinja2
@@ -1,7 +1,10 @@
-{% extends 'email/en_us/base.jinja2' %}
-{% block title %}Collaboration Approved, {{ site_name }}{% endblock %}
-{% block main %}
-<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">Your collaboration request on {{ context_name }} was approved by {{ sender_name }}.</p>
+<html>
+        <body>
+                <p>Hello {{ site_name }} user,</p>
 
-<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">{{ sender_link }}</p>
-{% endblock %}
+                <p>{{ sender_name }} approved your collaboration request. You should now be able to view data on <a href="{{ site_url_prefix }}/users/{{ sender_guid }}">their profile</a>.</p>
+
+                <p>Happy collaborating,<br />
+                The {{ site_name }} team</p>
+        </body>
+</html>

--- a/app/templates/email/en_us/notifications/collaboration_approved_subject.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_approved_subject.jinja2
@@ -1,1 +1,1 @@
-Your collaboration request was approved by {{ sender_name }} on {{ context_name }}
+{{ sender_name }} approved your collaboration request

--- a/app/templates/email/en_us/notifications/collaboration_edit_approved.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_edit_approved.jinja2
@@ -1,7 +1,10 @@
-{% extends 'email/en_us/base.jinja2' %}
-{% block title %}Collaboration Approved, {{ site_name }}{% endblock %}
-{% block main %}
-<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">Your collaboration edit request on {{ context_name }} was approved by {{ sender_name }}.</p>
+<html>
+        <body>
+                <p>Hello {{ site_name }} user,</p>
 
-<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">{{ sender_link }}</p>
-{% endblock %}
+                <p>{{ sender_name }} approved your collaboration edit request. You should now be able to edit data on <a href="{{ site_url_prefix }}/users/{{ sender_guid }}">their profile</a>.</p>
+
+                <p>Happy collaborating,<br />
+                The {{ site_name }} team</p>
+        </body>
+</html>

--- a/app/templates/email/en_us/notifications/collaboration_edit_approved_subject.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_edit_approved_subject.jinja2
@@ -1,1 +1,1 @@
-Your collaboration edit request from {{ sender_name }} on {{ context_name }} was approved
+{{ sender_name }} approved your collaboration edit request

--- a/app/templates/email/en_us/notifications/collaboration_edit_request.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_edit_request.jinja2
@@ -1,7 +1,10 @@
-{% extends 'email/en_us/base.jinja2' %}
-{% block title %}Collaboration Request, {{ site_name }}{% endblock %}
-{% block main %}
-<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">You have a request to edit on your collaboration on {{ context_name }} with {{ sender_name }}.</p>
+<html>
+        <body>
+                <p>Hello {{ site_name }} user,</p>
 
-<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">{{ sender_link }}</p>
-{% endblock main %}
+                <p>{{ sender_name }} sent you a collaboration edit request. To respond to their request, visit your <a href="{{ site_url_prefix }}">homepage</a> on {{ site_name }}.</p>
+
+                <p>Happy collaborating,<br />
+                The {{ site_name }} team</p>
+        </body>
+</html>

--- a/app/templates/email/en_us/notifications/collaboration_edit_request_subject.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_edit_request_subject.jinja2
@@ -1,1 +1,1 @@
-You have a collaboration edit request from {{ sender_name }} on {{ context_name }}
+{{ sender_name }} sent you a collaboration edit request

--- a/app/templates/email/en_us/notifications/collaboration_edit_revoke.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_edit_revoke.jinja2
@@ -1,7 +1,10 @@
-{% extends 'email/en_us/base.jinja2' %}
-{% block title %}Collaboration Revoked, {{ site_name }}{% endblock %}
-{% block main %}
-<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">Your collaboration on {{ context_name }} with {{ sender_name }} has had edit permission revoked.</p>
+<html>
+        <body>
+                <p>Hello {{ site_name }} user,</p>
 
-<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">{{ sender_link }}</p>
-{% endblock %}
+                <p>We are writing to inform you that {{ sender_name }} revoked edit privileges on your collaboration. You can view the status of your collaboration with {{ sender_name }} on your <a href="{{ site_url_prefix }}">homepage</a>.</p>
+
+                <p>Best,<br />
+                The {{ site_name }} team</p>
+        </body>
+</html>

--- a/app/templates/email/en_us/notifications/collaboration_edit_revoke_subject.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_edit_revoke_subject.jinja2
@@ -1,1 +1,1 @@
-Your collaboration with {{ sender_name }} on {{ context_name }} has had edit permission revoked.
+{{ sender_name }} revoked edit permissions on your collaboration

--- a/app/templates/email/en_us/notifications/collaboration_manager_create.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_manager_create.jinja2
@@ -1,7 +1,10 @@
-{% extends 'email/en_us/base.jinja2' %}
-{% block title %}Collaboration Created, {{ site_name }}{% endblock %}
-{% block main %}
-<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">A collaboration has been created by {{ sender_name }} on {{ context_name }} between {{user1_name}} and {{user2_name}}.</p>
+<html>
+        <body>
+                <p>Hello {{ site_name }} user,</p>
 
-<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">{{ sender_link }}</p>
-{% endblock %}
+                <p>We are writing to inform you that {{ manager_name }} created a collaboration between {{user1_name}} and {{user2_name}}. You can view your collaborations on your <a href="{{ site_url_prefix }}">homepage</a>.</p>
+
+                <p>Happy collaborating,<br />
+                The {{ site_name }} team</p>
+        </body>
+</html>

--- a/app/templates/email/en_us/notifications/collaboration_manager_create_subject.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_manager_create_subject.jinja2
@@ -1,1 +1,1 @@
-A collaboration has been created on {{ context_name }} between {{user1_name}} and {{user2_name}}
+{{ manager_name }} created a collaboration between {{user1_name}} and {{user2_name}}

--- a/app/templates/email/en_us/notifications/collaboration_manager_revoke.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_manager_revoke.jinja2
@@ -1,7 +1,10 @@
-{% extends 'email/en_us/base.jinja2' %}
-{% block title %}Collaboration Revoked, {{ site_name }}{% endblock %}
-{% block main %}
-<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">The collaboration on {{ context_name }} between {{user1_name}} and {{user2_name}} has been revoked by {{ sender_name }}.</p>
+<html>
+        <body>
+                <p>Hello {{ site_name }} user,</p>
 
-<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">{{ sender_link }}</p>
-{% endblock %}
+                <p>We are writing to inform you that {{ manager_name }} revoked the collaboration between {{user1_name}} and {{user2_name}}. You can view your collaborations on your <a href="{{ site_url_prefix }}">homepage</a>.</p>
+
+                <p>Best,<br />
+                The {{ site_name }} team</p>
+        </body>
+</html>

--- a/app/templates/email/en_us/notifications/collaboration_manager_revoke_subject.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_manager_revoke_subject.jinja2
@@ -1,1 +1,1 @@
-The collaboration between {{user1_name}} and {{user2_name}} on {{ context_name }} has been revoked.
+{{ manager_name }} revoked the collaboration between {{user1_name}} and {{user2_name}}

--- a/app/templates/email/en_us/notifications/collaboration_request.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_request.jinja2
@@ -1,7 +1,10 @@
-{% extends 'email/en_us/base.jinja2' %}
-{% block title %}Collaboration Request, {{ site_name }}{% endblock %}
-{% block main %}
-<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">You have a request to collaborate on {{ context_name }} from {{ sender_name }}.</p>
+<html>
+        <body>
+                <p>Hello {{ site_name }} user,</p>
 
-<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">{{ sender_link }}</p>
-{% endblock %}
+                <p>{{ sender_name }} sent you a collaboration request. To respond to their request, visit your <a href="{{ site_url_prefix }}">homepage</a>.</p>
+
+                <p>Happy collaborating,<br />
+                The {{ site_name }} team</p>
+        </body>
+</html>

--- a/app/templates/email/en_us/notifications/collaboration_request_subject.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_request_subject.jinja2
@@ -1,1 +1,1 @@
-You have a collaboration request from {{ sender_name }} on {{ context_name }}
+{{ sender_name }} sent you a collaboration request

--- a/app/templates/email/en_us/notifications/collaboration_revoke.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_revoke.jinja2
@@ -1,7 +1,10 @@
-{% extends 'email/en_us/base.jinja2' %}
-{% block title %}Collaboration Revoked, {{ site_name }}{% endblock %}
-{% block main %}
-<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">Your collaboration on {{ context_name }} with {{ sender_name }} has been revoked.</p>
+<html>
+        <body>
+                <p>Hello {{ site_name }} user,</p>
 
-<p style="Margin:0;Margin-bottom:10px;color:#0a0a0a;font-family:Helvetica,Arial,sans-serif;font-size:16px;font-weight:400;line-height:1.3;margin:0;margin-bottom:10px;padding:0;text-align:left">{{ sender_link }}</p>
-{% endblock %}
+                <p>We are writing to inform you that {{ sender_name }} revoked your collaboration with them. You can view your collaborations on your <a href="{{ site_url_prefix }}">homepage</a>.</p>
+
+                <p>Best,<br />
+                The {{ site_name }} team</p>
+        </body>
+</html>

--- a/app/templates/email/en_us/notifications/collaboration_revoke_subject.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_revoke_subject.jinja2
@@ -1,1 +1,1 @@
-Your collaboration with {{ sender_name }} on {{ context_name }} has been revoked.
+{{ sender_name }} revoked your collaboration privileges

--- a/app/templates/email/en_us/notifications/individual_merge_complete.jinja1
+++ b/app/templates/email/en_us/notifications/individual_merge_complete.jinja1
@@ -1,6 +1,0 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" >
-	<body>
-		{{sender_name}} {{request_id}}
-	</body>
-</html>

--- a/app/templates/email/en_us/notifications/individual_merge_complete.jinja2
+++ b/app/templates/email/en_us/notifications/individual_merge_complete.jinja2
@@ -1,0 +1,10 @@
+<html>
+				<body>
+								<p>Hello {{ site_name }} user,</p>
+
+								<p>We are writing to inform you that the merge between {{ target_individual_name }} and {{ source_names_list }} is now complete. The <a href="{{ site_url_prefix }}/individuals/{{ target_individual_guid }}">new individual's profile</a> contains merged data from the original individuals.</p>
+
+								<p>Best,<br />
+								The {{ site_name }} team</p>
+				</body>
+</html>

--- a/app/templates/email/en_us/notifications/individual_merge_complete_subject.jinja2
+++ b/app/templates/email/en_us/notifications/individual_merge_complete_subject.jinja2
@@ -1,1 +1,1 @@
-A queued merge has completed {{request_id}}
+{{ target_individual_name }} and {{ source_names_list }} have been merged

--- a/app/templates/email/en_us/notifications/individual_merge_request.jinja2
+++ b/app/templates/email/en_us/notifications/individual_merge_request.jinja2
@@ -1,6 +1,10 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" >
-	<body>
-		{{sender_name}} {{request_id}}
-	</body>
+<html>
+				<body>
+								<p>Hello {{ site_name }} user,</p>
+
+								<p>{{ sender_name }} wants to merge {{ target_individual_name }} and {{ source_names_list }}. To respond to their request, visit your <a href="{{ site_url_prefix }}">homepage</a>.</p>
+
+								<p>Best,<br />
+								The {{ site_name }} team</p>
+				</body>
 </html>

--- a/app/templates/email/en_us/notifications/individual_merge_request_subject.jinja2
+++ b/app/templates/email/en_us/notifications/individual_merge_request_subject.jinja2
@@ -1,1 +1,1 @@
-Please review this merge request {{request_id}}
+{{ sender_name }} wants to merge {{ target_individual_name }} and {{ source_names_list }}

--- a/tests/modules/notifications/test_models.py
+++ b/tests/modules/notifications/test_models.py
@@ -87,8 +87,8 @@ def test_notification_message(db, researcher_1, researcher_2, flask_app, request
     sent_email = notification._channels_sent['email']
     assert 'collaboration request' in sent_email.subject
     assert researcher_2.email in sent_email.recipients
-    assert 'a request to collaborate on' in sent_email.html
-    assert '</table>' in sent_email.html
+    assert 'sent you a collaboration request' in sent_email.html
+    assert '</body>' in sent_email.html
     with db.session.begin():
         db.session.delete(notification_preferences)
 


### PR DESCRIPTION
This PR starts the process of setting up email templates for MVP. The content is basically plain text, for now I think we can forego any fancy css, logos or markup. However I do think it's important that the links back to the platform work, so hopefully we can at least achieve that! Where I noticed existing jinja2 variables in the existing templates I used them, however I also "invented" some new variables which hopefully some benevolent Houstonian can legitimately set up so the emails work as expected. Here's my list of such variables:

**sender_name** - this variable already exists for collaboration request emails, however i was also hoping it could exist for merge request emails 
**site_url_prefix** - the hosted domain name of the platform, eg `https://www.flukebook.org`
**sender_guid** - where sender name exists, hoping we can get their GUID also so that we can construct links to their profile in some situations
**manager_name** - when a manager creates or revokes a collaboration, this would be the name of that user
**individual_name_1** - one of the individual's names in a merge request email
**individual_name_2** - the other individual's name in a merge request email
**individual_guid** - the GUID of the "final" merged individual in the merge complete email 

Also worth noting that I couldn't actually test send these emails so hopefully whoever picks this PR up can check that they look legit! However I did try to double-check and re-read so hopefully they aren't toooo sloppy