### PR TITLE
DEX-873 Celery integration check

### DIFF
--- a/scripts/tests/run_tasks_for_coverage.sh
+++ b/scripts/tests/run_tasks_for_coverage.sh
@@ -57,6 +57,7 @@ fi
 if [ "$HOUSTON_APP_CONTEXT" == 'codex' ]; then
     # `|| true` is used to ignore integration fail with gitlab
     coverage run --append `which invoke` codex.integrations.check || true
+    coverage run --append `which invoke` codex.integrations.check-celery || true
 fi
 
 # test app.users.*

--- a/tasks/codex/integrations.py
+++ b/tasks/codex/integrations.py
@@ -12,7 +12,7 @@ def bool_to_emoji(b):
     return '⭐' if b else '❌'
 
 
-def check_db_connection(_app):
+def check_db_connection(_app, verbose):
     """Check the database connection"""
     from app.extensions import db
 
@@ -21,17 +21,20 @@ def check_db_connection(_app):
         return list(results) == [(1,)]
 
 
-def check_edm(app):
+def check_edm(app, verbose):
     """Check for connectivity to EDM"""
     try:
         app.edm._ensure_initialized()
-    except Exception:
-        log.exception('')
+    except Exception as e:
+        if verbose:
+            log.exception('')
+        else:
+            log.error(str(e))
         return False
     return True
 
 
-def check_edm_db(app):
+def check_edm_db(app, verbose):
     """Check for connectivity to directly to the EDM database.
     This connection is used by the indexing procedures.
 
@@ -43,35 +46,58 @@ def check_edm_db(app):
         with engine.connect() as conn:
             result = conn.execute('SELECT 1')
             assert result.scalar() == 1
-    except Exception:
-        log.exception('')
+    except Exception as e:
+        if verbose:
+            log.exception('')
+        else:
+            log.error(str(e))
         return False
     return True
 
 
-def check_gitlab(app):
+def check_gitlab(app, verbose):
     """Check the gitlab connection indirectly through the GitlabManager"""
     try:
         app.git_backend._ensure_initialized()
         app.git_backend.gl.projects.list()
-    except Exception:
-        log.exception('')
+    except Exception as e:
+        if verbose:
+            log.exception('')
+        else:
+            log.error(str(e))
         return False
     return True
 
 
-def check_elasticsearch(app):
+def check_elasticsearch(app, verbose):
     """Check the elasticsearch connection through the Elasticsearch client"""
     try:
         app.elasticsearch.info()
-    except Exception:
-        log.exception('')
+    except Exception as e:
+        if verbose:
+            log.exception('')
+        else:
+            log.error(str(e))
+        return False
+    return True
+
+
+def check_celery_tasks(app, verbose):
+    from app.utils import get_celery_tasks_scheduled
+
+    try:
+        get_celery_tasks_scheduled()
+    except Exception as e:
+        if verbose:
+            log.exception('')
+        else:
+            log.error(str(e))
         return False
     return True
 
 
 @app_context_task()
-def check(context):
+def check(context, verbose=True):
     """Check integration connectivity"""
     from flask import current_app as app
 
@@ -81,13 +107,14 @@ def check(context):
         'edm': check_edm,
         'edm database': check_edm_db,
         'elasticsearch': check_elasticsearch,
+        'celery': check_celery_tasks,
         # ...
     }
 
     overall_status = True
     # Check connectivity to integration services
     for name, state_check in service_checks.items():
-        status = state_check(app)
+        status = state_check(app, verbose=verbose)
         print(f'{bool_to_emoji(status)} {name}')
         overall_status = overall_status and status
 

--- a/tasks/codex/integrations.py
+++ b/tasks/codex/integrations.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+import pprint
 import sys
 
 from tasks.utils import app_context_task
@@ -120,3 +121,11 @@ def check(context, verbose=True):
 
     if not overall_status:
         sys.exit(1)
+
+
+@app_context_task()
+def check_celery(context, type=None):
+    from app.utils import get_celery_tasks_scheduled
+
+    print('Scheduled Tasks:')
+    pprint.pprint(get_celery_tasks_scheduled(type=type))


### PR DESCRIPTION
- Add celery and --no-verbose to codex.integrations.check

  When `--no-verbose` is used, only include the error message without the
  traceback.

- Add codex.integrations.check-celery task

  With optional `--type` to filter by scheduled task type.
