### PR TITLE
DEX-807: better error reporting on encounter api DELETE when blocked by cascading delete

### DIFF
--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -190,11 +190,16 @@ class EDMManager(RestManager):
 
             message = {'unknown error'}
             error = None
+            vulnerable_sighting_guid = None
+            vulnerable_individual_guid = None
 
             if response_data is not None and 'message' in response_data:
                 message = response_data['message']
             if response_data is not None and 'errorFields' in response_data:
                 error = response_data['errorFields']
+            if response_data:
+                vulnerable_individual_guid = response_data.get('vulnerableIndividual')
+                vulnerable_sighting_guid = response_data.get('vulnerableSighting')
 
             raise HoustonException(
                 log,
@@ -204,6 +209,8 @@ class EDMManager(RestManager):
                 message=message,
                 error=error,
                 edm_status_code=response.status_code,
+                vulnerable_sighting_guid=vulnerable_sighting_guid,
+                vulnerable_individual_guid=vulnerable_individual_guid,
             )
 
         return response, response_data, result_data

--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -190,16 +190,11 @@ class EDMManager(RestManager):
 
             message = {'unknown error'}
             error = None
-            vulnerable_sighting_guid = None
-            vulnerable_individual_guid = None
 
             if response_data is not None and 'message' in response_data:
                 message = response_data['message']
             if response_data is not None and 'errorFields' in response_data:
                 error = response_data['errorFields']
-            if response_data:
-                vulnerable_individual_guid = response_data.get('vulnerableIndividual')
-                vulnerable_sighting_guid = response_data.get('vulnerableSighting')
 
             raise HoustonException(
                 log,
@@ -209,8 +204,7 @@ class EDMManager(RestManager):
                 message=message,
                 error=error,
                 edm_status_code=response.status_code,
-                vulnerable_sighting_guid=vulnerable_sighting_guid,
-                vulnerable_individual_guid=vulnerable_individual_guid,
+                response_data=response_data,
             )
 
         return response, response_data, result_data

--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -226,11 +226,12 @@ class EncounterByID(Resource):
             log.warning(
                 f'Encounter.delete {encounter.guid} failed: ({ex.status_code} / edm={edm_status_code}) {ex.message}'
             )
+            response_data = ex.get_val('response_data', {})
             abort(
                 400,
                 'Delete failed',
-                vulnerableIndividualGuid=ex.get_val('vulnerable_individual_guid', None),
-                vulnerableSightingGuid=ex.get_val('vulnerable_sighting_guid', None),
+                vulnerableIndividualGuid=response_data.get('vulnerableIndividual'),
+                vulnerableSightingGuid=response_data.get('vulnerableSighting'),
             )
 
         # we have to roll our own response here (to return) as it seems the only way we can add a header

--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -226,12 +226,12 @@ class EncounterByID(Resource):
             log.warning(
                 f'Encounter.delete {encounter.guid} failed: ({ex.status_code} / edm={edm_status_code}) {ex.message}'
             )
-            response_data = ex.get_val('response_data', {})
+            ex_response_data = ex.get_val('response_data', {})
             abort(
                 400,
                 'Delete failed',
-                vulnerableIndividualGuid=response_data.get('vulnerableIndividual'),
-                vulnerableSightingGuid=response_data.get('vulnerableSighting'),
+                vulnerableIndividualGuid=ex_response_data.get('vulnerableIndividual'),
+                vulnerableSightingGuid=ex_response_data.get('vulnerableSighting'),
             )
 
         # we have to roll our own response here (to return) as it seems the only way we can add a header

--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -226,7 +226,12 @@ class EncounterByID(Resource):
             log.warning(
                 f'Encounter.delete {encounter.guid} failed: ({ex.status_code} / edm={edm_status_code}) {ex.message}'
             )
-            abort(400, 'Delete failed')
+            abort(
+                400,
+                'Delete failed',
+                vulnerableIndividualGuid=ex.get_val('vulnerableIndividual'),
+                vulnerableSightingGuid=ex.get_val('vulnerableSighting'),
+            )
 
         # we have to roll our own response here (to return) as it seems the only way we can add a header
         #   (which we are using to denote the encounter DELETE also triggered a sighting DELETE, since

--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -229,8 +229,8 @@ class EncounterByID(Resource):
             abort(
                 400,
                 'Delete failed',
-                vulnerableIndividualGuid=ex.get_val('vulnerableIndividual'),
-                vulnerableSightingGuid=ex.get_val('vulnerableSighting'),
+                vulnerableIndividualGuid=ex.get_val('vulnerableIndividual', None),
+                vulnerableSightingGuid=ex.get_val('vulnerableSighting', None),
             )
 
         # we have to roll our own response here (to return) as it seems the only way we can add a header

--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -229,8 +229,8 @@ class EncounterByID(Resource):
             abort(
                 400,
                 'Delete failed',
-                vulnerableIndividualGuid=ex.get_val('vulnerableIndividual', None),
-                vulnerableSightingGuid=ex.get_val('vulnerableSighting', None),
+                vulnerableIndividualGuid=ex.get_val('vulnerable_individual_guid', None),
+                vulnerableSightingGuid=ex.get_val('vulnerable_sighting_guid', None),
             )
 
         # we have to roll our own response here (to return) as it seems the only way we can add a header

--- a/tests/modules/encounters/resources/test_delete_encounter.py
+++ b/tests/modules/encounters/resources/test_delete_encounter.py
@@ -76,6 +76,7 @@ def test_delete_method(
     response = enc_utils.delete_encounter(
         flask_app_client, staff_user, enc1_id, expected_status_code=400
     )
+    assert response.json['vulnerableSightingGuid'] == sighting_id
     ct = test_utils.all_count(db)
     assert ct['Encounter'] == orig_ct['Encounter'] + 1
 
@@ -84,6 +85,7 @@ def test_delete_method(
     response = enc_utils.delete_encounter(
         flask_app_client, staff_user, enc1_id, headers=headers, expected_status_code=400
     )
+    assert response.json['vulnerableIndividualGuid'] == individual_guid
 
     # now this should work but take the sighting and individual with it as well
     headers = (


### PR DESCRIPTION
## Pull Request Overview

- `DELETE /api/v1/encounters/GUID` gives a little more info when deletion is blocked due to cascading error
- body of returned 400 response will contain `vulnerableIndividualGuid: GUID` or `vulnerableSightingGuid: GUID` as appropriate
