### PR TITLE
DEX 857: Add Flower celery monitoring service to the composition

### DIFF
--- a/.env
+++ b/.env
@@ -84,3 +84,10 @@ LOG_WIDTH=""
 # Sentry error telemetry
 SENTRY_DSN_PRODUCTION=""
 SENTRY_DSN_DEVELOPMENT=""
+
+# ########################################
+#   Flower
+# ########################################
+
+FLOWER_USER=admin
+FLOWER_PASSWORD=4dm1n

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -26,6 +26,9 @@ Flask-Paranoid
 
 flask-restx>=0.2.0
 Flask-SQLAlchemy>=2.4,<3
+
+flower
+
 gevent
 
 gitpython

--- a/docker-compose.codex.yml
+++ b/docker-compose.codex.yml
@@ -252,6 +252,8 @@ services:
       WILDBOOK_DB_USER: "${WILDBOOK_DB_USER}"
       WILDBOOK_DB_PASSWORD: "${WILDBOOK_DB_PASSWORD}"
       LOG_WIDTH: ${LOG_WIDTH}
+      FLOWER_USER: "${FLOWER_USER}"
+      FLOWER_PASSWORD: "${FLOWER_PASSWORD}"
 
   celery_beat:
     image: wildme/houston:latest
@@ -286,6 +288,25 @@ services:
     networks:
       - intranet
     environment: *houston-environment
+
+  flower:
+    image: wildme/houston:latest
+    build: *houston-build
+    command: ["celery", "-A", "app.extensions.celery.celery", "flower", "--basic_auth=${FLOWER_USER}:${FLOWER_PASSWORD}"]
+    depends_on:
+      houston:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://${FLOWER_USER}:${FLOWER_PASSWORD}@localhost:5555/metrics"]
+      interval: 10s
+      timeout: 5s
+      retries: 60
+    volumes: *houston-volumes
+    networks:
+      - intranet
+    environment: *houston-environment
+    ports:
+      - "86:5555"
 
   dev-frontend:
     # this component is intended to only be used in development

--- a/docker-compose.mws.yml
+++ b/docker-compose.mws.yml
@@ -252,6 +252,25 @@ services:
       - intranet
     environment: *houston-environment
 
+  flower:
+    image: wildme/houston:latest
+    build: *houston-build
+    command: ["celery", "-A", "app.extensions.celery.celery", "flower", "--basic_auth=${FLOWER_USER}:${FLOWER_PASSWORD}"]
+    depends_on:
+      houston:
+        condition: service_healthy
+    healthcheck:
+      test: [ "CMD", "curl", "-f", "http://${FLOWER_USER}:${FLOWER_PASSWORD}@localhost:5555/metrics"]
+      interval: 10s
+      timeout: 5s
+      retries: 60
+    volumes: *houston-volumes
+    networks:
+      - intranet
+    environment: *houston-environment
+    ports:
+      - "86:5555"
+
   dev-frontend:
     # this component is intended to only be used in development
     image: node:lts


### PR DESCRIPTION
This will allow us to inspect celery workers and tasks.

See the basic features available in the flower documentation: https://flower.readthedocs.io/en/latest/

Task inspection interface:
<img width="1696" alt="Screen Shot 2022-03-23 at 14 03 27" src="https://user-images.githubusercontent.com/168470/159795721-46e995f3-4840-43c1-998b-241b42ea8cf3.png">
Note, this is looking at an empty houston instance. So the times are short because nothing has happened in the instance. But it shows the basic idea.