### PR TITLE
Fix Pagination for MWS Asset Search with Elasticsearch

### DIFF
--- a/app/extensions/elasticsearch/__init__.py
+++ b/app/extensions/elasticsearch/__init__.py
@@ -1575,6 +1575,7 @@ def es_elasticsearch(
     sort='guid',
     reverse=False,
     reverse_after=False,
+    filter_guids=None,
     total=False,
 ):
     index = es_index_name(cls)
@@ -1607,12 +1608,17 @@ def es_elasticsearch(
     all_guids = cls.query.with_entities(cls.guid).all()
     all_guids = set([item[0] for item in all_guids])
 
+    if filter_guids is None:
+        filter_guids = all_guids
+    filter_guids = set(filter_guids)
+
     # Cross reference with ES hit GUIDs
     search_guids = []
     search_prune = []
     for guid in hit_guids:
         if guid in all_guids:
-            search_guids.append(guid)
+            if guid in filter_guids:
+                search_guids.append(guid)
         else:
             search_prune.append(guid)
 

--- a/app/extensions/elasticsearch/__init__.py
+++ b/app/extensions/elasticsearch/__init__.py
@@ -875,7 +875,7 @@ def register_elasticsearch_model(cls):
     }
 
 
-def es_index_name(cls, app=None):
+def es_index_name(cls, app=None, quiet=False):
     from flask import current_app
 
     if app is None:
@@ -885,7 +885,8 @@ def es_index_name(cls, app=None):
         return None
 
     if cls not in REGISTERED_MODELS:
-        logging.error('Model (%r) is not in Elasticsearch' % (cls,))
+        if not quiet:
+            log.error('Model (%r) is not in Elasticsearch' % (cls,))
         return None
 
     index = ('%s.%s' % (cls.__module__, cls.__name__)).lower()
@@ -967,11 +968,11 @@ def es_validate(obj):
                 )
 
 
-def es_index(obj, app=None, force=False):
+def es_index(obj, app=None, force=False, quiet=False):
     from flask import current_app
 
     cls = obj.__class__
-    index = es_index_name(cls)
+    index = es_index_name(cls, quiet=quiet)
 
     if index is None:
         return None

--- a/app/modules/missions/parameters.py
+++ b/app/modules/missions/parameters.py
@@ -208,7 +208,7 @@ class CreateMissionTaskParameters(SetOperationsJSONParameters):
                 )
 
         if field == 'search':
-            return obj.asset_search(value)
+            return obj.asset_search(value, total=False, limit=None)
         elif field == 'collections':
             assets = []
 

--- a/app/modules/missions/resources.py
+++ b/app/modules/missions/resources.py
@@ -308,7 +308,6 @@ class AssetsForMission(Resource):
     @api.paginate()
     def get(self, args, mission):
         search = {}
-        args['total'] = True
         return mission.asset_search(search, **args)
 
     @api.permission_required(
@@ -322,7 +321,6 @@ class AssetsForMission(Resource):
     @api.paginate()
     def post(self, args, mission):
         search = request.get_json()
-        args['total'] = True
         return mission.asset_search(search, **args)
 
 

--- a/flask_restx_patched/parameters.py
+++ b/flask_restx_patched/parameters.py
@@ -197,7 +197,7 @@ class PatchJSONParameters(Parameters):
         for obj in objs:
             if obj is not None:
                 if hasattr(obj, 'index'):
-                    obj.index(force=True)
+                    obj.index(force=True, quiet=True)
 
         if obj_cls is not None:
             return objs


### PR DESCRIPTION
This PR fixes the pagination filtering for asset search, which is needed for viewing mission collections and creating mission tasks.