### PR TITLE
799 Notifications GET APIs

### DIFF
--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -719,7 +719,7 @@ class AssetGroupSightingDetected(Resource):
         permissions.ObjectAccessPermission,
         kwargs_on_request=lambda kwargs: {
             'obj': kwargs['asset_group_sighting'],
-            'action': AccessOperation.WRITE_PRIVILEGED,
+            'action': AccessOperation.WRITE_INTERNAL,
         },
     )
     def post(self, asset_group_sighting, job_guid):

--- a/app/modules/assets/resources.py
+++ b/app/modules/assets/resources.py
@@ -168,7 +168,7 @@ class AssetSrcRawByID(Resource):
         permissions.ObjectAccessPermission,
         kwargs_on_request=lambda kwargs: {
             'obj': kwargs['asset'],
-            'action': AccessOperation.READ_PRIVILEGED,
+            'action': AccessOperation.READ_INTERNAL,
         },
     )
     def get(self, asset):

--- a/app/modules/notifications/models.py
+++ b/app/modules/notifications/models.py
@@ -233,6 +233,27 @@ class Notification(db.Model, HoustonModel):
             ')>'.format(class_name=self.__class__.__name__, self=self)
         )
 
+    @classmethod
+    def get_notifications_for_user(cls, user):
+        from sqlalchemy import desc
+
+        return (
+            Notification.query.filter_by(recipient_guid=user.guid)
+            .order_by(desc(Notification.created))
+            .all()
+        )
+
+    @classmethod
+    def get_unread_notifications_for_user(cls, user):
+        from sqlalchemy import desc
+
+        return (
+            Notification.query.filter_by(recipient_guid=user.guid)
+            .filter_by(is_read=False)
+            .order_by(desc(Notification.created))
+            .all()
+        )
+
     @property
     def owner(self):
         return self.recipient

--- a/app/modules/notifications/resources.py
+++ b/app/modules/notifications/resources.py
@@ -136,7 +136,9 @@ class AllUnreadNotifications(Resource):
         Returns a list of Notification starting from ``offset`` limited by ``limit``
         parameter.
         """
-        notifications = Notification.query.all()
+        from sqlalchemy import desc
+
+        notifications = Notification.query.order_by(desc(Notification.created)).all()
         # Manually apply offset and limit after the list is created
         return notifications[args['offset'] : args['limit'] - args['offset']]
 

--- a/app/modules/notifications/resources.py
+++ b/app/modules/notifications/resources.py
@@ -54,7 +54,7 @@ class MyNotifications(Resource):
         parameter.
         """
 
-        returned_notifications = current_user.get_notifications()
+        returned_notifications = Notification.get_notifications_for_user(current_user)
 
         # Manually apply offset and limit after the unique list is created
         return returned_notifications[args['offset'] : args['limit'] - args['offset']]
@@ -108,7 +108,9 @@ class MyUnreadNotifications(Resource):
         Returns a list of Notification starting from ``offset`` limited by ``limit``
         parameter.
         """
-        unread_notifications = current_user.get_unread_notifications()
+        unread_notifications = Notification.get_unread_notifications_for_user(
+            current_user
+        )
         # Manually apply offset and limit after the list is created
         return unread_notifications[args['offset'] : args['limit'] - args['offset']]
 

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -677,7 +677,7 @@ class SightingSageIdentified(Resource):
         permissions.ObjectAccessPermission,
         kwargs_on_request=lambda kwargs: {
             'obj': kwargs['sighting'],
-            'action': AccessOperation.WRITE_PRIVILEGED,
+            'action': AccessOperation.WRITE_INTERNAL,
         },
     )
     def post(self, sighting, job_guid):

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -621,15 +621,17 @@ class User(db.Model, FeatherModel, UserEDMMixin):
         return returned_notifications
 
     def get_notifications(self):
-        return self._apply_notification_preferences(self.notifications)
+        from app.modules.notifications.models import Notification
+
+        return self._apply_notification_preferences(
+            Notification.get_notifications_for_user(self)
+        )
 
     def get_unread_notifications(self):
         from app.modules.notifications.models import Notification
 
         return self._apply_notification_preferences(
-            Notification.query.filter_by(recipient_guid=self.guid)
-            .filter_by(is_read=False)
-            .all()
+            Notification.get_unread_notifications_for_user(self)
         )
 
     @module_required('individuals', resolve='warn', default=[])

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -608,32 +608,6 @@ class User(db.Model, FeatherModel, UserEDMMixin):
         preferences = UserNotificationPreferences.get_user_preferences(self)
         return preferences
 
-    def _apply_notification_preferences(self, all_notifications):
-        from app.modules.notifications.models import NotificationChannel
-
-        preferences = self.get_notification_preferences()
-        returned_notifications = [
-            notif
-            for notif in all_notifications
-            if preferences[notif.message_type][NotificationChannel.rest]
-        ]
-
-        return returned_notifications
-
-    def get_notifications(self):
-        from app.modules.notifications.models import Notification
-
-        return self._apply_notification_preferences(
-            Notification.get_notifications_for_user(self)
-        )
-
-    def get_unread_notifications(self):
-        from app.modules.notifications.models import Notification
-
-        return self._apply_notification_preferences(
-            Notification.get_unread_notifications_for_user(self)
-        )
-
     @module_required('individuals', resolve='warn', default=[])
     def get_individual_merge_requests(self):
         from app.modules.individuals.models import Individual

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -46,6 +46,7 @@ MODULE_USER_MAP = {
     ('Collaboration', AccessOperation.WRITE): ['is_active'],
     ('Collaboration', AccessOperation.READ): ['is_user_manager'],
     ('Notification', AccessOperation.READ): ['is_active'],
+    ('Notification', AccessOperation.READ_PRIVILEGED): ['is_user_manager'],
     ('Keyword', AccessOperation.READ): ['is_active'],
     ('Keyword', AccessOperation.WRITE): ['is_active'],
     ('AuditLog', AccessOperation.READ): ['is_admin'],
@@ -76,7 +77,7 @@ OBJECT_USER_MAP = {
         'is_researcher',
     ],
     ('Individual', AccessOperation.READ): ['is_researcher'],
-    ('AssetGroupSighting', AccessOperation.WRITE_PRIVILEGED): ['is_internal'],
+    ('AssetGroupSighting', AccessOperation.WRITE_INTERNAL): ['is_internal'],
     ('Encounter', AccessOperation.READ): ['is_researcher'],
     ('User', AccessOperation.WRITE): [
         'is_user_manager',
@@ -91,7 +92,7 @@ OBJECT_USER_MAP = {
         'is_admin',
     ],
     ('Keyword', AccessOperation.READ): ['is_active'],
-    ('Sighting', AccessOperation.WRITE_PRIVILEGED): ['is_internal'],
+    ('Sighting', AccessOperation.WRITE_INTERNAL): ['is_internal'],
     ('Sighting', AccessOperation.READ_PRIVILEGED): ['is_staff'],
     ('SocialGroup', AccessOperation.READ): ['is_researcher'],
     ('SocialGroup', AccessOperation.WRITE): ['is_researcher'],
@@ -116,7 +117,7 @@ OBJECT_USER_METHOD_MAP = {
     ('Sighting', AccessOperation.READ): ['user_is_owner'],
     ('Sighting', AccessOperation.WRITE): ['user_owns_all_encounters'],
     ('Sighting', AccessOperation.DELETE): ['user_can_edit_all_encounters'],
-    ('Asset', AccessOperation.READ_PRIVILEGED): ['user_raw_read'],
+    ('Asset', AccessOperation.READ_INTERNAL): ['user_raw_read'],
     ('Asset', AccessOperation.WRITE): ['user_is_owner'],
     ('Annotation', AccessOperation.READ): ['user_is_owner'],
     ('Annotation', AccessOperation.WRITE): ['user_is_owner'],
@@ -327,15 +328,17 @@ class ObjectActionRule(DenyAbortMixin, Rule):
         return True, False
 
     def elevated_permission(self, user):
+        # internal access cannot be achieved by elevated permission
         if (
-            self._action == AccessOperation.READ_PRIVILEGED
-            or self._action == AccessOperation.WRITE_PRIVILEGED
+            self._action == AccessOperation.READ_INTERNAL
+            or self._action == AccessOperation.WRITE_INTERNAL
         ):
             return False
         elif self._action == AccessOperation.READ_DEBUG:
             # Only staff can read debug info, not owners
             return user.is_privileged
         else:
+            # Specifically also includes READ_PRIVILEGED
             return owner_or_privileged(user, self._obj)
 
     def check(self):

--- a/app/modules/users/permissions/types.py
+++ b/app/modules/users/permissions/types.py
@@ -13,8 +13,11 @@ class AccessOperation(enum.Enum):
     READ = 1
     # Debug generally only available to staff users so needs a separate category
     READ_DEBUG = 2
-    # Some information needs to be much more secure
+    # Some information needs to be more secure (mostly admin but some other roles (user_manager) occasionally)
     READ_PRIVILEGED = 3
-    WRITE = 4
-    WRITE_PRIVILEGED = 5
-    DELETE = 6
+    # internal operations only (only Sage, no wetware users)
+    READ_INTERNAL = 4
+    WRITE = 5
+    # internal operations only (only Sage, no wetware users)
+    WRITE_INTERNAL = 6
+    DELETE = 7

--- a/tests/modules/collaborations/resources/test_collaboration_notification.py
+++ b/tests/modules/collaborations/resources/test_collaboration_notification.py
@@ -160,7 +160,7 @@ def test_multi_collaboration(
         flask_app_client, researcher_1
     )
     notifs_manager = notif_utils.read_all_notifications(
-        flask_app_client, user_manager_user
+        flask_app_client, user_manager_user, 'all_unread'
     )
 
     # Manager should see all 6 notifications, researcher1 should only see those for themselves

--- a/tests/modules/notifications/resources/test_notifications.py
+++ b/tests/modules/notifications/resources/test_notifications.py
@@ -73,16 +73,29 @@ def test_get_notifications(
     researcher_1_notifs = notif_utils.read_all_notifications(
         flask_app_client, researcher_1
     )
+    researcher_1_unread_notifs = notif_utils.read_all_notifications(
+        flask_app_client, researcher_1, 'unread'
+    )
     researcher_2_notifs = notif_utils.read_all_notifications(
         flask_app_client, researcher_2
     )
+    researcher_2_unread_notifs = notif_utils.read_all_notifications(
+        flask_app_client, researcher_2
+    )
+
     user_manager_notifs = notif_utils.read_all_notifications(
         flask_app_client, user_manager_user
     )
+    user_manager_all_notifs = notif_utils.read_all_notifications(
+        flask_app_client, user_manager_user, 'all_unread'
+    )
 
     assert len(researcher_1_notifs.json) == len(prev_researcher_1_notifs.json) + 1
+    assert len(researcher_1_unread_notifs.json) == 1
     assert len(researcher_2_notifs.json) == len(prev_researcher_2_notifs.json) + 1
-    assert len(user_manager_notifs.json) == len(prev_user_manager_notifs.json) + 2
+    assert len(researcher_2_unread_notifs.json) == 1
+    assert len(user_manager_notifs.json) == len(prev_user_manager_notifs.json)
+    assert len(user_manager_all_notifs.json) == 2
 
     collab_reqs_from_researcher_1 = get_notifications_with_guid(
         researcher_2_notifs.json,

--- a/tests/modules/notifications/resources/utils.py
+++ b/tests/modules/notifications/resources/utils.py
@@ -92,12 +92,12 @@ def read_notification(
     )
 
 
-def read_all_notifications(flask_app_client, user, expected_status_code=200):
+def read_all_notifications(flask_app_client, user, sub_path='', expected_status_code=200):
     return test_utils.get_list_via_flask(
         flask_app_client,
         user,
         scopes='notifications:read',
-        path=PATH,
+        path=f'{PATH}{sub_path}',
         expected_status_code=expected_status_code,
         expected_fields=EXPECTED_LIST_KEYS,
     )


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Notifications GET returns all of that users notifications
- /unread returns unread notifications for that user (API already existed but all now reworked to hopefully be more efficient)
- /all_unread for a user manager or admin to see all unread notifications in the system
- POST of a Notification disabled, Should never be used by the frontend
- READ_INTERNAL added separate to READ_PRIVILEGED

---

**Review Notes**
Please specifically focus on:
READ_PRIVILEGED and WRITE_PRIVILEGED was getting confused between privileged things that staff and admin could do and things that only Sage could do. The Sage only stuff is now READ_INTERNAL and WRITE_INTERNAL. The READ_PRIVILEGED is what human privileged users can do. Currently no need fro a WRITE_PRIVILEGED. 
Also @naknomum please check the unread notifications filter stuff. I think that should be more efficient than manually applying the is_read check to self.notifications but not sure.

**REST API Updates **

The contents in terms of the notification details are unchanged so will not be documented here but these are the three APIs. 
/notifications GET will return all of a users notifications (read and unread) after notification preferences are applied
/notifications/unread GET will return all of a users unread notifications, after notification preferences applied
/notifications/all_unread GET All unread notifications I have access to (mine and others) without notification preferences applied.
