### PR TITLE
Add ElasticsearchModel.elasticsearchable when elasticsearch is disabled

### DIFF
--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -370,7 +370,7 @@ if elasticsearch is None:
         return context
 
     class ElasticsearchModel(object):
-        pass
+        elasticsearchable = True
 
 else:
 


### PR DESCRIPTION
When elasticsearch module is disabled, tests return errors like:

```
AttributeError: "elasticsearchable" is not a valid field for <AssetGroup(guid=56618dc2-ab0d-46c5-aee1-c01fea174ce0, )>.
```

The easiest way is just to add `elasticsearchable` to the dummy
ElasticsearchModel class.

