### PR TITLE
Use SERVER_NAME and PREFERRED_URL_SCHEME in the composition

### DIFF
--- a/.dockerfiles/docker-healthcheck.sh
+++ b/.dockerfiles/docker-healthcheck.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+
+curl -f "http://0.0.0.0:5000/api/v1/site-settings/heartbeat" -H "Host: $SERVER_NAME"

--- a/.env
+++ b/.env
@@ -41,9 +41,9 @@ WBIA_DB_DIR=/data/db
 HOUSTON_DB_NAME=houston
 HOUSTON_DB_USER=houston
 HOUSTON_DB_PASSWORD=development
-HOUSTON_URL=http://houston:5000/
-MAIL_BASE_URL=http://localhost:84/
 WILDBOOK_DB_HOST=db
+SERVER_NAME=localhost
+PREFERRED_URL_SCHEME=http
 
 #: i.e. postgresql://${HOUSTON_DB_USER}:${HOUSTON_DB_PASSWORD}@db/${HOUSTON_DB_NAME}
 SQLALCHEMY_DATABASE_URI=postgresql://houston:development@db/houston

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Run docker-compose
         run: |
           set -ex
-          docker-compose up -d db redis elasticsearch elasticsearch2 elasticsearch3 acm edm houston celery_beat celery_worker dev-frontend www
+          docker-compose up -d db redis elasticsearch elasticsearch2 elasticsearch3 acm edm houston celery_beat celery_worker dev-frontend localhost
 
       - name: Install dependencies
         run: |
@@ -79,12 +79,12 @@ jobs:
               exit 1
             fi
             # Wait for houston to be ready
-            wget --tries=1 -O - http://localhost:83/api/v1/users/admin_user_initialized && break
+            wget --tries=1 -O - --header='Host: localhost' http://127.0.0.1:83/api/v1/users/admin_user_initialized && break
           done
           # Wait for frontend to be ready
           while sleep 10
           do
-            wget --tries=1 -O - http://localhost:84/ && break
+            wget --tries=1 -O - http://localhost/ && break
           done
           # Wait for acm to be ready
           while sleep 10

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -107,7 +107,7 @@ jobs:
             then
               exit 1
             fi
-            wget --tries=1 -O - http://localhost:83/houston/ && break
+            wget --tries=1 -O - --header="Host: localhost" http://localhost:83/houston/ && break
           done
 
       - name: Run tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,7 @@ VOLUME [ "${DATA_VOLUME}" ]
 ENV HOUSTON_DOTENV ${DATA_ROOT}/.env
 
 COPY ./.dockerfiles/docker-entrypoint.sh /docker-entrypoint.sh
+COPY ./.dockerfiles/docker-healthcheck.sh /docker-healthcheck.sh
 
 COPY ./.dockerfiles/embed.sh /bin/embed
 

--- a/app/extensions/tus/README.md
+++ b/app/extensions/tus/README.md
@@ -6,4 +6,3 @@ spotty history.  It is does the backend work of the Tus transfer.
 We needed to make a couple of customizations:
 
 * adding `request` and `app` as args to the call to `filename = self.upload_file_handler_cb()`
-* helping `create_url()` understand **X-Forwarded-Proto** so that *https* did not turn into *http*

--- a/app/modules/app_ui.py
+++ b/app/modules/app_ui.py
@@ -3,6 +3,7 @@
 import datetime
 import logging
 from functools import wraps
+from urllib.parse import urljoin
 
 # from app.modules.users.permissions import PasswordRequiredPermissionMixin
 import flask
@@ -46,7 +47,7 @@ def init_app(app):
 def _render_template(template, **kwargs):
     now = datetime.datetime.now(tz=current_app.config.get('TIMEZONE'))
     config = {
-        'base_url': current_app.config.get('BASE_URL'),
+        'base_url': urljoin(url_for('backend.home'), '/'),
         'google_analytics_tag': current_app.config.get('GOOGLE_ANALYTICS_TAG'),
         'stripe_public_key': current_app.config.get('STRIPE_PUBLIC_KEY'),
         'year': now.year,

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -3,7 +3,7 @@
 Assets database models
 --------------------
 """
-from flask import current_app
+from flask import current_app, url_for
 from functools import total_ordering
 import pathlib
 
@@ -228,7 +228,9 @@ class Asset(db.Model, HoustonModel):
 
     @property
     def src(self):
-        return '/api/v1/assets/src/%s' % (str(self.guid),)
+        return url_for(
+            'api.assets_asset_src_u_by_id_2', asset_guid=str(self.guid), _external=False
+        )
 
     @property
     @module_required('annotations', resolve='warn', default=-1)
@@ -333,9 +335,9 @@ class Asset(db.Model, HoustonModel):
         return dmeta
 
     def get_image_url(self):
-        from app.utils import site_url_prefix
-
-        return f'{site_url_prefix()}/api/v1/assets/src/{self.guid}'
+        return url_for(
+            'api.assets_asset_src_u_by_id_2', asset_guid=self.guid, _external=True
+        )
 
     # right now we _only_ use `derived` values, so not much logic here
     # TODO alter when we allow ways to override derived (or have more complex logic based on orientation)

--- a/app/modules/fileuploads/models.py
+++ b/app/modules/fileuploads/models.py
@@ -8,7 +8,7 @@ import uuid
 import os
 import shutil
 
-from flask import current_app
+from flask import current_app, url_for
 from PIL import Image
 
 from app.extensions import db, HoustonModel
@@ -151,7 +151,11 @@ class FileUpload(db.Model, HoustonModel):
 
     @property
     def src(self):
-        return '/api/v1/fileuploads/src/%s' % (str(self.guid),)
+        return url_for(
+            'api.fileuploads_file_upload_src_u_by_id_2',
+            fileupload_guid=str(self.guid),
+            _external=False,
+        )
 
     def derive_mime_type(self):
         import magic

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -5,7 +5,7 @@ Individuals database models
 """
 
 from app.extensions import FeatherModel, db
-from flask import current_app
+from flask import current_app, url_for
 import uuid
 import logging
 import app.extensions.logging as AuditLog
@@ -293,13 +293,17 @@ class Individual(db.Model, FeatherModel):
         return last_enc.created
 
     def get_featured_image_url(self):
-        from app.utils import site_url_prefix
-
         featured_image_url = None
         featured_asset_guid = self.get_featured_asset_guid()
         if featured_asset_guid:
+            # FIXME Does this route exist?
             featured_image_url = (
-                f'{site_url_prefix()}/api/v1/annotations/{featured_asset_guid}/image'
+                url_for(
+                    'api.annotations_annotation_by_id',
+                    annotation_guid=str(featured_asset_guid),
+                    _external=True,
+                )
+                + '/image'
             )
         return featured_image_url
 

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -7,7 +7,7 @@ import enum
 import logging
 import uuid
 from datetime import datetime  # NOQA
-from flask import current_app
+from flask import current_app, url_for
 from flask_restx_patched._http import HTTPStatus
 
 from app.extensions import FeatherModel, HoustonModel, db
@@ -665,12 +665,13 @@ class Sighting(db.Model, FeatherModel):
             return {}
 
         from app.extensions.acm import to_acm_uuid
-
-        base_url = current_app.config.get('BASE_URL')
         from app.modules.ia_config_reader import IaConfig
 
-        callback_url = (
-            f'{base_url}api/v1/sightings/{str(self.guid)}/sage_identified/{str(job_uuid)}'
+        callback_url = url_for(
+            'api.sightings_sighting_sage_identified',
+            sighting_guid=str(self.guid),
+            job_guid=str(job_uuid),
+            _external=True,
         )
         ia_config_reader = IaConfig(current_app.config.get('CONFIG_MODEL'))
         try:

--- a/app/modules/site_settings/resources.py
+++ b/app/modules/site_settings/resources.py
@@ -305,9 +305,11 @@ class MainConfiguration(Resource):
             ss_json = {}
             for ss in houston_settings:
                 if ss.file_upload is not None:
-                    ss_json[
-                        ss.key
-                    ] = f'/api/v1/fileuploads/src/{str(ss.file_upload.guid)}'
+                    ss_json[ss.key] = url_for(
+                        'api.fileuploads_file_upload_src_u_by_id_2',
+                        fileupload_guid=str(ss.file_upload.guid),
+                        _external=False,
+                    )
             data['response']['configuration']['site.images'] = ss_json
 
             for key in SiteSetting.get_setting_keys():

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -5,10 +5,9 @@ User database models
 """
 import enum
 import logging
-from urllib.parse import urljoin
 import uuid
 
-from flask import current_app
+from flask import current_app, url_for
 from sqlalchemy_utils import types as column_types
 
 from flask_login import current_user  # NOQA
@@ -740,8 +739,11 @@ class User(db.Model, FeatherModel, UserEDMMixin):
     def send_verify_account_email(self):
         code = self.get_email_confirmation_code()
         msg = Email(recipients=[self])
-        url_prefix = msg.template_kwargs['site_url_prefix']
-        verify_link = urljoin(url_prefix, f'/api/v1/auth/code/{code.accept_code}')
+        verify_link = url_for(
+            'api.auth_code_received',
+            code_string_dot_json=code.accept_code,
+            _external=True,
+        )
         msg.template('misc/account_verify', verify_link=verify_link)
         msg.send_message()
 

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -8,7 +8,7 @@ import json
 import logging
 from urllib.parse import urljoin
 
-from flask import current_app, send_file, request
+from flask import current_app, send_file, request, url_for
 from flask_login import current_user
 from flask_restx_patched import Resource
 from flask_restx_patched._http import HTTPStatus
@@ -431,8 +431,11 @@ class UserResetPasswordEmail(Resource):
             return
         code = user.get_account_recovery_code()
         msg = Email(recipients=[user])
-        url_prefix = msg.template_kwargs['site_url_prefix']
-        reset_link = urljoin(url_prefix, f'/auth/code/{code.accept_code}')
+        # /auth/code/ instead of /api/v1/auth/code/ because we want the user to
+        # go to the frontend page
+        reset_link = urljoin(
+            url_for('api.root', _external=True), f'/auth/code/{code.accept_code}'
+        )
         msg.template('misc/password_reset', reset_link=reset_link)
         msg.send_message()
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -39,20 +39,6 @@ def to_ascii(val):
     return unicodedata.normalize('NFKD', val).encode('ascii', 'ignore').decode()
 
 
-# generally speaking, we should use flask url_for() method to construct urls, i guess.  but this seems handy to have?
-#   see:   https://flask.palletsprojects.com/en/2.0.x/quickstart/#url-building
-#   and:   https://flask.palletsprojects.com/en/2.0.x/api/#flask.url_for
-def site_url_prefix():
-    from flask import current_app
-
-    scheme = current_app.config.get('PREFERRED_URL_SCHEME', 'https')
-    host = current_app.config.get('SERVER_NAME', 'codex.example.com')
-    if not scheme or not host:
-        scheme = 'http'
-        host = 'localhost:84'  # development
-    return f'{scheme}://{host}'.lower()
-
-
 def site_email_hostname():
     from flask import current_app
 

--- a/config/codex.py
+++ b/config/codex.py
@@ -83,9 +83,6 @@ class BaseCodexConfig(
 class ProductionConfig(BaseCodexConfig):
     TESTING = False
 
-    BASE_URL = os.environ.get('HOUSTON_URL')
-
-    MAIL_BASE_URL = os.environ.get('MAIL_BASE_URL', BASE_URL)
     MAIL_OVERRIDE_RECIPIENTS = None
     MAIL_ERROR_RECIPIENTS = [
         'mail-errors@wildme.org',
@@ -97,9 +94,6 @@ class ProductionConfig(BaseCodexConfig):
 class DevelopmentConfig(BaseCodexConfig):
     DEBUG = True
 
-    BASE_URL = os.environ.get('HOUSTON_URL', 'https://wildme.ngrok.io/')
-
-    MAIL_BASE_URL = os.environ.get('MAIL_BASE_URL', BASE_URL)
     MAIL_OVERRIDE_RECIPIENTS = [
         'testing@wildme.org',
     ]

--- a/config/mws.py
+++ b/config/mws.py
@@ -72,9 +72,6 @@ class BaseMWSConfig(
 class ProductionConfig(BaseMWSConfig):
     TESTING = False
 
-    BASE_URL = os.environ.get('HOUSTON_URL')
-
-    MAIL_BASE_URL = BASE_URL
     MAIL_OVERRIDE_RECIPIENTS = None
     MAIL_ERROR_RECIPIENTS = [
         'mail-errors@wildme.org',
@@ -86,9 +83,6 @@ class ProductionConfig(BaseMWSConfig):
 class DevelopmentConfig(BaseMWSConfig):
     DEBUG = True
 
-    BASE_URL = os.environ.get('HOUSTON_URL', 'https://wildme.ngrok.io/')
-
-    MAIL_BASE_URL = BASE_URL
     MAIL_OVERRIDE_RECIPIENTS = [
         'testing@wildme.org',
     ]

--- a/docker-compose.codex.yml
+++ b/docker-compose.codex.yml
@@ -49,7 +49,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+      test: ["CMD-SHELL", "curl --silent --fail 127.0.0.1:9200/_cluster/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -77,7 +77,7 @@ services:
     depends_on:
       - elasticsearch
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+      test: ["CMD-SHELL", "curl --silent --fail 127.0.0.1:9200/_cluster/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -101,7 +101,7 @@ services:
     depends_on:
       - elasticsearch2
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+      test: ["CMD-SHELL", "curl --silent --fail 127.0.0.1:9200/_cluster/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -126,7 +126,7 @@ services:
       elasticsearch:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail localhost:5601/status || exit 1"]
+      test: ["CMD-SHELL", "curl --silent --fail 127.0.0.1:5601/status || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -167,7 +167,7 @@ services:
       db:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/dbconnections.jsp"]
+      test: [ "CMD", "curl", "-f", "http://127.0.0.1:8080/dbconnections.jsp"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -202,7 +202,7 @@ services:
       elasticsearch:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:5000/api/v1/site-settings/heartbeat"]
+      test: ['CMD', '/docker-healthcheck.sh']
       interval: 10s
       timeout: 5s
       retries: 60
@@ -210,6 +210,7 @@ services:
       - houston-var:/data
       # These are added for development. Do not mount these in production.
       - .dockerfiles/docker-entrypoint.sh:/docker-entrypoint.sh
+      - .dockerfiles/docker-healthcheck.sh:/docker-healthcheck.sh
       - .dockerfiles/docker-entrypoint-init.d.codex:/docker-entrypoint-init.d
       - .dockerfiles/docker-entrypoint-always-init.d:/docker-entrypoint-always-init.d
       # FIXME: pull in development code while working on bringing up the container
@@ -222,6 +223,9 @@ services:
       - "83:5000"
     environment: &houston-environment
       HOUSTON_APP_CONTEXT: codex
+      # exposed service is 'localhost' using default port 80
+      SERVER_NAME: "${SERVER_NAME}"
+      PREFERRED_URL_SCHEME: "${PREFERRED_URL_SCHEME}"
       FLASK_ENV: development
       SQLALCHEMY_DATABASE_URI: "${SQLALCHEMY_DATABASE_URI}"
       TEST_DATABASE_URI: "${TEST_DATABASE_URI}"
@@ -230,8 +234,6 @@ services:
       EDM_AUTHENTICATIONS_PASSWORD__DEFAULT: "${EDM_AUTHENTICATIONS_PASSWORD__DEFAULT}"
       ACM_AUTHENTICATIONS_URI__DEFAULT: "${ACM_AUTHENTICATIONS_URI__DEFAULT}"
       ELASTICSEARCH_HOSTS: "${ELASTICSEARCH_HOSTS}"
-      HOUSTON_URL: "${HOUSTON_URL}"
-      MAIL_BASE_URL: "${MAIL_BASE_URL}"
       REDIS_HOST: redis
       REDIS_PASSWORD: "seekret_development_password"
       GITLAB_PROTO: "${GITLAB_PROTO}"
@@ -319,7 +321,7 @@ services:
       houston:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://${FLOWER_USER}:${FLOWER_PASSWORD}@localhost:5555/metrics"]
+      test: [ "CMD", "curl", "-f", "http://${FLOWER_USER}:${FLOWER_PASSWORD}@127.0.0.1:5555/metrics"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -336,7 +338,7 @@ services:
     working_dir: /code
     entrypoint: "/docker-entrypoint.sh"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:3000/"]
+      test: [ "CMD", "curl", "-f", "http://127.0.0.1:3000/"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -351,7 +353,7 @@ services:
       HOST: "0.0.0.0"
       PORT: "84"
 
-  www:
+  localhost:
     image: nginx:latest
     depends_on:
       edm:
@@ -363,7 +365,7 @@ services:
       dev-frontend:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:80/"]
+      test: [ "CMD", "curl", "-f", "http://localhost/"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -373,6 +375,8 @@ services:
       - intranet
       - frontend
     ports:
+      - "80:80"
+      # BBB deprecated in favor or port 80, remains for backward compat
       - "84:80"
 
 networks:

--- a/docker-compose.mws.yml
+++ b/docker-compose.mws.yml
@@ -49,7 +49,7 @@ services:
       redis:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+      test: ["CMD-SHELL", "curl --silent --fail 127.0.0.1:9200/_cluster/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -77,7 +77,7 @@ services:
     depends_on:
       - elasticsearch
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+      test: ["CMD-SHELL", "curl --silent --fail 127.0.0.1:9200/_cluster/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -101,7 +101,7 @@ services:
     depends_on:
       - elasticsearch2
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail localhost:9200/_cluster/health || exit 1"]
+      test: ["CMD-SHELL", "curl --silent --fail 127.0.0.1:9200/_cluster/health || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -126,7 +126,7 @@ services:
       elasticsearch:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "curl --silent --fail localhost:5601/status || exit 1"]
+      test: ["CMD-SHELL", "curl --silent --fail 127.0.0.1:5601/status || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -171,7 +171,7 @@ services:
       elasticsearch:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:5000/api/v1/site-settings/heartbeat"]
+      test: ['CMD', '/docker-healthcheck.sh']
       interval: 10s
       timeout: 5s
       retries: 60
@@ -179,6 +179,7 @@ services:
       - houston-var:/data
       # These are added for development. Do not mount these in production.
       - .dockerfiles/docker-entrypoint.sh:/docker-entrypoint.sh
+      - .dockerfiles/docker-healthcheck.sh:/docker-healthcheck.sh
       - .dockerfiles/docker-entrypoint-init.d.mws:/docker-entrypoint-init.d
       - .dockerfiles/docker-entrypoint-always-init.d:/docker-entrypoint-always-init.d
       # FIXME: pull in development code while working on bringing up the container
@@ -191,12 +192,14 @@ services:
       - "83:5000"
     environment: &houston-environment
       HOUSTON_APP_CONTEXT: mws
+      # exposed service is 'localhost' using default port 80
+      SERVER_NAME: "${SERVER_NAME}"
+      PREFERRED_URL_SCHEME: "${PREFERRED_URL_SCHEME}"
       FLASK_ENV: development
       SQLALCHEMY_DATABASE_URI: "${SQLALCHEMY_DATABASE_URI}"
       TEST_DATABASE_URI: "${TEST_DATABASE_URI}"
       ACM_AUTHENTICATIONS_URI__DEFAULT: "${ACM_AUTHENTICATIONS_URI__DEFAULT}"
       ELASTICSEARCH_HOSTS: "${ELASTICSEARCH_HOSTS}"
-      HOUSTON_URL: "${HOUSTON_URL}"
       REDIS_HOST: redis
       REDIS_PASSWORD: "seekret_development_password"
       GITLAB_PROTO: "${GITLAB_PROTO}"
@@ -282,7 +285,7 @@ services:
       houston:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://${FLOWER_USER}:${FLOWER_PASSWORD}@localhost:5555/metrics"]
+      test: [ "CMD", "curl", "-f", "http://${FLOWER_USER}:${FLOWER_PASSWORD}@127.0.0.1:5555/metrics"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -299,7 +302,7 @@ services:
     working_dir: /code
     entrypoint: "/docker-entrypoint.sh"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:3000/"]
+      test: [ "CMD", "curl", "-f", "http://127.0.0.1:3000/"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -314,7 +317,7 @@ services:
       HOST: "0.0.0.0"
       PORT: "84"
 
-  www:
+  localhost:
     image: nginx:latest
     depends_on:
       # acm:
@@ -324,7 +327,7 @@ services:
       dev-frontend:
         condition: service_healthy
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:80/"]
+      test: [ "CMD", "curl", "-f", "http://localhost/"]
       interval: 10s
       timeout: 5s
       retries: 60
@@ -334,6 +337,8 @@ services:
       - intranet
       - frontend
     ports:
+      - "80:80"
+      # BBB deprecated in favor or port 80, remains for backward compat
       - "84:80"
 
 networks:

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -15,7 +15,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 
 TIMEOUT = int(os.getenv('TIMEOUT', 20))
 POLL_FREQUENCY = int(os.getenv('POLL_FREQUENCY', 1))
-CODEX_URL = os.getenv('CODEX_URL', 'http://localhost:84/')
+CODEX_URL = os.getenv('CODEX_URL', 'http://localhost/')
 ADMIN_EMAIL = os.getenv('ADMIN_EMAIL', 'root@example.org')
 ADMIN_PASSWORD = os.getenv('ADMIN_PASSWORD', 'password')
 ADMIN_NAME = os.getenv('ADMIN_NAME', 'Test admin')

--- a/scripts/tests/run_tasks_for_coverage.sh
+++ b/scripts/tests/run_tasks_for_coverage.sh
@@ -34,9 +34,9 @@ coverage run --append `which invoke` app.boilerplates.crud-module --module-name=
 coverage run --append `which invoke` app.boilerplates.crud-module --module-name=testapp
 
 # test app.config.*
-coverage run --append `which invoke` app.config.set --key=BASE_URL --value=http://localhost/
+coverage run --append `which invoke` app.config.set --key=MAX_CONTENT_LENGTH --value=1000000
 coverage run --append `which invoke` app.config.list
-coverage run --append `which invoke` app.config.forget --key=BASE_URL
+coverage run --append `which invoke` app.config.forget --key=MAX_CONTENT_LENGTH
 coverage run --append `which invoke` app.config.show
 
 # test interpreter shells

--- a/tests/modules/asset_groups/resources/test_create_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_create_asset_group.py
@@ -599,7 +599,7 @@ def test_create_asset_group_repeat_detection(
             'labeler_model_tag',
         }
         assert params['image_uuid_list'] == json.dumps(
-            [f'houston+http://houston:5000/api/v1/assets/src_raw/{asset_guid}']
+            [f'houston+http://localhost/api/v1/assets/src_raw/{asset_guid}']
         )
         job_uuid = params['jobid']
         assert ags1.stage == AssetGroupSightingStage.detection

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -513,13 +513,13 @@ def create_asset_group_sim_sage_init_resp(
             assert params['endpoint'] == '/api/engine/detect/cnn/lightnet/'
             assert re.match('[a-f0-9-]{36}', params['jobid'])
             assert re.match(
-                r'houston\+http://houston:5000/api/v1/asset_groups/sighting/[a-f0-9-]{36}/sage_detected/'
+                r'houston\+http://localhost/api/v1/asset_groups/sighting/[a-f0-9-]{36}/sage_detected/'
                 + params['jobid'],
                 params['callback_url'],
             )
             assert all(
                 re.match(
-                    r'houston\+http://houston:5000/api/v1/assets/src_raw/[a-f0-9-]{36}',
+                    r'houston\+http://localhost/api/v1/assets/src_raw/[a-f0-9-]{36}',
                     uri,
                 )
                 for uri in json.loads(params['image_uuid_list'])

--- a/tests/modules/users/resources/test_emails.py
+++ b/tests/modules/users/resources/test_emails.py
@@ -28,7 +28,7 @@ def test_reset_password(flask_app_client, researcher_1):
         'href=([^"> ]+)', email.html
     )
     code = Code.get(researcher_1, CodeTypes.recover, create=False)
-    assert f'http://localhost:84/auth/code/{code.accept_code}' in all_hrefs
+    assert f'http://localhost/auth/code/{code.accept_code}' in all_hrefs
 
 
 def test_verify_account(flask_app_client, researcher_1):
@@ -44,4 +44,4 @@ def test_verify_account(flask_app_client, researcher_1):
     email = send.call_args[0][0]
     assert email.recipients == [researcher_1.email]
     code = Code.get(researcher_1, CodeTypes.email, create=False)
-    assert f'action=http://localhost:84/api/v1/auth/code/{code.accept_code}' in email.html
+    assert f'action=http://localhost/api/v1/auth/code/{code.accept_code}' in email.html

--- a/tests/test_tus.py
+++ b/tests/test_tus.py
@@ -214,11 +214,10 @@ def test_tus_corner_cases(flask_app, flask_app_client, file_upload_filename):
             'Upload-Metadata': f'filename {encoded_filename}',
             'Upload-Length': len(a_txt),
             'Tus-Resumable': '1.0.0',
-            'X-Forwarded-Proto': 'https',
         },
     )
     assert response.status_code == 201
-    assert response.headers['Location'].startswith('https://')
+    assert response.headers['Location'].startswith('http://localhost/api/v1/tus/')
 
     path = urllib.parse.urlparse(response.headers['Location']).path
     filename = path.split('/')[-1]


### PR DESCRIPTION
- Remove `BASE_URL` and `MAIL_BASE_URL` and change code to use
  `flask.url_for` to generate urls
- Rename the nginx service from www to localhost
- Add port forwarding 80 to the nginx service so now the site is
  accessible at http://localhost/
- Change all the `localhost` to `127.0.0.1` in docker-compose
  healthchecks, as `localhost` is now the name of the nginx service

This attempts to use the `SERVER_NAME` and `PREFERRED_URL_SCHEME`
environment variables. This is a move towards deprecating the
`HOUSTON_URL` environment variable that sets the `BASE_URL`
configuration setting. See also
[DEX-695 Obsolete the BASE_URL configuration
setting](https://wildme.atlassian.net/browse/DEX-695)

One downside of this change is that `SERVER_NAME` setting has special
behavior within Werkzeug. The server, much like nginx or any other
server, will only serve for the given name; so the `Host:
$SERVER_NAME` request header must be supplied when making requests
within the houston container if trying to directly contact the service
without the reverse proxy.

On the upside, because we tell Werkzeug to serve under this name,
we must also be able to actual server under the name and share it with
other services (i.e. ACM in the callback url). To do this I've worked
around the issue by utilizing the name `localhost` for both internal
(to the composition's network) and external usage. For example,
requesting `http://localhost/api/v1/users/me` will work both inside the
container and outside of it.

Using this change will mean the composition is serving very similar to
how it would be served in production (or at least how Flask likes to
be served in production). And thus no workaround, other than the
service named `localhost` added in this change, will need to be
present. That means cleaner code with less special snowflakes! Yay!

