### PR TITLE
Display email in houston logs if email not configured

### DIFF
--- a/app/extensions/email/__init__.py
+++ b/app/extensions/email/__init__.py
@@ -346,6 +346,10 @@ class Email(Message):
             log.debug(
                 f'Codex not configured for email; failed to send to {self.recipients}: {self.subject}'
             )
+            if self.body:
+                log.debug(self.body)
+            if self.html:
+                log.debug(self.html)
             response = {
                 'status': 'Codex email not properly configured',
                 'success': False,

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -407,7 +407,7 @@ class UserResetPasswordEmail(Resource):
         user = User.find(email=email)
         if not user:
             # Log for development purposes but do not show anything to the API user
-            log.warning('User with email address {repr(email)} not found')
+            log.warning(f'User with email address {repr(email)} not found')
             return
         code = Code.get(user, CodeTypes.recover, replace=True)
         msg = Email(recipients=[user])


### PR DESCRIPTION
- Display email address in  password reset user not found log

  I forgot to put in the `f` at the beginning of the string causing the
  log to look like:
  
  ```
  WARNING  [app.modules.users.resources] User with email address {repr(email)} not found
  ```
  
  Now it looks like:
  
  ```
  WARNING  [app.modules.users.resources] User with email address 'public@wildme.org' not found
  ```

- Display email in houston logs if email not configured

  This allows easier development even if email isn't configured:
  
  ```
  DEBUG    [app.extensions.email] Codex not configured for email; failed to send to ['testing@wildme.org']: Codex account password reset                                        __init__.py:346
  DEBUG    [app.extensions.email] <html><head><link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Assistant:200|Chango|Molle:400i&display=swap"><link          __init__.py:352
           rel="stylesheet" href="https://fonts.googleapis.com/icon?family=Material+Icons"><link rel="stylesheet"
           href="https://fonts.googleapis.com/css?family=Source+Code+Pro&display=swap"></head><body><p>Hello Codex user,</p><p></p><p>You can reset your password here: <a href
           =http://localhost:84/auth/code/D60669C93CEF414C4D3F62104193372514714568172B84CB226FB8388ACB763D>http://localhost:84/auth/code/D60669C93CEF414C4D3F621041933725147145
           68172B84CB226FB8388ACB763D</a></p><p>If you received this without requesting a password reset, you can ignore it.</p><p>The Codex team</p></body></html>
  INFO     [werkzeug] 172.20.0.3 - - [08/Mar/2022 11:49:03] "[37mPOST /api/v1/users/reset_password_email HTTP/1.0[0m" 200 -                                                    _internal.py:122
  ```
