### PR TITLE
DEX-824 Account verification emails

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -68,7 +68,7 @@ def _ensure_oauth_user(config):
         from app.modules.users.models import User
 
         try:
-            user = User.ensure_user(**oauth_user)
+            user = User.ensure_user(send_verification=False, **oauth_user)
         except (sqlalchemy.exc.OperationalError, sqlalchemy.exc.ProgrammingError):
             # sqlite3.OperationalError no such table
             # sqlalchemy.exc.ProgrammingError: (psycopg2.errors.UndefinedTable) relation "user" does not exist

--- a/app/modules/auth/models.py
+++ b/app/modules/auth/models.py
@@ -403,7 +403,7 @@ class Code(db.Model, HoustonModel):
                 'expires': expires_utc,
             }
             code = Code(**code_kwargs)
-            with db.session.begin():
+            with db.session.begin(subtransactions=True):
                 db.session.add(code)
             db.session.refresh(code)
             db.session.refresh(user)

--- a/app/modules/auth/resources.py
+++ b/app/modules/auth/resources.py
@@ -228,6 +228,10 @@ class CodeReceived(Resource):
         url_args = {}
         if code.code_type == CodeTypes.recover:
             redirect_uri = '/reset_password'
+        elif code.code_type == CodeTypes.email:
+            # nothing to do because User.is_email_confirmed looks into Code for
+            # the user filtered by CodeTypes.email is_resolved
+            redirect_uri = '/email_verified'
         else:
             abort(404, f'Unrecognized code type: {code.code_type}')
 
@@ -258,6 +262,10 @@ class CodeReceived(Resource):
                     db.session.merge(code)
                 url_args['message'] = str(e)
                 url_args['status'] = 400
+        elif code.code_type == CodeTypes.email:
+            # nothing to do because User.is_email_confirmed looks into Code for
+            # the user filtered by CodeTypes.email is_resolved
+            url_args['message'] = 'Email successfully verified.'
         else:
             abort(404, f'Unrecognized code type: {code.code_type}')
 

--- a/app/modules/auth/resources.py
+++ b/app/modules/auth/resources.py
@@ -6,8 +6,9 @@ Auth resources
 """
 import json
 import logging
+from urllib.parse import urlencode
 
-from flask import current_app, request
+from flask import current_app, request, redirect
 from flask_login import current_user, login_user, logout_user
 from flask_restx_patched import Resource
 from flask_restx_patched._http import HTTPStatus
@@ -209,16 +210,38 @@ class ReCaptchaPublicServerKey(Resource):
         return response
 
 
-@api.route('/code/<string:code_string>')
+@api.route('/code/<string:code_string_dot_json>')
 class CodeReceived(Resource):
-    def post(self, code_string):
+    def post(self, code_string_dot_json):
+        if code_string_dot_json.endswith('.json'):
+            is_json = True
+            code_string = code_string_dot_json[:-5]
+        else:
+            is_json = False
+            code_string = code_string_dot_json
+
         decision, code = Code.received(code_string)
+        if code is None:
+            abort(404, f'Code {repr(code_string)} not found')
+
+        redirect_uri = None
+        url_args = {}
+        if code.code_type == CodeTypes.recover:
+            redirect_uri = '/reset_password'
+        else:
+            abort(404, f'Unrecognized code type: {code.code_type}')
+
         if decision == CodeDecisions.expired:
-            abort(400, f'Code {repr(code_string)} is expired')
-        if decision == CodeDecisions.error or code is None:
-            abort(400, f'Code {repr(code_string)} not found')
-        if decision == CodeDecisions.dismiss:
-            abort(400, f'Code {repr(code_string)} already used')
+            url_args['message'] = 'Code has expired'
+        elif decision == CodeDecisions.error:
+            url_args['message'] = 'Code not found'
+        elif decision == CodeDecisions.dismiss:
+            url_args['message'] = 'Code already used'
+
+        if url_args.get('message'):
+            if is_json:
+                abort(400, url_args['message'])
+            return redirect(f'{redirect_uri}?{urlencode(url_args)}')
 
         try:
             data = json.loads(request.data)
@@ -228,10 +251,18 @@ class CodeReceived(Resource):
         if code.code_type == CodeTypes.recover:
             try:
                 code.user.set_password(data.get('password', ''))
+                url_args['message'] = 'Password successfully set.'
             except Exception as e:
                 code.response = None
                 with db.session.begin():
                     db.session.merge(code)
-                abort(400, str(e))
+                url_args['message'] = str(e)
+                url_args['status'] = 400
         else:
-            abort(400, f'Unrecognized code type: {code.code_type}')
+            abort(404, f'Unrecognized code type: {code.code_type}')
+
+        if is_json:
+            if url_args.get('status', 200) != 200:
+                abort(url_args['status'], url_args.get('message'))
+            return {'message': url_args.get('message')}
+        return redirect(f'{redirect_uri}?{urlencode(url_args)}')

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -387,7 +387,7 @@ class User(db.Model, FeatherModel, UserEDMMixin):
         is_admin=False,
         is_staff=False,
         is_researcher=False,
-        is_contributor=True,
+        is_contributor=False,
         is_user_manager=False,
         is_exporter=False,
         is_active=True,
@@ -420,7 +420,7 @@ class User(db.Model, FeatherModel, UserEDMMixin):
                 **kwargs,
             )
 
-            with db.session.begin():
+            with db.session.begin(subtransactions=True):
                 db.session.add(user)
 
             log.info('New user created: %r' % (user,))

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -140,9 +140,7 @@ class Users(Resource):
         else:
 
             with context:
-                new_user = User(**args)
-                db.session.add(new_user)
-            db.session.refresh(new_user)
+                new_user = User.ensure_user(**args)
             AuditLog.user_create_object(
                 log, new_user, msg=f'{new_user.email}', duration=timer.elapsed()
             )

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -17,7 +17,6 @@ from app.extensions.api import Namespace, abort
 import app.extensions.logging as AuditLog
 from app.extensions import is_extension_enabled
 from app.extensions.email import Email
-from app.modules.auth.models import Code, CodeTypes
 
 from . import permissions, schemas, parameters
 from app.modules.users.permissions.types import AccessOperation
@@ -407,12 +406,19 @@ class UserResetPasswordEmail(Resource):
             # Log for development purposes but do not show anything to the API user
             log.warning(f'User with email address {repr(email)} not found')
             return
-        code = Code.get(user, CodeTypes.recover, replace=True)
+        code = user.get_account_recovery_code()
         msg = Email(recipients=[user])
         url_prefix = msg.template_kwargs['site_url_prefix']
         reset_link = urljoin(url_prefix, f'/auth/code/{code.accept_code}')
         msg.template('misc/password_reset', reset_link=reset_link)
         msg.send_message()
+
+
+@api.route('/verify_account_email')
+@api.login_required(oauth_scopes=[])
+class UserVerifyAccountEmail(Resource):
+    def post(self):
+        current_user.send_verify_account_email()
 
 
 if is_module_enabled('asset_groups'):

--- a/app/modules/users/schemas.py
+++ b/app/modules/users/schemas.py
@@ -51,6 +51,7 @@ class UserListSchema(BaseUserSchema):
             User.is_admin.fget.__name__,
             User.in_alpha.fget.__name__,
             User.in_beta.fget.__name__,
+            User.is_email_confirmed.fget.__name__,
             User.profile_fileupload.key,
         )
 

--- a/app/templates/email/en_us/misc/account_verify.jinja2
+++ b/app/templates/email/en_us/misc/account_verify.jinja2
@@ -1,0 +1,14 @@
+<html>
+    <body>
+        <p>Hello {{ site_name }} user,</p>
+
+        <p>
+            Please click on this button to verify your email:
+            <form action="{{ verify_link }}" method="post">
+                <input type="submit" value="Verify Email" />
+            </form>
+        </p>
+
+        <p>The {{ site_name }} team</p>
+    </body>
+</html>

--- a/app/templates/email/en_us/misc/account_verify_subject.jinja2
+++ b/app/templates/email/en_us/misc/account_verify_subject.jinja2
@@ -1,0 +1,1 @@
+{{ site_name }} account email address verification

--- a/tests/modules/auth/resources/test_code.py
+++ b/tests/modules/auth/resources/test_code.py
@@ -11,27 +11,28 @@ def test_reset_password(flask_app_client, researcher_1, request):
     request.addfinalizer(recover.delete)
 
     # Use the recover code without sending a password
-    response = flask_app_client.post(f'/api/v1/auth/code/{recover.accept_code}')
+    response = flask_app_client.post(f'/api/v1/auth/code/{recover.accept_code}.json')
     assert response.status_code == 400
     assert response.json['message'] == 'Empty password not allowed'
 
     # Use the recover code to reset password
     response = flask_app_client.post(
-        f'/api/v1/auth/code/{recover.accept_code}',
+        f'/api/v1/auth/code/{recover.accept_code}.json',
         content_type='application/json',
         data='{"password": "new-password"}',
     )
     assert response.status_code == 200
+    assert response.json['message'] == 'Password successfully set.'
     assert User.find(email=researcher_1.email, password='new-password') == researcher_1
 
     # Use the recover code again
     response = flask_app_client.post(
-        f'/api/v1/auth/code/{recover.accept_code}',
+        f'/api/v1/auth/code/{recover.accept_code}.json',
         content_type='application/json',
         data='{"password": "new-password"}',
     )
     assert response.status_code == 400
-    assert response.json['message'] == f'Code {repr(recover.accept_code)} already used'
+    assert response.json['message'] == 'Code already used'
 
     # Create a recover code that is expired
     expired = Code.get(researcher_1, CodeTypes.recover)
@@ -39,12 +40,12 @@ def test_reset_password(flask_app_client, researcher_1, request):
 
     # Use an expired recover code
     response = flask_app_client.post(
-        f'/api/v1/auth/code/{expired.accept_code}',
+        f'/api/v1/auth/code/{expired.accept_code}.json',
         content_type='application/json',
         data='{"password": "new-password"}',
     )
     assert response.status_code == 400
-    assert response.json['message'] == f'Code {repr(expired.accept_code)} is expired'
+    assert response.json['message'] == 'Code has expired'
 
     # Use a code that does not exist
     response = flask_app_client.post(
@@ -52,5 +53,5 @@ def test_reset_password(flask_app_client, researcher_1, request):
         content_type='application/json',
         data='{"password": "new-password"}',
     )
-    assert response.status_code == 400
+    assert response.status_code == 404
     assert response.json['message'] == "Code '1234' not found"

--- a/tests/modules/users/resources/test_emails.py
+++ b/tests/modules/users/resources/test_emails.py
@@ -23,9 +23,25 @@ def test_reset_password(flask_app_client, researcher_1):
         )
         assert response.status_code == 200
     email = send.call_args[0][0]
+    assert email.recipients == [researcher_1.email]
     all_hrefs = re.findall('href="([^"]*)"', email.html) + re.findall(
         'href=([^"> ]+)', email.html
     )
     code = Code.get(researcher_1, CodeTypes.recover, create=False)
     assert f'http://localhost:84/auth/code/{code.accept_code}' in all_hrefs
-    assert response.status_code == 200
+
+
+def test_verify_account(flask_app_client, researcher_1):
+    url = '/api/v1/users/verify_account_email'
+    with mock.patch('app.extensions.email.mail.send') as send:
+        response = flask_app_client.post(url)
+        assert response.status_code == 401
+
+        with flask_app_client.login(researcher_1):
+            response = flask_app_client.post(url)
+            assert response.status_code == 200
+
+    email = send.call_args[0][0]
+    assert email.recipients == [researcher_1.email]
+    code = Code.get(researcher_1, CodeTypes.email, create=False)
+    assert f'action=http://localhost:84/api/v1/auth/code/{code.accept_code}' in email.html

--- a/tests/modules/users/resources/test_getting_users_info.py
+++ b/tests/modules/users/resources/test_getting_users_info.py
@@ -86,6 +86,7 @@ def test_getting_list_of_users_by_authorized_user(
         'is_admin': False,
         'in_alpha': True,
         'in_beta': False,
+        'is_email_confirmed': False,
         'profile_fileupload': {
             'created': f'{fup.created.isoformat()}+00:00',
             'updated': f'{fup.updated.isoformat()}+00:00',

--- a/tests/modules/users/resources/test_signup.py
+++ b/tests/modules/users/resources/test_signup.py
@@ -280,6 +280,7 @@ def test_new_user_creation_roles_admin(flask_app_client, admin_user, db):
         'is_researcher': True,
         'is_staff': False,
         'is_user_manager': False,
+        'is_email_confirmed': False,
         'location': '',
         'profile_fileupload': None,
         'updated': response.json['updated'],

--- a/tests/modules/users/resources/test_signup.py
+++ b/tests/modules/users/resources/test_signup.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
+from unittest import mock
 import uuid
 import tests.modules.users.resources.utils as user_utils
 from app.modules import is_module_enabled
@@ -39,11 +40,16 @@ def create_new_user(flask_app_client, data, must_succeed=True):
 
 def test_new_user_creation(patch_User_password_scheme, flask_app_client, db):
     # pylint: disable=invalid-name,unused-argument
-    user_guid = create_new_user(
-        flask_app_client,
-        data={'email': 'user1@localhost', 'password': 'user1_password'},
-    )
+    with mock.patch('app.extensions.email.mail.send') as send:
+        user_guid = create_new_user(
+            flask_app_client,
+            data={'email': 'user1@localhost', 'password': 'user1_password'},
+        )
     assert isinstance(user_guid, uuid.UUID)
+    assert send.called
+    email = send.call_args[0][0]
+    assert email.recipients == ['user1@localhost']
+    assert 'verify' in email.html.lower()
 
     # Cleanup
     from app.modules.users.models import User

--- a/tests/modules/users/test_schemas.py
+++ b/tests/modules/users/test_schemas.py
@@ -51,6 +51,7 @@ def test_DetailedUserSchema_dump_user_instance(user_instance):
         'is_admin',
         'in_alpha',
         'in_beta',
+        'is_email_confirmed',
         'profile_fileupload',
         'affiliation',
         'location',


### PR DESCRIPTION
- Use User.ensure_user in user creation API

  This is so we have a function for creating a user which can include
  sending account verification emails.

- APIs for account verification emails

  For re-sending verification emails:
  
  ```
  POST /api/v1/users/<user-guid>/verify_account_email
  ```
  
  The email looks like:
  
  > Hello Codex user,
  >
  > Please click on this link to verify your email: http://localhost:84/auth/code/B466F3E0145CB540C84481830C202D1E099A5D6CB53DF1BDB62D886F67918F9F
  >
  > The Codex team
  
  For verifying the email:
  
  ```
  POST /api/v1/auth/code/<code>
  ```
