### PR TITLE
Automatically reload houston when app.debug is True

### DIFF
--- a/tasks/app/run.py
+++ b/tasks/app/run.py
@@ -110,8 +110,7 @@ def run(
     # Turn off logging the access log for noisy endpoints (like the heartbeat)
     hide_noisy_endpoint_logs()
 
-    # use_reloader = app.debug
-    use_reloader = False
+    use_reloader = app.debug
 
     if uwsgi:
         uwsgi_args = [


### PR DESCRIPTION
Set flask reloader to the same as `app.debug` so during development,
houston restarts when the code changes.

---

@bluemellophone You reverted the changes (added in https://github.com/WildMeOrg/houston/commit/adab1efb8965230a4dc50e94041802e012d7c28f) in commit https://github.com/WildMeOrg/houston/commit/dbb4ef656be508022709758dc02b8665555dbf50 "Use gevent workers (processes for database connections, instead of thread-local DB connection) for celery and fix tests", you didn't include any reasons in the commit message so I don't know if it was accidental or if there's really a reason for reverting it.
