### PR TITLE
Increase MAX_CONTENT_LENGTH to 30MB

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -167,7 +167,7 @@ class BaseConfig(FlaskConfigOverrides, RedisConfig):
     PREMAILER_CACHE_MAXSIZE = 1024
     CONFIG_MODEL = 'zebra'
 
-    MAX_CONTENT_LENGTH = 16 * 1024 * 1024  # Maximum size of 16MB
+    MAX_CONTENT_LENGTH = 30 * 1024 * 1024  # Maximum size of 30MB
 
     PERMANENT_SESSION_LIFETIME = datetime.timedelta(days=7)
     SESSION_COOKIE_SECURE = False


### PR DESCRIPTION
When uploading images bigger than 16MB to create a sighting:

```
PATCH /api/v1/tus/<tus-id>
```

returns 413 Request Entity Too Large

