### PR TITLE
865 individual custom field edm patch

### DIFF
--- a/app/modules/individuals/parameters.py
+++ b/app/modules/individuals/parameters.py
@@ -41,6 +41,7 @@ class PatchIndividualDetailsParameters(PatchJSONParameters):
         '/timeOfBirth',
         '/timeOfDeath',
         '/comments',
+        '/customFields',
     )
 
     PATH_CHOICES_HOUSTON = ('/featuredAssetGuid', '/encounters', '/names')

--- a/tests/modules/individuals/resources/test_individual_crud.py
+++ b/tests/modules/individuals/resources/test_individual_crud.py
@@ -413,3 +413,31 @@ def test_individual_mixed_edm_houston_patch(
     # EDM patch should have succeeded, Houston failed
     assert individual_json['timeOfBirth'] == '1445410800000'
     assert individual_json['names'] == []
+
+
+@pytest.mark.skipif(
+    module_unavailable('individuals'), reason='Individuals module disabled'
+)
+def test_individual_edm_patch_add(db, flask_app_client, researcher_1, request, test_root):
+    uuids = individual_utils.create_individual_and_sighting(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root,
+    )
+    individual_id = uuids['individual']
+    time_of_death = 1445410803000  # I feel incredible power setting this var
+
+    individual_utils.patch_individual(
+        flask_app_client,
+        researcher_1,
+        individual_id,
+        [
+            {'op': 'add', 'path': '/timeOfDeath', 'value': time_of_death},
+        ],
+    )
+    individual_json = individual_utils.read_individual(
+        flask_app_client, researcher_1, individual_id
+    ).json
+
+    assert individual_json['timeOfDeath'] == time_of_death

--- a/tests/modules/individuals/resources/test_individual_crud.py
+++ b/tests/modules/individuals/resources/test_individual_crud.py
@@ -419,40 +419,6 @@ def test_individual_mixed_edm_houston_patch(
 @pytest.mark.skipif(
     module_unavailable('individuals'), reason='Individuals module disabled'
 )
-def test_individual_edm_patch_add(db, flask_app_client, researcher_1, request, test_root):
-    uuids = individual_utils.create_individual_and_sighting(
-        flask_app_client,
-        researcher_1,
-        request,
-        test_root,
-    )
-    individual_id = uuids['individual']
-    time_of_death = 1445410803000  # I feel incredible power setting this var
-    time_of_birth_str = '1445410800000'
-    sex = 'female'
-
-    individual_utils.patch_individual(
-        flask_app_client,
-        researcher_1,
-        individual_id,
-        [
-            {'op': 'add', 'path': '/timeOfDeath', 'value': time_of_death},
-            {'op': 'add', 'path': '/timeOfBirth', 'value': time_of_birth_str},
-            {'op': 'add', 'path': '/sex', 'value': sex},
-        ],
-    )
-    individual_json = individual_utils.read_individual(
-        flask_app_client, researcher_1, individual_id
-    ).json
-
-    assert individual_json['timeOfDeath'] == str(time_of_death)
-    assert individual_json['timeOfBirth'] == time_of_birth_str
-    assert individual_json['sex'] == sex
-
-
-@pytest.mark.skipif(
-    module_unavailable('individuals'), reason='Individuals module disabled'
-)
 def test_edm_custom_field_patch(
     db, flask_app_client, researcher_1, admin_user, request, test_root
 ):

--- a/tests/modules/individuals/resources/test_individual_crud.py
+++ b/tests/modules/individuals/resources/test_individual_crud.py
@@ -427,6 +427,8 @@ def test_individual_edm_patch_add(db, flask_app_client, researcher_1, request, t
     )
     individual_id = uuids['individual']
     time_of_death = 1445410803000  # I feel incredible power setting this var
+    time_of_birth_str = '1445410800000'
+    sex = 'female'
 
     individual_utils.patch_individual(
         flask_app_client,
@@ -434,10 +436,14 @@ def test_individual_edm_patch_add(db, flask_app_client, researcher_1, request, t
         individual_id,
         [
             {'op': 'add', 'path': '/timeOfDeath', 'value': time_of_death},
+            {'op': 'add', 'path': '/timeOfBirth', 'value': time_of_birth_str},
+            {'op': 'add', 'path': '/sex', 'value': sex},
         ],
     )
     individual_json = individual_utils.read_individual(
         flask_app_client, researcher_1, individual_id
     ).json
 
-    assert individual_json['timeOfDeath'] == time_of_death
+    assert individual_json['timeOfDeath'] == str(time_of_death)
+    assert individual_json['timeOfBirth'] == time_of_birth_str
+    assert individual_json['sex'] == sex


### PR DESCRIPTION
Adds support for patching individual custom fields. Very simple so IMO merge-able after one reviewer checks off.

One-line fix as identified by Emily and Jon in DEX-865, along with a test replicating the reported bug. The test simply creates an individual, creates a custom field (these fields are registered in the EDM db), and then sets that custom field for the individual.

Before the one-line fix, the test broke. After the one-line fix, the test passes.