### PR TITLE
remove sex key required for individual in tests

### DIFF
--- a/tests/modules/individuals/resources/utils.py
+++ b/tests/modules/individuals/resources/utils.py
@@ -13,7 +13,6 @@ EXPECTED_KEYS = {
     'names',
     'timeOfBirth',
     'social_groups',
-    'sex',
     'hasView',
     'hasEdit',
     'timeOfDeath',


### PR DESCRIPTION
Tiny change to make sex not a required individual value in tests before a change to EDM is pushed.