### PR TITLE
DEX-777:  api for initiating annot identification (including matching set query)

### DIFF
--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -486,24 +486,10 @@ class Annotation(db.Model, HoustonModel):
 
     def send_to_identification(self, matching_set_query=None):
         sighting = self.get_sighting()
-        sighting.validate_id_configs()
         if not sighting:
             raise HoustonException(
                 log, f'{self} requires a sighting to run send_to_identification()'
             )
-        # now we attempt to send it
-        job_count = 0
-        for config_id in range(len(sighting.id_configs)):
-            for algorithm_id in range(len(sighting.id_configs[config_id]['algorithms'])):
-                sent = sighting.send_annot_for_detection(
-                    self,
-                    config_id,
-                    algorithm_id,
-                    matching_set_query_override=matching_set_query,
-                )
-                log.debug(
-                    f'annot.send_to_identification() success={sent} queueing up ID job for config_id={config_id} {self}: algo {algorithm_id}'
-                )
-                if sent:
-                    job_count += 1
+        sighting.validate_id_configs()
+        job_count = sighting.send_annot_for_identification(self, matching_set_query)
         return job_count

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -496,7 +496,10 @@ class Annotation(db.Model, HoustonModel):
         for config_id in range(len(sighting.id_configs)):
             for algorithm_id in range(len(sighting.id_configs[config_id]['algorithms'])):
                 sent = sighting.send_annot_for_detection(
-                    self, config_id, algorithm_id, matching_set_query
+                    self,
+                    config_id,
+                    algorithm_id,
+                    matching_set_query_override=matching_set_query,
                 )
                 log.debug(
                     f'annot.send_to_identification() success={sent} queueing up ID job for config_id={config_id} {self}: algo {algorithm_id}'

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -253,8 +253,11 @@ class Annotation(db.Model, HoustonModel):
             query = self.get_matching_set_default_query()
         else:
             query = self.resolve_matching_set_query(query)
-        log.info(f'finding matching set for {self} using query {query}')
-        return self.elasticsearch(query, load=load)
+        matching_set = self.elasticsearch(query, load=load)
+        log.info(
+            f'annot.get_matching_set(): finding matching set for {self} using (resolved) query {query} => {len(matching_set)} annots'
+        )
+        return matching_set
 
     def get_matching_set_default_query(self):
         # n.b. default will not take any locationId or ownership into consideration

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -491,5 +491,5 @@ class Annotation(db.Model, HoustonModel):
                 log, f'{self} requires a sighting to run send_to_identification()'
             )
         sighting.validate_id_configs()
-        job_count = sighting.send_annot_for_identification(self, matching_set_query)
+        job_count = sighting.send_annotation_for_identification(self, matching_set_query)
         return job_count

--- a/app/modules/annotations/resources.py
+++ b/app/modules/annotations/resources.py
@@ -363,11 +363,11 @@ class AnnotationIdentifyByID(Resource):
     )
     def post(self, annotation):
         """
-        Accepts an optional query via body.  Uses default matching-set if none provided.
+        Accepts an optional matching-set query via body.  Uses default matching-set if none provided.
         """
         request_in = json.loads(request.data)
-        job_count = annotation.ia_pipeline(request_in)
-        return {'sent': True, 'job_count': job_count}
+        job_count = annotation.send_to_annotation(request_in)
+        return {'job_count': job_count}
 
 
 @api.route('/debug/<uuid:annotation_guid>')

--- a/app/modules/annotations/resources.py
+++ b/app/modules/annotations/resources.py
@@ -366,7 +366,7 @@ class AnnotationIdentifyByID(Resource):
         Accepts an optional matching-set query via body.  Uses default matching-set if none provided.
         """
         request_in = json.loads(request.data)
-        job_count = annotation.send_to_annotation(request_in)
+        job_count = annotation.send_to_identification(request_in)
         return {'job_count': job_count}
 
 

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -868,7 +868,14 @@ class AssetGroupSighting(db.Model, HoustonModel):
                 self.config['encounters'][encounter_num]['annotations'].remove(annot_guid)
 
     def get_id_configs(self):
-        return self.config.get('idConfigs', [])
+        return self.config.get(
+            'idConfigs',
+            [
+                {
+                    'algorithms': ['hotspotter_nosv'],
+                }
+            ],
+        )
 
 
 class AssetGroup(GitStore):

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -869,14 +869,17 @@ class AssetGroupSighting(db.Model, HoustonModel):
 
     # will default to hotspotter if no idConfigs provided by AGS
     def get_id_configs(self):
-        return self.config.get(
-            'idConfigs',
-            [
-                {
-                    'algorithms': ['hotspotter_nosv'],
-                }
-            ],
-        )
+        configs = self.config.get('idConfigs')
+        if configs:
+            return configs
+
+        from app.modules.ia_config_reader import IaConfig
+
+        ia_config_reader = IaConfig(current_app.config.get('CONFIG_MODEL'))
+        identifiers = ia_config_reader.get('_identifiers')
+        if identifiers:
+            return [{'algorithms': [list(identifiers.keys())[0]]}]
+        return None
 
 
 class AssetGroup(GitStore):

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -867,19 +867,8 @@ class AssetGroupSighting(db.Model, HoustonModel):
             ):
                 self.config['encounters'][encounter_num]['annotations'].remove(annot_guid)
 
-    # will default to hotspotter if no idConfigs provided by AGS
     def get_id_configs(self):
-        configs = self.config.get('idConfigs')
-        if configs:
-            return configs
-
-        from app.modules.ia_config_reader import IaConfig
-
-        ia_config_reader = IaConfig(current_app.config.get('CONFIG_MODEL'))
-        identifiers = ia_config_reader.get('_identifiers')
-        if identifiers:
-            return [{'algorithms': [list(identifiers.keys())[0]]}]
-        return None
+        return self.config.get('idConfigs', [])
 
 
 class AssetGroup(GitStore):

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -867,6 +867,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
             ):
                 self.config['encounters'][encounter_num]['annotations'].remove(annot_guid)
 
+    # will default to hotspotter if no idConfigs provided by AGS
     def get_id_configs(self):
         return self.config.get(
             'idConfigs',

--- a/app/modules/ia_config_reader.py
+++ b/app/modules/ia_config_reader.py
@@ -85,7 +85,14 @@ class IaConfig:
     def get_identifiers_dict(self, genus_species, ia_class):
         identifiers = self.get_identifiers_with_links(genus_species, ia_class)
         identifiers_dict = self._resolve_links_to_dict(identifiers)
-        return identifiers_dict
+        # trim the '_identifiers.' prefix off the keys
+        trimmed = dict()
+        for key in identifiers_dict:
+            algo = key
+            if key.startswith('_identifiers.'):
+                algo = key[13:]
+            trimmed[algo] = identifiers_dict[key]
+        return trimmed
 
     def _resolve_links_in_value_list(self, value_list):
         resolved_list = [

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -613,7 +613,7 @@ class Sighting(db.Model, FeatherModel):
         annotation = Annotation.query.get(annotation_guid)
         assert annotation
         log.debug(
-            f'sighting {self} finding matching set for {annotation} using {matching_set_config}'
+            f'sighting.get_matching_set_data(): sighting {self} finding matching set for {annotation} using {matching_set_config}'
         )
         matching_set_annotations = annotation.get_matching_set(matching_set_config)
 
@@ -638,8 +638,8 @@ class Sighting(db.Model, FeatherModel):
                         matching_set_individual_uuids.append(individual_guid)
 
         log.debug(
-            f'Built matching set individuals {matching_set_individual_uuids}, '
-            f'annots {matching_set_annot_uuids}'
+            f'sighting.get_matching_set_data(): Built matching set individuals {matching_set_individual_uuids}, '
+            f'annots {matching_set_annot_uuids} for Annot {annotation_guid} on {self}'
         )
         return matching_set_individual_uuids, matching_set_annot_uuids
 

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -1186,7 +1186,7 @@ class Sighting(db.Model, FeatherModel):
         if not annotation.content_guid or not annotation.encounter_guid:
             log.warning(f'Skipping {annotation} due to lack of content_guid or encounter')
             return False
-        # force this to be up-to-date in index, just to be safe (only do once, hence config_id==0)
+        # force this to be up-to-date in index
         annotation.index()
 
         matching_set_query = matching_set_query or self.id_configs[config_id].get(

--- a/app/modules/sightings/tasks.py
+++ b/app/modules/sightings/tasks.py
@@ -20,7 +20,7 @@ def send_identification(
     algorithm_id,
     annotation_uuid,
     annotation_sage_guid,
-    matching_set_query_override=None,
+    matching_set_query=None,
 ):
     from .models import Sighting
 
@@ -32,7 +32,7 @@ def send_identification(
             algorithm_id,
             annotation_uuid,
             annotation_sage_guid,
-            matching_set_query_override,
+            matching_set_query,
         )
     else:
         log.warning('Failed to find the sighting to perform Identification on')

--- a/app/modules/sightings/tasks.py
+++ b/app/modules/sightings/tasks.py
@@ -15,7 +15,12 @@ log = logging.getLogger(__name__)
     max_retries=10,
 )
 def send_identification(
-    sighting_guid, config_id, algorithm_id, annotation_uuid, annotation_sage_guid
+    sighting_guid,
+    config_id,
+    algorithm_id,
+    annotation_uuid,
+    annotation_sage_guid,
+    matching_set_query_override=None,
 ):
     from .models import Sighting
 
@@ -23,7 +28,11 @@ def send_identification(
 
     if sighting:
         sighting.send_identification(
-            config_id, algorithm_id, annotation_uuid, annotation_sage_guid
+            config_id,
+            algorithm_id,
+            annotation_uuid,
+            annotation_sage_guid,
+            matching_set_query_override,
         )
     else:
         log.warning('Failed to find the sighting to perform Identification on')

--- a/tests/modules/annotations/resources/test_annotation_identification.py
+++ b/tests/modules/annotations/resources/test_annotation_identification.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+import uuid
+
+import tests.modules.asset_groups.resources.utils as asset_group_utils
+import tests.modules.sightings.resources.utils as sighting_utils
+import tests.utils as test_utils
+
+import pytest
+
+from tests.utils import (
+    module_unavailable,
+    extension_unavailable,
+    wait_for_elasticsearch_status,
+)
+
+
+@pytest.mark.skipif(
+    module_unavailable('sightings'),
+    reason='Sighting module disabled',
+)
+@pytest.mark.skipif(
+    extension_unavailable('elasticsearch'),
+    reason='Elasticsearch extension disabled',
+)
+def test_annotation_identification(
+    flask_app,
+    flask_app_client,
+    researcher_1,
+    internal_user,
+    test_root,
+    db,
+    request,
+):
+    # pylint: disable=invalid-name
+    from app.modules.sightings.models import Sighting, SightingStage
+    from app.modules.annotations.models import Annotation
+    from app.extensions import elasticsearch as es
+
+    if es.is_disabled():
+        pytest.skip('Elasticsearch disabled (via command-line)')
+
+    # Create two sightings so that there will be a valid annotation when doing ID for the second one.
+    # Otherwise the get_matching_set_data in sightings will return an empty list
+    (
+        asset_group_uuid1,
+        asset_group_sighting_guid1,
+        asset_uuid1,
+    ) = asset_group_utils.create_simple_asset_group(
+        flask_app_client, researcher_1, request, test_root
+    )
+    target_annot_guid = asset_group_utils.patch_in_dummy_annotation(
+        flask_app_client, db, researcher_1, asset_group_sighting_guid1, asset_uuid1
+    )
+    commit_response = asset_group_utils.commit_asset_group_sighting(
+        flask_app_client, researcher_1, asset_group_sighting_guid1
+    )
+    sighting_uuid = commit_response.json['guid']
+
+    # mark it as processed or it won't be valid in the matching set
+    sighting_utils.write_sighting_path(
+        flask_app_client, researcher_1, f'{sighting_uuid}/reviewed', {}
+    )
+
+    # Second sighting, the one we'll use for testing, Create with annotation but don't commit.... yet
+    (
+        asset_group_uuid2,
+        asset_group_sighting_guid2,
+        asset_uuid2,
+    ) = asset_group_utils.create_simple_asset_group(
+        flask_app_client, researcher_1, request, test_root
+    )
+    query_annot_guid = asset_group_utils.patch_in_dummy_annotation(
+        flask_app_client, db, researcher_1, asset_group_sighting_guid2, asset_uuid2
+    )
+    target_annot = Annotation.query.get(target_annot_guid)
+    query_annot = Annotation.query.get(query_annot_guid)
+    # content guid allocated by Sage normally but we're simulating sage
+    target_annot.content_guid = uuid.uuid4()
+    query_annot.content_guid = uuid.uuid4()
+    # make annots neighbors
+    target_annot.viewpoint = 'up'
+    query_annot.viewpoint = 'upright'
+    with db.session.begin(subtransactions=True):
+        db.session.merge(target_annot)
+        db.session.merge(query_annot)
+
+    # this is basically a duplicate of tests/modules/sightings/resources/test_identify_sighting.py
+    #   so we dont do a ton of validation here; we are just setting up for an additional test of
+    #   single-annotation identification
+
+    id_configs = [
+        {
+            'algorithms': [
+                'hotspotter_nosv',
+            ],
+        }
+    ]
+    patch_data = [test_utils.patch_replace_op('idConfigs', id_configs)]
+    asset_group_utils.patch_asset_group_sighting(
+        flask_app_client,
+        researcher_1,
+        asset_group_sighting_guid2,
+        patch_data,
+    )
+
+    # Start ID simulating success response from Sage
+    response = asset_group_utils.commit_asset_group_sighting_sage_identification(
+        flask_app, flask_app_client, researcher_1, asset_group_sighting_guid2
+    )
+    sighting_uuid = response.json['guid']
+    wait_for_elasticsearch_status(flask_app_client, researcher_1)
+
+    sighting = Sighting.query.get(sighting_uuid)
+    assert sighting.stage == SightingStage.identification
+    annotation = sighting.encounters[0].annotations[0]
+    num_sent = annotation.send_to_identification()
+    assert num_sent == 1
+    bad_query = {
+        'bool': {
+            'filter': [
+                {'match': {'encounter_guid': '00000000-0000-0000-0000-badbadbadbad'}}
+            ]
+        }
+    }
+    num_sent = annotation.send_to_identification(bad_query)
+    assert num_sent == 0

--- a/tests/modules/annotations/resources/test_matching_set.py
+++ b/tests/modules/annotations/resources/test_matching_set.py
@@ -39,6 +39,8 @@ def test_annotation_matching_set(
     if es.is_disabled():
         pytest.skip('Elasticsearch disabled (via command-line)')
 
+    # make sure we dont have stray annots around
+    Annotation.query.delete()
     clone = sub_utils.clone_asset_group(
         flask_app_client,
         researcher_1,

--- a/tests/modules/test_ia_config.py
+++ b/tests/modules/test_ia_config.py
@@ -68,9 +68,8 @@ def test_get_identifiers_zebras(flask_app_client):
     identifiers = ia_config_reader.get_identifiers_dict(species, ia_class)
 
     # copy/pasted from the config and pythonified (vs json)
-    # also '_identifiers.' prefix added to algo names
     desired_identifiers = {
-        '_identifiers.hotspotter_nosv': {
+        'hotspotter_nosv': {
             'sage': {'query_config_dict': {'sv_on': False}},
             'frontend': {'description': 'HotSpotter pattern-matcher'},
         }
@@ -136,9 +135,7 @@ def test_get_detect_model_frontend_data(flask_app_client):
                     'itis_id': 202400,
                     'ia_classes': ['zebra_grevys', 'zebra'],
                     'id_algos': {
-                        '_identifiers.hotspotter_nosv': {
-                            'description': 'HotSpotter pattern-matcher'
-                        }
+                        'hotspotter_nosv': {'description': 'HotSpotter pattern-matcher'}
                     },
                 },
                 {
@@ -147,9 +144,7 @@ def test_get_detect_model_frontend_data(flask_app_client):
                     'itis_id': 624996,
                     'ia_classes': ['zebra_grevys', 'zebra'],
                     'id_algos': {
-                        '_identifiers.hotspotter_nosv': {
-                            'description': 'HotSpotter pattern-matcher'
-                        }
+                        'hotspotter_nosv': {'description': 'HotSpotter pattern-matcher'}
                     },
                 },
             ],


### PR DESCRIPTION
## Pull Request Overview

- Introduces new API to start identification on a single Annotation:  `/api/v1/annotations/identify/GUID` (optionally can pass ES query for _matching-set_ on POST body)
- Sets default algorithm in the event no `idConfigs` value is provided during Sighting submission, so pipeline will complete
- Bonus tweak of json output (related to ident algorithms) of `/api/v1/site-settings/detection`

---
**REST API Updates**

Initiate Identification on a single Annotation.  Can _optionally_ include an Elasticsearch query on the body of the POST.  If not query is provided, the _default_ matching-set query will be used.  (Returns `{ "job_count": N }` with number of ID jobs successfully started.)

```
POST   /api/v1/annotations/identify/GUID
{
    "bool": {
        "filter": [ ...... ],
    }
}
```
