### PR TITLE
856 ensure all assets are used

### DIFF
--- a/app/extensions/tus/__init__.py
+++ b/app/extensions/tus/__init__.py
@@ -106,6 +106,10 @@ def tus_upload_dir(app, git_store_guid=None, transaction_id=None, session_id=Non
     if git_store_guid is not None:
         return os.path.join(base_path, '-'.join(['sub', str(git_store_guid)]))
     if transaction_id is not None:
+        from uuid import UUID
+
+        # this is just to test it is a valid uuid - will throw ValueError if not! (500 response)
+        UUID(transaction_id, version=4)
         return os.path.join(base_path, '-'.join(['trans', transaction_id]))
     # must be session_id
     h = hashlib.sha256(session_id)

--- a/app/modules/fileuploads/models.py
+++ b/app/modules/fileuploads/models.py
@@ -74,28 +74,28 @@ class FileUpload(db.Model, HoustonModel):
     #   note: this is 'path' from { transaction_id, path } in tus args.  sorry so many things called path.
     @classmethod
     def create_fileupload_from_tus(cls, transaction_id, path):
-        from app.extensions.tus import _tus_filepaths_from, _tus_purge
+        from app.extensions.tus import tus_filepaths_from, tus_purge
 
         assert transaction_id is not None
         assert path is not None
-        source_paths, _ = _tus_filepaths_from(transaction_id=transaction_id, paths=[path])
+        source_paths, _ = tus_filepaths_from(transaction_id=transaction_id, paths=[path])
         fup = FileUpload.create_fileupload_from_path(source_paths[0])
-        _tus_purge(transaction_id=transaction_id)
+        tus_purge(transaction_id=transaction_id)
         return fup
 
     # plural paths is optional (will do all files in dir if skipped)
     @classmethod
     def create_fileuploads_from_tus(cls, transaction_id, paths=None):
-        from app.extensions.tus import _tus_filepaths_from, _tus_purge
+        from app.extensions.tus import tus_filepaths_from, tus_purge
 
         assert transaction_id is not None
-        source_paths, _ = _tus_filepaths_from(transaction_id=transaction_id, paths=paths)
+        source_paths, _ = tus_filepaths_from(transaction_id=transaction_id, paths=paths)
         if source_paths is None or len(source_paths) < 1:
             return None
         fups = []
         for source_path in source_paths:
             fups.append(FileUpload.create_fileupload_from_path(source_path))
-        _tus_purge(transaction_id=transaction_id)
+        tus_purge(transaction_id=transaction_id)
         return fups
 
     @classmethod

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -491,14 +491,14 @@ def test_delete_asset_group_sightings(session, login, codex_url, test_root, requ
             'transactionId': transaction_id,
             'sightings': [
                 {
-                    'assetReferences': ['turtle1.jpg'],
+                    'assetReferences': ['turtle1.jpg', 'turtle5.jpg'],
                     'locationId': 'PYTEST',
                     'time': '2014-01-01T09:00:00.000+00:00',
                     'timeSpecificity': 'time',
                     'encounters': [{}],
                 },
                 {
-                    'assetReferences': ['turtle2.jpg', 'turtle3.jpg'],
+                    'assetReferences': ['turtle2.jpg', 'turtle3.jpg', 'turtle4.jpg'],
                     'locationId': 'PYTEST too',
                     'time': '2014-01-01T09:00:00.000+00:00',
                     'timeSpecificity': 'time',

--- a/tests/extensions/tus/utils.py
+++ b/tests/extensions/tus/utils.py
@@ -10,7 +10,7 @@ import shutil
 import tqdm
 from PIL import Image
 import numpy as np
-from app.extensions.tus import tus_upload_dir
+from app.extensions.tus import tus_upload_dir, tus_write_file_metadata
 from app.utils import get_stored_filename
 from tests.utils import random_nonce
 
@@ -34,6 +34,8 @@ def prep_tus_dir(test_root, transaction_id=None, filename='zebra.jpg'):
     input_image = path.split(os.sep)[-1]
     stored_image = get_stored_filename(input_image)
     shutil.copy(image_file, f'{upload_dir}/{stored_image}')
+    tus_write_file_metadata(f'{upload_dir}/{stored_image}', input_image)
+
     size = os.path.getsize(image_file)
     assert size > 0
     return transaction_id, filename
@@ -53,6 +55,9 @@ def prep_randomized_tus_dir(total=100, transaction_id=None):
         numpy_image = np.around(np.random.rand(128, 128, 3) * 255.0).astype(np.uint8)
         Image.fromarray(numpy_image, 'RGB').save(image_file)
         size = os.path.getsize(image_file)
+        stored_image = get_stored_filename(filename)
+        os.rename(image_file, f'{upload_dir}/{stored_image}')
+        tus_write_file_metadata(f'{upload_dir}/{stored_image}', filename)
         assert size > 0
 
     return transaction_id

--- a/tests/modules/asset_groups/resources/test_create_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_create_asset_group.py
@@ -632,6 +632,23 @@ def test_create_bulk_asset_group_dup_asset(
 @pytest.mark.skipif(
     module_unavailable('asset_groups'), reason='AssetGroups module disabled'
 )
+def test_create_bulk_asset_group_missing_asset(
+    flask_app_client, researcher_1, test_root, db, request
+):
+    # pylint: disable=invalid-name
+
+    data = asset_group_utils.get_bulk_creation_data(test_root, request)
+    raw_data = data.get()
+    raw_data['sightings'][0]['assetReferences'].remove('coelacanth.png')
+    expected_err = "Asset(s) ['coelacanth.png'] are not used"
+    asset_group_utils.create_asset_group(
+        flask_app_client, researcher_1, data.get(), 400, expected_err
+    )
+
+
+@pytest.mark.skipif(
+    module_unavailable('asset_groups'), reason='AssetGroups module disabled'
+)
 def test_create_bulk_asset_group(flask_app_client, researcher_1, test_root, db, request):
     # pylint: disable=invalid-name
     import uuid

--- a/tests/modules/asset_groups/test_tus_creation.py
+++ b/tests/modules/asset_groups/test_tus_creation.py
@@ -5,7 +5,7 @@ import pathlib
 import pytest
 import shutil
 
-from tests.utils import module_unavailable, get_stored_path
+from tests.utils import module_unavailable
 from tests.extensions.tus import utils as tus_utils
 
 
@@ -13,7 +13,7 @@ from tests.extensions.tus import utils as tus_utils
     module_unavailable('asset_groups'), reason='AssetGroups module disabled'
 )
 def test_create_asset_group_from_tus(flask_app, db, researcher_1, test_root):
-
+    from app.utils import HoustonException
     from app.modules.asset_groups.models import AssetGroup
 
     tid = tus_utils.get_transaction_id()  # '11111111-1111-1111-1111-111111111111'
@@ -29,7 +29,7 @@ def test_create_asset_group_from_tus(flask_app, db, researcher_1, test_root):
 
     # now with a file dir+files but ask for wrong one
     tid, valid_file = tus_utils.prep_tus_dir(test_root)
-    with pytest.raises(AssertionError):
+    with pytest.raises(HoustonException):
         sub = AssetGroup.create_from_tus('PYTEST', researcher_1, tid, paths=['fail.jpg'])
 
     # test with explicit paths (should succeed)
@@ -44,7 +44,7 @@ def test_create_asset_group_from_tus(flask_app, db, researcher_1, test_root):
     tid, valid_file = tus_utils.prep_tus_dir(test_root)
     sub = AssetGroup.create_from_tus('PYTEST', researcher_1, tid)
     assert len(sub.assets) == 1
-    assert sub.assets[0].path == get_stored_path(valid_file)
+    assert sub.assets[0].path == valid_file
     if os.path.exists(sub.get_absolute_path()):
         shutil.rmtree(sub.get_absolute_path())
     sub.delete()

--- a/tests/modules/fileuploads/test_models.py
+++ b/tests/modules/fileuploads/test_models.py
@@ -4,13 +4,14 @@
 import os
 import pathlib
 import shutil
+import uuid
 
 from app.modules.fileuploads.models import FileUpload, modify_image
 from PIL import Image
 import pytest
 
 from tests.utils import (
-    TemporaryDirectoryGraceful,
+    TemporaryDirectoryUUID,
     create_transaction_dir,
     copy_uploaded_file,
     write_uploaded_file,
@@ -64,7 +65,7 @@ def test_fileupload_create_delete(db, flask_app, test_root, request):
 
 def test_fileupload_from_tus(db, flask_app, test_root, request):
     FILEUPLOAD_BASE_PATH = pathlib.Path(flask_app.config.get('FILEUPLOAD_BASE_PATH'))
-    TRANSACTION_ID = 'transaction-id'
+    TRANSACTION_ID = str(uuid.uuid4())
     fup_dir = None
 
     def cleanup():
@@ -93,7 +94,7 @@ def test_fileupload_from_tus(db, flask_app, test_root, request):
 def test_fileuploads_from_tus(db, flask_app, test_root, request):
     UPLOADS_DATABASE_PATH = pathlib.Path(flask_app.config.get('UPLOADS_DATABASE_PATH'))
     FILEUPLOAD_BASE_PATH = pathlib.Path(flask_app.config.get('FILEUPLOAD_BASE_PATH'))
-    TRANSACTION_ID = 'transaction-id'
+    TRANSACTION_ID = str(uuid.uuid4())
     tus_dir = UPLOADS_DATABASE_PATH / f'trans-{TRANSACTION_ID}'
     fup_dirs = []
     fups = []
@@ -152,7 +153,7 @@ def test_fileuploads_get_src(flask_app, flask_app_client, db, test_root, request
 
 
 def test_modify_image(flask_app, test_root):
-    with TemporaryDirectoryGraceful() as td:
+    with TemporaryDirectoryUUID() as td:
         test_file = copy_uploaded_file(
             test_root, 'zebra.jpg', pathlib.Path(td), 'zebra.jpg'
         )

--- a/tests/modules/missions/test_collection_tus_creation.py
+++ b/tests/modules/missions/test_collection_tus_creation.py
@@ -5,7 +5,7 @@ import pathlib
 import pytest
 import shutil
 
-from tests.utils import module_unavailable, get_stored_path
+from tests.utils import module_unavailable
 from tests.extensions.tus import utils as tus_utils
 
 
@@ -13,6 +13,7 @@ from tests.extensions.tus import utils as tus_utils
 def test_create_mission_collection_from_tus(flask_app, db, data_manager_1, test_root):
 
     from app.modules.missions.models import Mission, MissionCollection
+    from app.utils import HoustonException
 
     temp_mission = Mission(
         title='Temp Mission',
@@ -37,7 +38,7 @@ def test_create_mission_collection_from_tus(flask_app, db, data_manager_1, test_
 
     # now with a file dir+files but ask for wrong one
     tid, valid_file = tus_utils.prep_tus_dir(test_root)
-    with pytest.raises(AssertionError):
+    with pytest.raises(HoustonException):
         sub = MissionCollection.create_from_tus(
             'PYTEST', data_manager_1, tid, mission=temp_mission, paths={'fail.jpg'}
         )
@@ -58,7 +59,7 @@ def test_create_mission_collection_from_tus(flask_app, db, data_manager_1, test_
         'PYTEST', data_manager_1, tid, mission=temp_mission
     )
     assert len(sub.assets) == 1
-    assert sub.assets[0].path == get_stored_path(valid_file)
+    assert sub.assets[0].path == valid_file
     if os.path.exists(sub.get_absolute_path()):
         shutil.rmtree(sub.get_absolute_path())
     sub.delete()

--- a/tests/modules/site_settings/resources/test_file_operations.py
+++ b/tests/modules/site_settings/resources/test_file_operations.py
@@ -116,7 +116,6 @@ def test_file_settings(admin_user, flask_app_client, flask_app, db, request, tes
         with TemporaryDirectoryGraceful(prefix='trans-', dir=upload_dir) as td:
             transaction_id = Path(td).name[len('trans-') :]
             write_uploaded_file('a.txt', Path(td), '1234')
-            write_uploaded_file('b.txt', Path(td), '5678')
 
             resp = flask_app_client.post(
                 '/api/v1/site-settings/file',

--- a/tests/modules/site_settings/resources/test_file_operations.py
+++ b/tests/modules/site_settings/resources/test_file_operations.py
@@ -5,7 +5,7 @@ from app.modules.fileuploads.models import FileUpload
 from app.modules.site_settings.models import SiteSetting
 
 from tests.utils import (
-    TemporaryDirectoryGraceful,
+    TemporaryDirectoryUUID,
     module_unavailable,
     copy_uploaded_file,
     write_uploaded_file,
@@ -79,7 +79,7 @@ def test_file_settings(admin_user, flask_app_client, flask_app, db, request, tes
 
         # Edit site setting using transactionId
         upload_dir = flask_app.config['UPLOADS_DATABASE_PATH']
-        with TemporaryDirectoryGraceful(prefix='trans-', dir=upload_dir) as td:
+        with TemporaryDirectoryUUID(prefix='trans-', dir=upload_dir) as td:
             transaction_id = Path(td).name[len('trans-') :]
             copy_uploaded_file(test_root, 'zebra.jpg', Path(td), 'image.jpg')
 
@@ -95,7 +95,7 @@ def test_file_settings(admin_user, flask_app_client, flask_app, db, request, tes
             assert resp.json['file_upload_guid'] != str(fup.guid)
 
         # Edit site setting using transactionId with 2 files
-        with TemporaryDirectoryGraceful(prefix='trans-', dir=upload_dir) as td:
+        with TemporaryDirectoryUUID(prefix='trans-', dir=upload_dir) as td:
             transaction_id = Path(td).name[len('trans-') :]
             write_uploaded_file('a.txt', Path(td), '1234')
             write_uploaded_file('b.txt', Path(td), '5678')
@@ -113,7 +113,7 @@ def test_file_settings(admin_user, flask_app_client, flask_app, db, request, tes
             )
 
         # Edit site setting using transactionId and transactionPath
-        with TemporaryDirectoryGraceful(prefix='trans-', dir=upload_dir) as td:
+        with TemporaryDirectoryUUID(prefix='trans-', dir=upload_dir) as td:
             transaction_id = Path(td).name[len('trans-') :]
             write_uploaded_file('a.txt', Path(td), '1234')
 

--- a/tests/modules/users/resources/test_modifying_users_info.py
+++ b/tests/modules/users/resources/test_modifying_users_info.py
@@ -12,7 +12,7 @@ from app.modules.fileuploads.models import FileUpload
 from PIL import Image
 
 from tests.utils import (
-    TemporaryDirectoryGraceful,
+    TemporaryDirectoryUUID,
     copy_uploaded_file,
     write_uploaded_file,
 )
@@ -358,7 +358,7 @@ def test_user_profile_fileupload(
 
         # Create file upload
         file_contents = 'abcd\n'
-        with TemporaryDirectoryGraceful() as td:
+        with TemporaryDirectoryUUID() as td:
             testfile = write_uploaded_file('a.txt', Path(td), file_contents)
             fup = FileUpload.create_fileupload_from_path(str(testfile))
         with db.session.begin():
@@ -546,7 +546,7 @@ def test_user_profile_fileupload(
         assert updated_user.profile_fileupload_guid is None
 
         # Create file upload
-        with TemporaryDirectoryGraceful() as td:
+        with TemporaryDirectoryUUID() as td:
             testfile = copy_uploaded_file(test_root, zebra_file, td, 'image.jpg')
 
             fup = FileUpload.create_fileupload_from_path(str(testfile))
@@ -630,7 +630,7 @@ def test_user_profile_fileupload(
         response.close()
 
         # Create non image fileupload
-        with TemporaryDirectoryGraceful() as td:
+        with TemporaryDirectoryUUID() as td:
             testfile = write_uploaded_file('a.txt', td, 'abcd\n')
 
             fup = FileUpload.create_fileupload_from_path(str(testfile))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -111,10 +111,32 @@ class JSONResponse(Response):
         return json.loads(self.get_data(as_text=True))
 
 
-class TemporaryDirectoryGraceful(tempfile.TemporaryDirectory):
+class RandomUUIDSequence:
+    """An instance of _RandomUUIDSequence generates an endless
+    sequence of unpredictable strings which can safely be incorporated
+    into file names.  Each string is eight characters long.  Multiple
+    threads can safely use the same instance at the same time.
+
+    _RandomUUIDSequence is an iterator."""
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        import uuid
+
+        return str(uuid.uuid4())
+
+
+class TemporaryDirectoryUUID(tempfile.TemporaryDirectory):
+    def __init__(self, *args, **kwargs):
+        tempfile._name_sequence = RandomUUIDSequence()
+
+        super(TemporaryDirectoryUUID, self).__init__(*args, **kwargs)
+
     def __exit__(self, *args, **kwargs):
         try:
-            super(TemporaryDirectoryGraceful, self).__exit__(*args, **kwargs)
+            super(TemporaryDirectoryUUID, self).__exit__(*args, **kwargs)
         except FileNotFoundError:
             assert not os.path.exists(self.name)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -605,14 +605,17 @@ def create_transaction_dir(flask_app, transaction_id):
 
 
 def write_uploaded_file(initial_filename, input_dir, file_data, write_mode='w'):
-    if isinstance(input_dir, str):
-        stored_path = os.path.join(input_dir, get_stored_path(initial_filename))
-        with open(stored_path, write_mode) as out_file:
-            out_file.write(file_data)
-    else:
-        stored_path = input_dir / get_stored_path(initial_filename)
-        with stored_path.open(write_mode) as out_file:
-            out_file.write(file_data)
+    from app.extensions.tus import tus_write_file_metadata
+
+    if not isinstance(input_dir, str):
+        input_dir = str(input_dir)
+    if not isinstance(initial_filename, str):
+        initial_filename = str(initial_filename)
+    stored_path = os.path.join(input_dir, get_stored_path(initial_filename))
+    with open(stored_path, write_mode) as out_file:
+        out_file.write(file_data)
+
+    tus_write_file_metadata(stored_path, initial_filename)
     return stored_path
 
 


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- All assets now must be used in sightings (almost)
- Metadata file stores the original filename along with the stored one.
- This is used to build up the list of the ones that were not processed to tell the user
- New tus util to create this, used in a couple of places in real code and in the unit test side
- Asset now has the original filename as the path, previously it was the stored filename and I think that was an error
- Private tus utils used across the system made public
- tus_filepaths_from now reads all the files and raises HoustonException if any requested are not present
> - Error message contains all missing files rather than asserting on the first one
- git_store import_tus_files raises Houston Exception if any paths missing (unless no paths passed, I'm assuming this is normal expected behaviour, someone please confirm)

 @karen, please check file handling changes. Testing seems to pass but I'm not certain that I have all the options covered.
 @bluemellophone, pretty sure that this is MWS safe now that I've fixed a few tests but please check



