### PR TITLE
Fix for some tests when using --no-elasticsearch option

### DIFF
--- a/tests/modules/annotations/resources/test_matching_set.py
+++ b/tests/modules/annotations/resources/test_matching_set.py
@@ -8,13 +8,21 @@ from tests.modules.encounters.resources import utils as enc_utils
 from tests.modules.site_settings.resources import utils as setting_utils
 import pytest
 
-from tests.utils import module_unavailable, wait_for_elasticsearch_status
+from tests.utils import (
+    module_unavailable,
+    extension_unavailable,
+    wait_for_elasticsearch_status,
+)
 from tests import utils
 
 
 @pytest.mark.skipif(
-    module_unavailable('asset_groups', 'elasticsearch'),
-    reason='AssetGroups/Elasticsearch module disabled',
+    module_unavailable('asset_groups'),
+    reason='AssetGroups module disabled',
+)
+@pytest.mark.skipif(
+    extension_unavailable('elasticsearch'),
+    reason='Elasticsearch extension disabled',
 )
 def test_annotation_matching_set(
     flask_app_client,
@@ -26,6 +34,10 @@ def test_annotation_matching_set(
 ):
     # pylint: disable=invalid-name
     from app.modules.annotations.models import Annotation
+    from app.extensions import elasticsearch as es
+
+    if es.is_disabled():
+        pytest.skip('Elasticsearch disabled (via command-line)')
 
     clone = sub_utils.clone_asset_group(
         flask_app_client,
@@ -233,9 +245,11 @@ def test_region_utils():
     assert ancestors == {top_id, parent1, parent2, parent3, loc1, loc2}
 
 
+# note: despite the name of this test, it can run without elasticsearch enabled,
+#   as it only is testing the schema content/construction
 @pytest.mark.skipif(
-    module_unavailable('asset_groups', 'elasticsearch'),
-    reason='AssetGroups/Elasticsearch module disabled',
+    module_unavailable('asset_groups'),
+    reason='AssetGroups module disabled',
 )
 def test_annotation_elasticsearch(
     flask_app_client,

--- a/tests/modules/sightings/resources/test_identify_sighting.py
+++ b/tests/modules/sightings/resources/test_identify_sighting.py
@@ -7,10 +7,21 @@ import tests.utils as test_utils
 
 import pytest
 
-from tests.utils import module_unavailable, wait_for_elasticsearch_status
+from tests.utils import (
+    module_unavailable,
+    extension_unavailable,
+    wait_for_elasticsearch_status,
+)
 
 
-@pytest.mark.skipif(module_unavailable('sightings'), reason='Sightings module disabled')
+@pytest.mark.skipif(
+    module_unavailable('sightings'),
+    reason='Sighting module disabled',
+)
+@pytest.mark.skipif(
+    extension_unavailable('elasticsearch'),
+    reason='Elasticsearch extension disabled',
+)
 def test_sighting_identification(
     flask_app,
     flask_app_client,
@@ -23,6 +34,10 @@ def test_sighting_identification(
     # pylint: disable=invalid-name
     from app.modules.sightings.models import Sighting, SightingStage
     from app.modules.annotations.models import Annotation
+    from app.extensions import elasticsearch as es
+
+    if es.is_disabled():
+        pytest.skip('Elasticsearch disabled (via command-line)')
 
     # Create two sightings so that there will be a valid annotation when doing ID for the second one.
     # Otherwise the get_matching_set_data in sightings will return an empty list

--- a/tests/tasks/app/test_job_control.py
+++ b/tests/tasks/app/test_job_control.py
@@ -7,7 +7,11 @@ import tests.modules.asset_groups.resources.utils as asset_group_utils
 from invoke import MockContext
 import pytest
 
-from tests.utils import module_unavailable, wait_for_elasticsearch_status
+from tests.utils import (
+    module_unavailable,
+    extension_unavailable,
+    wait_for_elasticsearch_status,
+)
 
 
 # Check that the task methods for the asset control job tasks print the correct output
@@ -73,7 +77,14 @@ def test_asset_group_detection_jobs(
 
 
 # Check that the task methods for the sighting job tasks print the correct output
-@pytest.mark.skipif(module_unavailable('sightings'), reason='Sightings module disabled')
+@pytest.mark.skipif(
+    module_unavailable('sightings'),
+    reason='Sighting module disabled',
+)
+@pytest.mark.skipif(
+    extension_unavailable('elasticsearch'),
+    reason='Elasticsearch extension disabled',
+)
 def test_sighting_identification_jobs(
     flask_app,
     flask_app_client,
@@ -84,6 +95,10 @@ def test_sighting_identification_jobs(
 ):
     # pylint: disable=invalid-name
     from app.modules.sightings.models import Sighting, SightingStage
+    from app.extensions import elasticsearch as es
+
+    if es.is_disabled():
+        pytest.skip('Elasticsearch disabled (via command-line)')
 
     # Create two sightings so that there will be a valid annotation when doing ID for the second one.
     # Otherwise the get_matching_set_data in sightings will return an empty list


### PR DESCRIPTION
## Pull Request Overview

As noted by @hwindsor, when using `--no-elasticsearch` option during testing, some tests fail.  This now skips those tests when this option is used.  It also does a little cleanup of how the `skipif` decorators is being used.