### PR TITLE
Only set email sender if sender is not set

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -39,17 +39,6 @@ def to_ascii(val):
     return unicodedata.normalize('NFKD', val).encode('ascii', 'ignore').decode()
 
 
-def site_email_hostname():
-    from flask import current_app
-
-    dom = current_app.config.get('SERVER_NAME', None)
-    if not dom:
-        dom = 'mail.example.com'
-    if dom.startswith('www.'):
-        dom = dom[4:]
-    return dom.lower()
-
-
 # optionally filter on type
 def get_celery_tasks_scheduled(type=None):
     from flask import current_app

--- a/config/base.py
+++ b/config/base.py
@@ -207,10 +207,16 @@ class EmailConfig(object):
     MAIL_USE_SSL = bool(os.getenv('MAIL_USE_SSL', False))
     MAIL_USERNAME = os.getenv('MAIL_USERNAME', 'dev@wildme.org')
     MAIL_PASSWORD = os.getenv('MAIL_PASSWORD', 'XXX')
-    MAIL_DEFAULT_SENDER = (
-        os.getenv('MAIL_DEFAULT_SENDER_NAME', 'Codex Mailbot'),
-        os.getenv('MAIL_DEFAULT_SENDER_EMAIL', 'changeme@example.com'),
-    )
+
+    @property
+    def MAIL_DEFAULT_SENDER(self):
+        return (
+            os.getenv('MAIL_DEFAULT_SENDER_NAME', 'Do Not Reply'),
+            os.getenv(
+                'MAIL_DEFAULT_SENDER_EMAIL',
+                f'do-not-reply@{self.SERVER_NAME.replace("www.", "", 1)}',
+            ),
+        )
 
 
 class ReCaptchaConfig(object):


### PR DESCRIPTION
Get the email default sender from `SiteSetting` and set it as the email
sender in `Email.__init__`.

Change app config `MAIL_DEFAULT_SENDER` to a property so we can guess
the email domain name.

Use `current_app.config['MAIL_DEFAULT_SENDER']` as the default for the
email default sender `SiteSetting` and remove
`app.utils.site_email_hostname`.
