### PR TITLE
Add status=200 to /api/v1/auth/code/<code> redirects

### DIFF
--- a/app/modules/auth/resources.py
+++ b/app/modules/auth/resources.py
@@ -245,6 +245,7 @@ class CodeReceived(Resource):
         if url_args.get('message'):
             if is_json:
                 abort(400, url_args['message'])
+            url_args['status'] = 400
             return redirect(f'{redirect_uri}?{urlencode(url_args)}')
 
         try:
@@ -256,6 +257,7 @@ class CodeReceived(Resource):
             try:
                 code.user.set_password(data.get('password', ''))
                 url_args['message'] = 'Password successfully set.'
+                url_args['status'] = 200
             except Exception as e:
                 code.response = None
                 with db.session.begin():
@@ -266,6 +268,7 @@ class CodeReceived(Resource):
             # nothing to do because User.is_email_confirmed looks into Code for
             # the user filtered by CodeTypes.email is_resolved
             url_args['message'] = 'Email successfully verified.'
+            url_args['status'] = 200
         else:
             abort(404, f'Unrecognized code type: {code.code_type}')
 

--- a/tests/modules/auth/resources/test_code.py
+++ b/tests/modules/auth/resources/test_code.py
@@ -67,7 +67,7 @@ def test_verify_account(flask_app_client, researcher_1, request):
     assert response.status_code == 302
     assert (
         response.headers['Location']
-        == 'http://localhost/email_verified?message=Email+successfully+verified.'
+        == 'http://localhost/email_verified?message=Email+successfully+verified.&status=200'
     )
     assert researcher_1.is_email_confirmed is True
 
@@ -76,7 +76,7 @@ def test_verify_account(flask_app_client, researcher_1, request):
     assert response.status_code == 302
     assert (
         response.headers['Location']
-        == 'http://localhost/email_verified?message=Code+already+used'
+        == 'http://localhost/email_verified?message=Code+already+used&status=400'
     )
 
     # Create a verify code that is expired
@@ -88,7 +88,7 @@ def test_verify_account(flask_app_client, researcher_1, request):
     assert response.status_code == 302
     assert (
         response.headers['Location']
-        == 'http://localhost/email_verified?message=Code+has+expired'
+        == 'http://localhost/email_verified?message=Code+has+expired&status=400'
     )
 
     # Use a code that does not exist


### PR DESCRIPTION
For account verification, the api used to redirect to `/email_verified`
with just `message=Email+successfully+verified.`, now this is adding
`status=200` (or `status=400`) to indicate if the API was successful or
not.

