### PR TITLE
319 individual validation for flatfile

### DIFF
--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -782,3 +782,15 @@ class IndividualDebugByID(Resource):
             return {}
 
         return individual.get_debug_json()
+
+
+@api.route('/name_validate')
+class IndividualNameValidate(Resource):
+    def post(self):
+        from flask_login import current_user
+
+        if not current_user or current_user.is_anonymous:
+            abort(code=401)
+        if not isinstance(request.json, list):
+            abort(message='must be passed a list of individual names', code=500)
+

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -783,6 +783,7 @@ class IndividualDebugByID(Resource):
 
         return individual.get_debug_json()
 
+
 @api.route('/validate')
 class FlatfileNameValidation(Resource):
     # values passed in from flatfile are val/index pairs:

--- a/app/modules/names/models.py
+++ b/app/modules/names/models.py
@@ -25,6 +25,9 @@ class NamePreferringUsersJoin(db.Model, HoustonModel):
     user = db.relationship('User')
 
 
+DEFAULT_NAME_CONTEXT = 'default_name'
+
+
 class Name(db.Model, HoustonModel, Timestamp):
     """
     Names database model.  For a name (one of possibly many) on an Individual.

--- a/tests/modules/individuals/resources/test_individual_names.py
+++ b/tests/modules/individuals/resources/test_individual_names.py
@@ -412,7 +412,7 @@ def test_name_validation(
 
     flatfile_query = [
         ['Zebra Prime', 0],
-        ['Prim', 1],
+        ['Big Dog', 1],
         ['Zebra Omega', 4],
         ['Jennifer', 100],
     ]
@@ -440,7 +440,7 @@ def test_name_validation(
         ],
         [
             {
-                'value': 'Prim',
+                'value': 'Big Dog',
                 'info': [
                     {
                         'message': 'This is a new name and submission will create a new individual',

--- a/tests/modules/individuals/resources/utils.py
+++ b/tests/modules/individuals/resources/utils.py
@@ -217,3 +217,22 @@ def merge_conflicts(
         response_200=set(),
     )
     return resp.json
+
+
+def validate_names(
+    flask_app_client,
+    user,
+    name_list,
+    auth_scopes=('individuals:read',),
+    expected_status_code=200,
+):
+    resp = test_utils.post_via_flask(
+        flask_app_client,
+        user,
+        scopes=auth_scopes,
+        path=f'/api/v1/individuals/validate',
+        data={name_list},
+        expected_status_code=expected_status_code,
+        response_200=set(),
+    )
+    return resp

--- a/tests/modules/individuals/resources/utils.py
+++ b/tests/modules/individuals/resources/utils.py
@@ -222,7 +222,7 @@ def merge_conflicts(
 def validate_names(
     flask_app_client,
     user,
-    name_list,
+    names_flatfile,
     auth_scopes=('individuals:read',),
     expected_status_code=200,
 ):
@@ -230,9 +230,10 @@ def validate_names(
         flask_app_client,
         user,
         scopes=auth_scopes,
-        path=f'/api/v1/individuals/validate',
-        data={name_list},
+        path='/api/v1/individuals/validate',
+        data=names_flatfile,
         expected_status_code=expected_status_code,
         response_200=set(),
+        returns_list=True,
     )
     return resp


### PR DESCRIPTION
This adds a new endpoint at `individual/validate` for bulk import individual name validation by the flatfile frontend library, conforming with [this guide for flatfile developers](https://flatfile.com/developers/react/data-hooks/).

The endpoint takes a list of name values and returns validation info for each (both input and output are formatted as required by flatfile, as tuples of [value, index corresponding to input form]). As discussed with the team, we are only validating _default context_ name values. To facilitate this, I added a `DEFAULT_NAME_CONTEXT` static/config field in the Name model.py.

The validation works like this

- If a default name already exists for one db individual, we inform the user that's the case, and provide that individual's guid.
- If a default name is new to the DB, we warn the user that's the case, and that a new individual will be created for that name. 
- If a default name exists on _multiple db individuals_, we throw a flat file error because that row cannot be resolved to one individual. For now, this would block the upload. It is up to future us ("outside the scope of this ticket") to decide how to respond to these un-assignable collisions. This blocking error is important because our existing backend infrastructure could not resolve collisions. Current validation levels are as requested by Ben, and I don't foresee such collisions on the zebra MVP. 

Pretty straightforward code: new endpoint in `individual/resources.py` along with a test showing its usage, and covering the various validation scenarios.