### PR TITLE
DEX-784 Password reset emails

### DIFF
--- a/app/extensions/restManager/RestManager.py
+++ b/app/extensions/restManager/RestManager.py
@@ -398,6 +398,10 @@ class RestManager(RestManagerUserMixin):
             data_ = passthrough_kwargs.pop('data', None)
             if data_ is not None:
                 passthrough_kwargs['json'] = data_
+        elif passthrough_kwargs.get('data'):
+            log.warning(
+                f'Data for tag={tag} is not sent as json: data={passthrough_kwargs["data"]}'
+            )
 
         response = self._request(
             method,

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -722,7 +722,7 @@ class User(db.Model, FeatherModel, UserEDMMixin):
         return self.get_codes(CodeTypes.recover, replace=True, replace_ttl=None)
 
     def set_password(self, password):
-        if password is None:
+        if not password:
             # This function "sets" the password, it's the responsibility of the caller to ensure it's valid
             raise ValueError('Empty password not allowed')
 

--- a/app/templates/email/en_us/misc/password_reset.jinja2
+++ b/app/templates/email/en_us/misc/password_reset.jinja2
@@ -1,0 +1,11 @@
+<html>
+    <body>
+        <p>Hello {{ site_name }} user,<p>
+
+        <p>You can reset your password here: <a href="{{ reset_link }}">{{ reset_link }}</a></p>
+
+        <p>If you received this without requesting a password reset, you can ignore it.</p>
+
+        <p>The {{ site_name }} team</p>
+    </body>
+</html>

--- a/app/templates/email/en_us/misc/password_reset_subject.jinja2
+++ b/app/templates/email/en_us/misc/password_reset_subject.jinja2
@@ -1,0 +1,1 @@
+{{ site_name }} account password reset

--- a/tests/modules/auth/resources/test_code.py
+++ b/tests/modules/auth/resources/test_code.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+import datetime
+
+from app.modules.auth.models import Code, CodeTypes
+from app.modules.users.models import User
+
+
+def test_reset_password(flask_app_client, researcher_1, request):
+    # Create a recover code
+    recover = Code.get(researcher_1, CodeTypes.recover)
+    request.addfinalizer(recover.delete)
+
+    # Use the recover code without sending a password
+    response = flask_app_client.post(f'/api/v1/auth/code/{recover.accept_code}')
+    assert response.status_code == 400
+    assert response.json['message'] == 'Empty password not allowed'
+
+    # Use the recover code to reset password
+    response = flask_app_client.post(
+        f'/api/v1/auth/code/{recover.accept_code}',
+        content_type='application/json',
+        data='{"password": "new-password"}',
+    )
+    assert response.status_code == 200
+    assert User.find(email=researcher_1.email, password='new-password') == researcher_1
+
+    # Use the recover code again
+    response = flask_app_client.post(
+        f'/api/v1/auth/code/{recover.accept_code}',
+        content_type='application/json',
+        data='{"password": "new-password"}',
+    )
+    assert response.status_code == 400
+    assert response.json['message'] == f'Code {repr(recover.accept_code)} already used'
+
+    # Create a recover code that is expired
+    expired = Code.get(researcher_1, CodeTypes.recover)
+    expired.expires -= datetime.timedelta(days=3650)
+
+    # Use an expired recover code
+    response = flask_app_client.post(
+        f'/api/v1/auth/code/{expired.accept_code}',
+        content_type='application/json',
+        data='{"password": "new-password"}',
+    )
+    assert response.status_code == 400
+    assert response.json['message'] == f'Code {repr(expired.accept_code)} is expired'
+
+    # Use a code that does not exist
+    response = flask_app_client.post(
+        '/api/v1/auth/code/1234',
+        content_type='application/json',
+        data='{"password": "new-password"}',
+    )
+    assert response.status_code == 400
+    assert response.json['message'] == "Code '1234' not found"

--- a/tests/modules/auth/test_models.py
+++ b/tests/modules/auth/test_models.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+import datetime
+
+import pytz
+
+from app.modules.auth.models import Code, CodeTypes, CodeDecisions
+
+
+def test_Code(db, researcher_1):
+    # Create a recover code
+    recover_1 = Code.get(researcher_1, CodeTypes.recover)
+    assert not recover_1.is_expired
+    assert not recover_1.is_resolved
+    assert Code.find_all(recover_1.accept_code) == [recover_1]
+    assert Code.find_all(recover_1.reject_code) == [recover_1]
+    assert recover_1.accept_code != recover_1.reject_code
+    assert 'type=recover' in repr(recover_1)
+
+    # Get the recover code (should not create a new one)
+    recover_2 = Code.get(researcher_1, CodeTypes.recover)
+    assert recover_1.guid == recover_2.guid
+
+    # Force create another recover code
+    recover_3 = Code.get(researcher_1, CodeTypes.recover, create_force=True)
+    assert recover_1.guid != recover_3.guid
+
+    # Get all the valid recover codes for the user
+    assert Code.valid_codes(researcher_1, CodeTypes.recover) == [recover_3, recover_1]
+
+    # Create another recover code and expire it
+    recover_4 = Code.get(researcher_1, CodeTypes.recover, create_force=True)
+    recover_4.expires = (
+        datetime.datetime.now() - datetime.timedelta(seconds=1)
+    ).astimezone(pytz.utc)
+    with db.session.begin():
+        db.session.merge(recover_4)
+
+    # Valid recover codes for the user should not include expired code
+    assert Code.valid_codes(researcher_1, CodeTypes.recover) == [recover_3, recover_1]
+
+    # Accept code that doesn't exist
+    assert Code.received('1') == (CodeDecisions.unknown, None)
+
+    # Accept recover code 1
+    assert Code.received(recover_1.accept_code) == (CodeDecisions.accept, recover_1)
+    assert recover_1.is_resolved is True
+
+    # Accept recover code 1 again
+    assert Code.received(recover_1.accept_code) == (CodeDecisions.dismiss, recover_1)
+    assert recover_1.is_resolved is True
+
+    # Accept expired recovery code 4
+    assert Code.received(recover_4.accept_code) == (CodeDecisions.expired, recover_4)
+    assert recover_4.is_resolved is False
+
+    # Replace recover code (delete all valid codes)
+    recover_5 = Code.get(researcher_1, CodeTypes.recover, replace=True, replace_ttl=None)
+    assert Code.valid_codes(researcher_1, CodeTypes.recover) == [recover_5]
+
+    # Recover code 1 is already resolved so not replaced
+    assert Code.query.get(recover_1.guid) == recover_1
+    # Recover code 3 was valid so was replaced
+    assert Code.query.get(recover_3.guid) is None
+    # Recover code 4 is already expired so not replaced
+    assert Code.query.get(recover_4.guid) == recover_4
+
+    # Reject recover code 5
+    assert Code.received(recover_5.reject_code) == (CodeDecisions.reject, recover_5)
+    assert recover_5.is_resolved is True
+
+    # No more valid recover codes for user
+    assert Code.valid_codes(researcher_1, CodeTypes.recover) == []
+
+    # Clean up expired but not resolved codes
+    Code.cleanup()
+    assert Code.query.get(recover_1.guid) == recover_1
+    assert Code.query.get(recover_4.guid) is None
+
+    # Delete other codes
+    recover_1.delete()
+    recover_5.delete()

--- a/tests/modules/users/resources/test_emails.py
+++ b/tests/modules/users/resources/test_emails.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+import json
+import re
+from unittest import mock
+
+from app.modules.auth.models import Code, CodeTypes
+
+
+def test_reset_password(flask_app_client, researcher_1):
+    url = '/api/v1/users/reset_password_email'
+    with mock.patch('app.extensions.email.mail.send') as send:
+        response = flask_app_client.post(url)
+        assert response.status_code == 400
+        assert (
+            response.json['message']
+            == 'JSON body needs to be in this format {"email": "user@example.org"}'
+        )
+
+        response = flask_app_client.post(
+            url,
+            content_type='application/json',
+            data=json.dumps({'email': researcher_1.email}),
+        )
+        assert response.status_code == 200
+    email = send.call_args[0][0]
+    all_hrefs = re.findall('href="([^"]*)"', email.html) + re.findall(
+        'href=([^"> ]+)', email.html
+    )
+    code = Code.get(researcher_1, CodeTypes.recover, create=False)
+    assert f'http://localhost:84/auth/code/{code.accept_code}' in all_hrefs
+    assert response.status_code == 200


### PR DESCRIPTION
- Add tests and refactor auth Code model

  - Change `Code.find` to `Code.find_all` because it returns multiple
    objects
  
  - Create new class function `Code.valid_codes` and include `expires` and
    `response` in the query instead of calling `is_expired` and
    `is_resolved` so we can make better use of sql instead of post
    processing the result
  
  - Compress `CODE_VALID_CHARACTERS` to a string from list of characters
  
    `CODE_VALID_CHARACTERS` is used in 2 ways:
  
    ```
    random.choice(CODE_VALID_CHARACTERS)
    ```
  
    and
  
    ```
    if char in CODE_VALID_CHARACTERS
    ```
  
    These work exactly the same way if `CODE_VALID_CHARACTERS` is a string
    instead.

- DEX-784 Password reset emails

  Use this API to send the user a password reset email:
  
  ```
  POST /api/v1/users/reset_password_email
  
  {"email": "public@wildme.org"}
  ```
  
  The email looks like:
  
  > Hello BetaBook user,
  >
  > You can reset your password here: http://localhost:84/auth/code/FEB9F20A8C27C650E316A4B493EE544841FC24C89252661A4A36335E0D5ED600
  >
  > The BetaBook team
  
  ^ Frontend needs to provide a page for resetting the password at `/auth/code/<code_string>`.
  
  The API for resetting the password is:
  
  ```
  POST /api/v1/auth/code/<code_string>
  
  {"password": "new-password"}
  ```
