### PR TITLE
885 AG test clone not cached and reduced usage

### DIFF
--- a/tests/extensions/test_elasticsearch.py
+++ b/tests/extensions/test_elasticsearch.py
@@ -65,7 +65,8 @@ def test_elasticsearch_utilities(
     temp_user,
     collab_user_a,
     collab_user_b,
-    test_clone_asset_group_data,
+    request,
+    test_root,
 ):
     from app.extensions.elasticsearch import tasks as es_tasks
     from app.extensions import elasticsearch as es
@@ -400,11 +401,10 @@ def test_elasticsearch_utilities(
         except AssertionError:
             failures.append(config_str)
 
-    clone = asset_group_utils.clone_asset_group(
-        flask_app_client,
-        staff_user,
-        test_clone_asset_group_data['asset_group_uuid'],
+    asset_group_utils.create_simple_asset_group_uuids(
+        flask_app_client, staff_user, request, test_root
     )
+
     with es.session.begin(blocking=True, verify=True):
         Asset.index_all()
 
@@ -679,8 +679,6 @@ def test_elasticsearch_utilities(
     # Test tasks
     es_tasks.es_task_refresh_index_all.s(True).apply().result
     es_tasks.es_task_invalidate_indexed_timestamps.s(True).apply().result
-
-    clone.cleanup()
 
 
 @pytest.mark.skipif(

--- a/tests/modules/asset_groups/resources/test_permissions.py
+++ b/tests/modules/asset_groups/resources/test_permissions.py
@@ -4,7 +4,6 @@ import uuid
 
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.modules.assets.resources.utils as asset_utils
-import tests.extensions.tus.utils as tus_utils
 from tests import utils as test_utils
 import pytest
 
@@ -15,116 +14,75 @@ from tests.utils import module_unavailable
     module_unavailable('asset_groups'), reason='AssetGroups module disabled'
 )
 def test_user_read_permissions(
-    flask_app_client,
-    researcher_1,
-    readonly_user,
-    db,
-    test_clone_asset_group_data,
+    flask_app_client, researcher_1, readonly_user, db, request, test_root
 ):
-    # Clone as the researcher user and then try to reread as both researcher and readonly user,
+    # Create as the researcher user and then try to reread as both researcher and readonly user,
     # read by researcher user should succeed, read by readonly user should be blocked
+    uuids = asset_group_utils.create_simple_asset_group_uuids(
+        flask_app_client, researcher_1, request, test_root
+    )
+    asset_guid = uuids['assets'][0]
+    asset_group_guid = uuids['asset_group']
 
-    clone = asset_group_utils.clone_asset_group(
-        flask_app_client,
-        researcher_1,
-        test_clone_asset_group_data['asset_group_uuid'],
-    )
-
-    asset_utils.read_asset(
-        flask_app_client,
-        researcher_1,
-        test_clone_asset_group_data['asset_uuids'][0],
-    )
+    asset_utils.read_asset(flask_app_client, researcher_1, asset_guid)
+    asset_group_utils.read_asset_group(flask_app_client, researcher_1, asset_group_guid)
+    asset_utils.read_asset(flask_app_client, readonly_user, asset_guid, 403)
     asset_group_utils.read_asset_group(
-        flask_app_client,
-        researcher_1,
-        test_clone_asset_group_data['asset_group_uuid'],
-    )
-    asset_utils.read_asset(
-        flask_app_client,
-        readonly_user,
-        test_clone_asset_group_data['asset_uuids'][0],
-        403,
-    )
-    asset_group_utils.read_asset_group(
-        flask_app_client,
-        readonly_user,
-        test_clone_asset_group_data['asset_group_uuid'],
-        403,
+        flask_app_client, readonly_user, asset_group_guid, 403
     )
     # and as no user
-    asset_group_utils.read_asset_group(
-        flask_app_client, None, test_clone_asset_group_data['asset_group_uuid'], 401
-    )
-    clone.cleanup()
+    asset_group_utils.read_asset_group(flask_app_client, None, asset_group_guid, 401)
 
 
 @pytest.mark.skipif(
     module_unavailable('asset_groups'), reason='AssetGroups module disabled'
 )
 def test_create_patch_asset_group(
-    flask_app_client, researcher_1, readonly_user, test_root, db
+    flask_app_client, researcher_1, readonly_user, test_root, db, request
 ):
     # pylint: disable=invalid-name
-    asset_group_guid = None
-    transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
-    try:
-        from app.modules.asset_groups.models import AssetGroup
+    uuids = asset_group_utils.create_simple_asset_group_uuids(
+        flask_app_client, researcher_1, request, test_root
+    )
+    asset_group_guid = uuids['asset_group']
+    from app.modules.asset_groups.models import AssetGroup
 
-        data = asset_group_utils.AssetGroupCreationData(transaction_id, test_filename)
+    temp_asset_group = AssetGroup.query.get(asset_group_guid)
 
-        create_response = asset_group_utils.create_asset_group(
-            flask_app_client, researcher_1, data.get()
-        )
-        assert create_response.json['description'] == data.get()['description']
-        asset_group_guid = create_response.json['guid']
-        temp_asset_group = AssetGroup.query.get(asset_group_guid)
+    # reassign ownership
+    patch_data = [
+        test_utils.patch_add_op(
+            'description', 'This is a test asset_group, kindly ignore'
+        ),
+    ]
 
-        # reassign ownership
-        patch_data = [
-            test_utils.patch_add_op(
-                'description', 'This is a test asset_group, kindly ignore'
-            ),
-        ]
+    # Try to patch as non owner and validate it fails
+    asset_group_utils.patch_asset_group(
+        flask_app_client, readonly_user, asset_group_guid, patch_data, 403
+    )
 
-        # Try to patch as non owner and validate it fails
-        asset_group_utils.patch_asset_group(
-            flask_app_client, readonly_user, asset_group_guid, patch_data, 403
-        )
+    # Should pass as owner
+    patch_response = asset_group_utils.patch_asset_group(
+        flask_app_client, researcher_1, asset_group_guid, patch_data
+    )
 
-        # Should pass as owner
-        patch_response = asset_group_utils.patch_asset_group(
-            flask_app_client, researcher_1, asset_group_guid, patch_data
-        )
+    assert patch_response.json['description'] == patch_data[0]['value']
+    assert patch_response.json['guid'] == asset_group_guid
 
-        assert patch_response.json['description'] == patch_data[0]['value']
-        assert patch_response.json['guid'] == asset_group_guid
+    db.session.refresh(temp_asset_group)
 
-        db.session.refresh(temp_asset_group)
+    # Readonly user should not be able to delete
+    asset_group_utils.delete_asset_group(
+        flask_app_client, readonly_user, asset_group_guid, 403
+    )
 
-        # Readonly user should not be able to delete
-        asset_group_utils.delete_asset_group(
-            flask_app_client, readonly_user, asset_group_guid, 403
-        )
+    # researcher should
+    asset_group_utils.delete_asset_group(flask_app_client, researcher_1, asset_group_guid)
+    # temp_asset_group should be already deleted on gitlab
+    assert not AssetGroup.is_on_remote(str(temp_asset_group.guid))
 
-        # researcher should
-        asset_group_utils.delete_asset_group(
-            flask_app_client, researcher_1, asset_group_guid
-        )
-        # temp_asset_group should be already deleted on gitlab
-        assert not AssetGroup.is_on_remote(str(temp_asset_group.guid))
+    # And if the asset_group is already gone, a re attempt at deletion should get the same response
+    asset_group_utils.delete_asset_group(flask_app_client, researcher_1, asset_group_guid)
 
-        # And if the asset_group is already gone, a re attempt at deletion should get the same response
-        asset_group_utils.delete_asset_group(
-            flask_app_client, researcher_1, asset_group_guid
-        )
-
-        # As should a delete of a random uuid
-        asset_group_utils.delete_asset_group(flask_app_client, researcher_1, uuid.uuid4())
-
-    finally:
-        tus_utils.cleanup_tus_dir(transaction_id)
-        # Restore original state
-        temp_asset_group = AssetGroup.query.get(asset_group_guid)
-        if temp_asset_group is not None:
-            temp_asset_group.delete()
+    # As should a delete of a random uuid
+    asset_group_utils.delete_asset_group(flask_app_client, researcher_1, uuid.uuid4())

--- a/tests/modules/assets/resources/test_asset_tags.py
+++ b/tests/modules/assets/resources/test_asset_tags.py
@@ -9,506 +9,435 @@ import pytest
 from tests.utils import module_unavailable
 
 
+def create_test_tag(db, name):
+    from app.modules.keywords.models import Keyword
+
+    keyword = Keyword(value=name)
+    with db.session.begin():
+        db.session.add(keyword)
+    assert keyword is not None
+    return keyword
+
+
+def cleanup_test_tags(db):
+    from app.modules.keywords.models import Keyword as Tag
+
+    for tag in Tag.query.all():
+        if tag.value.startswith('TEST_TAG_VALUE_'):
+            db.session.delete(tag)
+            read_tag = Tag.query.get(tag.guid)
+            assert read_tag is None
+
+
 @pytest.mark.skipif(
     module_unavailable('asset_groups'), reason='AssetGroups module disabled'
 )
-def test_tags_on_asset(flask_app_client, researcher_1, test_clone_asset_group_data, db):
+def test_tags_on_asset(flask_app_client, researcher_1, db, request, test_root):
     # pylint: disable=invalid-name
     from app.modules.assets.models import Asset
-    from app.modules.keywords.models import Keyword as Tag
     from app.modules.keywords.models import KeywordSource as TagSource
+
+    request.addfinalizer(lambda: cleanup_test_tags(db))
 
     # this gives us an "existing" tag to work with
     tag_value1 = 'TEST_TAG_VALUE_1'
-    tag = Tag(value=tag_value1)
-    with db.session.begin():
-        db.session.add(tag)
-    assert tag is not None
+    tag = create_test_tag(db, tag_value1)
 
-    # Clone the known asset_group so that the asset data is in the database
-    clone = asset_group_utils.clone_asset_group(
+    uuids = asset_group_utils.create_simple_asset_group_uuids(
+        flask_app_client, researcher_1, request, test_root
+    )
+    asset_guid = uuids['assets'][0]
+
+    response = asset_utils.read_asset(flask_app_client, researcher_1, asset_guid)
+    assert asset_guid == response.json['guid']
+    asset = Asset.query.get(asset_guid)
+    assert asset is not None
+
+    # patch to add *existing* tag
+    asset_utils.patch_asset(
         flask_app_client,
+        asset.guid,
         researcher_1,
-        test_clone_asset_group_data['asset_group_uuid'],
+        [utils.patch_add_op('tags', str(tag.guid))],
+    )
+    kw = asset.get_tags()
+    assert len(kw) == 1
+    assert kw[0].value == tag_value1
+
+    # patch to add *existing* tag
+    asset_utils.patch_asset(
+        flask_app_client,
+        asset.guid,
+        researcher_1,
+        [utils.patch_add_op('tags', str(tag.guid))],
+    )
+    kw = asset.get_tags()
+    assert len(kw) == 1
+    assert kw[0].value == tag_value1
+
+    # Doing this again should be fine and be a no-op
+    tag_value2 = 'TEST_TAG_VALUE_2'
+    asset_utils.patch_asset(
+        flask_app_client,
+        asset.guid,
+        researcher_1,
+        [utils.patch_add_op('tags', {'value': tag_value2, 'source': TagSource.user})],
+    )
+    kw = asset.get_tags()
+    assert len(kw) == 2
+    # since tag order is arbitrary, we dont know which this is, but should be one of them!
+    assert kw[0].value == tag_value2 or kw[1].value == tag_value2
+
+    # patch to add *new* tag (by value) -- except will fail (409) cuz tag exists
+    asset_utils.patch_asset(
+        flask_app_client,
+        asset.guid,
+        researcher_1,
+        [utils.patch_add_op('tags', {'value': tag_value2, 'source': TagSource.user})],
     )
 
-    asset = None
-    try:
-        asset_guid = clone.asset_group.assets[0].guid
+    # patch to add invalid tag guid
+    asset_utils.patch_asset(
+        flask_app_client,
+        asset.guid,
+        researcher_1,
+        [utils.patch_add_op('tags', '00000000-0000-0000-0000-000000002170')],
+        409,
+    )
+
+    # patch a tag with a test op
+    tag_value3 = 'TEST_TAG_VALUE_3'
+    asset_utils.patch_asset(
+        flask_app_client,
+        asset.guid,
+        researcher_1,
+        [
+            utils.patch_test_op(tag_value3, path='tags'),
+            utils.patch_add_op('tags', '[0]'),
+        ],
+    )
+
+    # Check if missing the op causes a failure
+    asset_utils.patch_asset(
+        flask_app_client,
+        asset.guid,
+        researcher_1,
+        [utils.patch_add_op('tags', '[0]')],
+        409,
+    )
+
+    # Check if duplicates cause an issue
+    tag_value4 = 'TEST_TAG_VALUE_4'
+    tag_value5 = 'TEST_TAG_VALUE_5'
+    asset_utils.patch_asset(
+        flask_app_client,
+        asset.guid,
+        researcher_1,
+        [
+            utils.patch_test_op(str(tag.guid), path='tags'),
+            utils.patch_test_op(
+                {'value': tag_value2, 'source': TagSource.user},
+                path='tags',
+            ),
+            utils.patch_test_op(tag_value3, path='tags'),
+            utils.patch_add_op('tags', str(tag.guid)),
+            utils.patch_add_op('tags', tag_value3),
+            utils.patch_add_op('tags', '[0]'),
+            utils.patch_add_op('tags', '[1]'),
+            utils.patch_add_op('tags', '[2]'),
+            utils.patch_add_op('tags', '[0]'),
+            utils.patch_test_op(tag_value5, path='tags'),
+            utils.patch_add_op('tags', {'value': tag_value4, 'source': TagSource.user}),
+            utils.patch_add_op('tags', '[3]'),
+        ],
+    )
+
+    # Check if removal works as well with indexing
+    asset_utils.patch_asset(
+        flask_app_client,
+        asset.guid,
+        researcher_1,
+        [
+            utils.patch_test_op(tag_value3, path='tags'),
+            utils.patch_remove_op('tags', '[0]'),
+            utils.patch_test_op(tag_value5, path='tags'),
+            utils.patch_remove_op(
+                'tags', {'value': tag_value4, 'source': TagSource.user}
+            ),
+            utils.patch_remove_op('tags', '[1]'),
+        ],
+    )
+
+    # patch to remove a tag (only can happen by id)
+    res = tag_utils.read_all_keywords(flask_app_client, researcher_1)
+    orig_kwct = len(res.json)
+
+    asset_utils.patch_asset(
+        flask_app_client,
+        asset.guid,
+        researcher_1,
+        [utils.patch_remove_op('tags', str(tag.guid))],
+    )
+    kw = asset.get_tags()
+    assert len(kw) == 1
+    assert kw[0].value == tag_value2
+
+    # Doing this again should be just fine
+    asset_utils.patch_asset(
+        flask_app_client,
+        asset.guid,
+        researcher_1,
+        [utils.patch_remove_op('tags', str(tag.guid))],
+    )
+    kw = asset.get_tags()
+    assert len(kw) == 1
+    assert kw[0].value == tag_value2
+
+    res = tag_utils.read_all_keywords(flask_app_client, researcher_1)
+    kwct = len(res.json)
+    # [DEX-347] op=remove above caused deletion of unused tag
+    assert kwct == orig_kwct - 1
+
+    guid = res.json[0]['guid']
+    asset_utils.patch_asset(
+        flask_app_client,
+        asset.guid,
+        researcher_1,
+        [utils.patch_remove_op('tags', str(guid))],
+    )
+
+    # the delete_asset above should take the un-reference tag with it [DEX-347], thus:
+    res = tag_utils.read_all_keywords(flask_app_client, researcher_1)
+    assert len(res.json) == kwct - 1
+
+
+@pytest.mark.skipif(
+    module_unavailable('asset_groups'), reason='AssetGroups module disabled'
+)
+def test_tags_on_bulk_asset(flask_app_client, researcher_1, db, request, test_root):
+    # pylint: disable=invalid-name
+    from app.modules.assets.models import Asset
+
+    request.addfinalizer(lambda: cleanup_test_tags(db))
+
+    # this gives us an "existing" tag to work with
+    tag_value1 = 'TEST_TAG_VALUE_1'
+    tag1 = create_test_tag(db, tag_value1)
+    tag_value2 = 'TEST_TAG_VALUE_2'
+    tag2 = create_test_tag(db, tag_value2)
+
+    uuids = asset_group_utils.create_large_asset_group_uuids(
+        flask_app_client, researcher_1, request, test_root
+    )
+
+    assets = []
+    for asset_guid in uuids['assets']:
         response = asset_utils.read_asset(flask_app_client, researcher_1, asset_guid)
         asset_guid = response.json['guid']
         asset = Asset.query.get(asset_guid)
         assert asset is not None
-
-        # patch to add *existing* tag
-        res = asset_utils.patch_asset(
-            flask_app_client,
-            asset.guid,
-            researcher_1,
-            [utils.patch_add_op('tags', str(tag.guid))],
-        )
+        assets.append(asset)
         kw = asset.get_tags()
-        assert len(kw) == 1
-        assert kw[0].value == tag_value1
+        assert len(kw) == 0
 
-        # patch to add *existing* tag
-        res = asset_utils.patch_asset(
-            flask_app_client,
-            asset.guid,
-            researcher_1,
-            [utils.patch_add_op('tags', str(tag.guid))],
-        )
-        kw = asset.get_tags()
-        assert len(kw) == 1
-        assert kw[0].value == tag_value1
+    patch_ops = []
+    for index, asset in enumerate(assets):
+        if index == 0:
+            patch_ops.append(utils.patch_add_op('tags', str(tag1.guid), guid=asset.guid))
+            # doing this twice should be fine
+            patch_ops.append(utils.patch_add_op('tags', str(tag1.guid), guid=asset.guid))
+        elif index == 1:
+            # Check if we can assign the same tag twice to the same asset
+            patch_ops.append(utils.patch_add_op('tags', str(tag1.guid), guid=asset.guid))
+            patch_ops.append(utils.patch_add_op('tags', str(tag2.guid), guid=asset.guid))
+        elif index == 2:
+            # Check if we can assign the same tag twice to the same asset
+            patch_ops.append(utils.patch_add_op('tags', str(tag2.guid), guid=asset.guid))
+            patch_ops.append(utils.patch_add_op('tags', str(tag1.guid), guid=asset.guid))
+        elif index == 3:
+            patch_ops.append(utils.patch_add_op('tags', str(tag2.guid), guid=asset.guid))
+        else:
+            raise RuntimeError()
 
-        # Doing this again should be fine and be a no-op
-        tag_value2 = 'TEST_TAG_VALUE_2'
-        res = asset_utils.patch_asset(
-            flask_app_client,
-            asset.guid,
-            researcher_1,
-            [utils.patch_add_op('tags', {'value': tag_value2, 'source': TagSource.user})],
-        )
-        kw = asset.get_tags()
-        assert len(kw) == 2
-        # since tag order is arbitrary, we dont know which this is, but should be one of them!
-        assert kw[0].value == tag_value2 or kw[1].value == tag_value2
-
-        # patch to add *new* tag (by value) -- except will fail (409) cuz tag exists
-        res = asset_utils.patch_asset(
-            flask_app_client,
-            asset.guid,
-            researcher_1,
-            [utils.patch_add_op('tags', {'value': tag_value2, 'source': TagSource.user})],
-        )
-
-        # patch to add invalid tag guid
-        res = asset_utils.patch_asset(
-            flask_app_client,
-            asset.guid,
-            researcher_1,
-            [utils.patch_add_op('tags', '00000000-0000-0000-0000-000000002170')],
-            409,
-        )
-
-        # patch a tag with a test op
-        tag_value3 = 'TEST_TAG_VALUE_3'
-        res = asset_utils.patch_asset(
-            flask_app_client,
-            asset.guid,
-            researcher_1,
-            [
-                utils.patch_test_op(
-                    tag_value3,
-                    path='tags',
-                ),
-                utils.patch_add_op('tags', '[0]'),
-            ],
-        )
-
-        # Check if missing the op causes a failure
-        res = asset_utils.patch_asset(
-            flask_app_client,
-            asset.guid,
-            researcher_1,
-            [utils.patch_add_op('tags', '[0]')],
-            409,
-        )
-
-        # Check if duplicates cause an issue
-        tag_value4 = 'TEST_TAG_VALUE_4'
-        tag_value5 = 'TEST_TAG_VALUE_5'
-        res = asset_utils.patch_asset(
-            flask_app_client,
-            asset.guid,
-            researcher_1,
-            [
-                utils.patch_test_op(
-                    str(tag.guid),
-                    path='tags',
-                ),
-                utils.patch_test_op(
-                    {'value': tag_value2, 'source': TagSource.user},
-                    path='tags',
-                ),
-                utils.patch_test_op(
-                    tag_value3,
-                    path='tags',
-                ),
-                utils.patch_add_op('tags', str(tag.guid)),
-                utils.patch_add_op('tags', tag_value3),
-                utils.patch_add_op('tags', '[0]'),
-                utils.patch_add_op('tags', '[1]'),
-                utils.patch_add_op('tags', '[2]'),
-                utils.patch_add_op('tags', '[0]'),
-                utils.patch_test_op(
-                    tag_value5,
-                    path='tags',
-                ),
-                utils.patch_add_op(
-                    'tags', {'value': tag_value4, 'source': TagSource.user}
-                ),
-                utils.patch_add_op('tags', '[3]'),
-            ],
-        )
-
-        # Check if removal works as well with indexing
-        res = asset_utils.patch_asset(
-            flask_app_client,
-            asset.guid,
-            researcher_1,
-            [
-                utils.patch_test_op(
-                    tag_value3,
-                    path='tags',
-                ),
-                utils.patch_remove_op('tags', '[0]'),
-                utils.patch_test_op(
-                    tag_value5,
-                    path='tags',
-                ),
-                utils.patch_remove_op(
-                    'tags', {'value': tag_value4, 'source': TagSource.user}
-                ),
-                utils.patch_remove_op('tags', '[1]'),
-            ],
-        )
-
-        # patch to remove a tag (only can happen by id)
-        res = tag_utils.read_all_keywords(flask_app_client, researcher_1)
-        orig_kwct = len(res.json)
-
-        res = asset_utils.patch_asset(
-            flask_app_client,
-            asset.guid,
-            researcher_1,
-            [utils.patch_remove_op('tags', str(tag.guid))],
-        )
-        kw = asset.get_tags()
-        assert len(kw) == 1
-        assert kw[0].value == tag_value2
-
-        # Doing this again should be just fine
-        res = asset_utils.patch_asset(
-            flask_app_client,
-            asset.guid,
-            researcher_1,
-            [utils.patch_remove_op('tags', str(tag.guid))],
-        )
-        kw = asset.get_tags()
-        assert len(kw) == 1
-        assert kw[0].value == tag_value2
-
-        res = tag_utils.read_all_keywords(flask_app_client, researcher_1)
-        kwct = len(res.json)
-        assert (
-            kwct == orig_kwct - 1
-        )  # [DEX-347] op=remove above caused deletion of unused tag
-
-        guid = res.json[0]['guid']
-        res = asset_utils.patch_asset(
-            flask_app_client,
-            asset.guid,
-            researcher_1,
-            [utils.patch_remove_op('tags', str(guid))],
-        )
-
-        # the delete_asset above should take the un-reference tag with it [DEX-347], thus:
-        res = tag_utils.read_all_keywords(flask_app_client, researcher_1)
-        assert len(res.json) == kwct - 1
-    finally:
-        with db.session.begin():
-            for asset in clone.asset_group.assets:
-                # Delete the asset
-                asset.delete_cascade()
-                read_asset = Asset.query.get(asset.guid)
-                assert read_asset is None
-
-            for tag in Tag.query.all():
-                if tag.value.startswith('TEST_TAG_VALUE_'):
-                    db.session.delete(tag)
-                    read_tag = Tag.query.get(tag.guid)
-                    assert read_tag is None
-
-        clone.cleanup()
-
-
-@pytest.mark.skipif(
-    module_unavailable('asset_groups'), reason='AssetGroups module disabled'
-)
-def test_tags_on_bulk_asset(
-    flask_app_client, researcher_1, test_clone_asset_group_data, db
-):
-    # pylint: disable=invalid-name
-    from app.modules.assets.models import Asset
-    from app.modules.keywords.models import Keyword as Tag
-
-    # this gives us an "existing" tag to work with
-    tag_value1 = 'TEST_TAG_VALUE_6'
-    tag1 = Tag(value=tag_value1)
-    with db.session.begin():
-        db.session.add(tag1)
-    assert tag1 is not None
-
-    tag_value2 = 'TEST_TAG_VALUE_7'
-    tag2 = Tag(value=tag_value2)
-    with db.session.begin():
-        db.session.add(tag2)
-    assert tag2 is not None
-
-    # Clone the known asset_group so that the asset data is in the database
-    clone = asset_group_utils.clone_asset_group(
+    # patch to add *existing* tag
+    asset_utils.patch_asset_bulk(
         flask_app_client,
         researcher_1,
-        test_clone_asset_group_data['asset_group_uuid'],
+        patch_ops,
     )
 
-    assets = []
-    try:
-        for asset_guid in test_clone_asset_group_data['asset_uuids']:
-            response = asset_utils.read_asset(flask_app_client, researcher_1, asset_guid)
-            asset_guid = response.json['guid']
-            asset = Asset.query.get(asset_guid)
-            assert asset is not None
-            assets.append(asset)
-            kw = asset.get_tags()
-            assert len(kw) == 0
+    for index, asset in enumerate(assets):
+        kw = asset.get_tags()
+        if index == 0:
+            assert len(kw) == 1
+            assert kw[0].value == tag_value1
+        elif index == 1:
+            assert len(kw) == 2
+            assert kw[0].value == tag_value1
+            assert kw[1].value == tag_value2
+        elif index == 2:
+            assert len(kw) == 2
+            assert kw[0].value == tag_value1
+            assert kw[1].value == tag_value2
+        elif index == 3:
+            assert len(kw) == 1
+            assert kw[0].value == tag_value2
+        else:
+            raise RuntimeError()
 
-        patch_ops = []
-        for index, asset in enumerate(assets):
-            if index == 0:
-                patch_ops.append(
-                    utils.patch_add_op('tags', str(tag1.guid), guid=asset.guid)
-                )
-                # doing this twice should be fine
-                patch_ops.append(
-                    utils.patch_add_op('tags', str(tag1.guid), guid=asset.guid)
-                )
-            elif index == 1:
-                # Check if we can assign the same tag twice to the same asset
-                patch_ops.append(
-                    utils.patch_add_op('tags', str(tag1.guid), guid=asset.guid)
-                )
-                patch_ops.append(
-                    utils.patch_add_op('tags', str(tag2.guid), guid=asset.guid)
-                )
-            elif index == 2:
-                # Check if we can assign the same tag twice to the same asset
-                patch_ops.append(
-                    utils.patch_add_op('tags', str(tag2.guid), guid=asset.guid)
-                )
-                patch_ops.append(
-                    utils.patch_add_op('tags', str(tag1.guid), guid=asset.guid)
-                )
-            elif index == 3:
-                patch_ops.append(
-                    utils.patch_add_op('tags', str(tag2.guid), guid=asset.guid)
-                )
-            else:
-                raise RuntimeError()
+    # patch to remove a tag (only can happen by id)
+    res = tag_utils.read_all_keywords(flask_app_client, researcher_1)
+    orig_kwct = len(res.json)
 
-        # patch to add *existing* tag
-        res = asset_utils.patch_asset_bulk(
-            flask_app_client,
-            researcher_1,
-            patch_ops,
-        )
-
-        for index, asset in enumerate(assets):
-            kw = asset.get_tags()
-            if index == 0:
-                assert len(kw) == 1
-                assert kw[0].value == tag_value1
-            elif index == 1:
-                assert len(kw) == 2
-                assert kw[0].value == tag_value1
-                assert kw[1].value == tag_value2
-            elif index == 2:
-                assert len(kw) == 2
-                assert kw[0].value == tag_value1
-                assert kw[1].value == tag_value2
-            elif index == 3:
-                assert len(kw) == 1
-                assert kw[0].value == tag_value2
-            else:
-                raise RuntimeError()
-
-        # patch to remove a tag (only can happen by id)
-        res = tag_utils.read_all_keywords(flask_app_client, researcher_1)
-        orig_kwct = len(res.json)
-
-        patch_ops = []
-        for index, asset in enumerate(assets):
-            if index == 0:
-                pass
-            elif index == 1:
-                # Check if we can assign the same tag twice to the same asset
-                patch_ops.append(
-                    utils.patch_remove_op('tags', str(tag1.guid), guid=asset.guid)
-                )
-            elif index == 2:
-                # Check if we can assign the same tag twice to the same asset
-                patch_ops.append(
-                    utils.patch_remove_op('tags', str(tag2.guid), guid=asset.guid)
-                )
-                patch_ops.append(
-                    utils.patch_remove_op('tags', str(tag1.guid), guid=asset.guid)
-                )
-            elif index == 3:
-                patch_ops.append(
-                    utils.patch_add_op('tags', str(tag1.guid), guid=asset.guid)
-                )
-            else:
-                raise RuntimeError()
-
-        # patch to remove (and modify) tags
-        res = asset_utils.patch_asset_bulk(
-            flask_app_client,
-            researcher_1,
-            patch_ops,
-        )
-
-        for index, asset in enumerate(assets):
-            kw = asset.get_tags()
-            if index == 0:
-                assert len(kw) == 1
-                assert kw[0].value == tag_value1
-            elif index == 1:
-                assert len(kw) == 1
-                assert kw[0].value == tag_value2
-            elif index == 2:
-                assert len(kw) == 0
-            elif index == 3:
-                assert len(kw) == 2
-                assert kw[0].value == tag_value1
-                assert kw[1].value == tag_value2
-            else:
-                raise RuntimeError()
-
-        res = tag_utils.read_all_keywords(flask_app_client, researcher_1)
-        kwct = len(res.json)
-        assert kwct == orig_kwct
-
-        # Remove all tag1 references
-        patch_ops = []
-        for index, asset in enumerate(assets):
-            if index == 0:
-                patch_ops.append(
-                    utils.patch_remove_op('tags', str(tag1.guid), guid=asset.guid)
-                )
-            elif index == 1:
-                pass
-            elif index == 2:
-                pass
-            elif index == 3:
-                patch_ops.append(
-                    utils.patch_remove_op('tags', str(tag1.guid), guid=asset.guid)
-                )
-            else:
-                raise RuntimeError()
-
-        # patch to remove (and modify) tags
-        res = asset_utils.patch_asset_bulk(
-            flask_app_client,
-            researcher_1,
-            patch_ops,
-        )
-
-        for index, asset in enumerate(assets):
-            kw = asset.get_tags()
-            if index == 0:
-                assert len(kw) == 0
-            elif index == 1:
-                assert len(kw) == 1
-                assert kw[0].value == tag_value2
-            elif index == 2:
-                assert len(kw) == 0
-            elif index == 3:
-                assert len(kw) == 1
-                assert kw[0].value == tag_value2
-            else:
-                raise RuntimeError()
-
-        res = tag_utils.read_all_keywords(flask_app_client, researcher_1)
-        kwct = len(res.json)
-        assert kwct == orig_kwct - 1
-
-        # Check test OP with batch apply
-        patch_ops = [
-            utils.patch_test_op(
-                str(tag2.guid),
-                path='tags',
+    patch_ops = []
+    for index, asset in enumerate(assets):
+        if index == 0:
+            pass
+        elif index == 1:
+            # Check if we can assign the same tag twice to the same asset
+            patch_ops.append(
+                utils.patch_remove_op('tags', str(tag1.guid), guid=asset.guid)
             )
-        ]
-        for index, asset in enumerate(assets):
-            if index == 0:
-                pass
-            elif index == 1:
-                patch_ops.append(utils.patch_add_op('tags', '[0]', guid=asset.guid))
-            elif index == 2:
-                pass
-            elif index == 3:
-                patch_ops.append(utils.patch_add_op('tags', '[0]', guid=asset.guid))
-                # Doing this should be fine
-                patch_ops.append(utils.patch_add_op('tags', '[0]', guid=asset.guid))
-            else:
-                raise RuntimeError()
+        elif index == 2:
+            # Check if we can assign the same tag twice to the same asset
+            patch_ops.append(
+                utils.patch_remove_op('tags', str(tag2.guid), guid=asset.guid)
+            )
+            patch_ops.append(
+                utils.patch_remove_op('tags', str(tag1.guid), guid=asset.guid)
+            )
+        elif index == 3:
+            patch_ops.append(utils.patch_add_op('tags', str(tag1.guid), guid=asset.guid))
+        else:
+            raise RuntimeError()
 
-        res = asset_utils.patch_asset_bulk(
-            flask_app_client,
-            researcher_1,
-            patch_ops,
-        )
+    # patch to remove (and modify) tags
+    asset_utils.patch_asset_bulk(
+        flask_app_client,
+        researcher_1,
+        patch_ops,
+    )
 
-        # Remove all tag1 references
-        patch_ops = []
-        for index, asset in enumerate(assets):
-            if index == 0:
-                pass
-            elif index == 1:
-                patch_ops.append(
-                    utils.patch_remove_op('tags', str(tag2.guid), guid=asset.guid)
-                )
-            elif index == 2:
-                pass
-            elif index == 3:
-                patch_ops.append(
-                    utils.patch_remove_op('tags', str(tag2.guid), guid=asset.guid)
-                )
-                # Doing this should be fine
-                patch_ops.append(
-                    utils.patch_remove_op('tags', str(tag2.guid), guid=asset.guid)
-                )
-            else:
-                raise RuntimeError()
-
-        # patch to remove (and modify) tags
-        res = asset_utils.patch_asset_bulk(
-            flask_app_client,
-            researcher_1,
-            patch_ops,
-        )
-
-        for index, asset in enumerate(assets):
-            kw = asset.get_tags()
+    for index, asset in enumerate(assets):
+        kw = asset.get_tags()
+        if index == 0:
+            assert len(kw) == 1
+            assert kw[0].value == tag_value1
+        elif index == 1:
+            assert len(kw) == 1
+            assert kw[0].value == tag_value2
+        elif index == 2:
             assert len(kw) == 0
+        elif index == 3:
+            assert len(kw) == 2
+            assert kw[0].value == tag_value1
+            assert kw[1].value == tag_value2
+        else:
+            raise RuntimeError()
 
-        # the delete_asset above should take the un-reference tag with it [DEX-347], thus:
-        res = tag_utils.read_all_keywords(flask_app_client, researcher_1)
-        assert len(res.json) == kwct - 1
-    finally:
-        with db.session.begin():
-            for asset in clone.asset_group.assets:
-                # Delete the asset
-                asset.delete_cascade()
-                read_asset = Asset.query.get(asset.guid)
-                assert read_asset is None
+    res = tag_utils.read_all_keywords(flask_app_client, researcher_1)
+    kwct = len(res.json)
+    assert kwct == orig_kwct
 
-            for tag in Tag.query.all():
-                if tag.value.startswith('TEST_TAG_VALUE_'):
-                    db.session.delete(tag)
-                    read_tag = Tag.query.get(tag.guid)
-                    assert read_tag is None
+    # Remove all tag1 references
+    patch_ops = []
+    for index, asset in enumerate(assets):
+        if index == 0:
+            patch_ops.append(
+                utils.patch_remove_op('tags', str(tag1.guid), guid=asset.guid)
+            )
+        elif index == 1:
+            pass
+        elif index == 2:
+            pass
+        elif index == 3:
+            patch_ops.append(
+                utils.patch_remove_op('tags', str(tag1.guid), guid=asset.guid)
+            )
+        else:
+            raise RuntimeError()
 
-        clone.cleanup()
+    # patch to remove (and modify) tags
+    asset_utils.patch_asset_bulk(
+        flask_app_client,
+        researcher_1,
+        patch_ops,
+    )
+
+    for index, asset in enumerate(assets):
+        kw = asset.get_tags()
+        if index == 0:
+            assert len(kw) == 0
+        elif index == 1:
+            assert len(kw) == 1
+            assert kw[0].value == tag_value2
+        elif index == 2:
+            assert len(kw) == 0
+        elif index == 3:
+            assert len(kw) == 1
+            assert kw[0].value == tag_value2
+        else:
+            raise RuntimeError()
+
+    res = tag_utils.read_all_keywords(flask_app_client, researcher_1)
+    kwct = len(res.json)
+    assert kwct == orig_kwct - 1
+
+    # Check test OP with batch apply
+    patch_ops = [utils.patch_test_op(str(tag2.guid), path='tags')]
+    for index, asset in enumerate(assets):
+        if index == 0:
+            pass
+        elif index == 1:
+            patch_ops.append(utils.patch_add_op('tags', '[0]', guid=asset.guid))
+        elif index == 2:
+            pass
+        elif index == 3:
+            patch_ops.append(utils.patch_add_op('tags', '[0]', guid=asset.guid))
+            # Doing this should be fine
+            patch_ops.append(utils.patch_add_op('tags', '[0]', guid=asset.guid))
+        else:
+            raise RuntimeError()
+
+    asset_utils.patch_asset_bulk(
+        flask_app_client,
+        researcher_1,
+        patch_ops,
+    )
+
+    # Remove all tag1 references
+    patch_ops = []
+    for index, asset in enumerate(assets):
+        if index == 0:
+            pass
+        elif index == 1:
+            patch_ops.append(
+                utils.patch_remove_op('tags', str(tag2.guid), guid=asset.guid)
+            )
+        elif index == 2:
+            pass
+        elif index == 3:
+            patch_ops.append(
+                utils.patch_remove_op('tags', str(tag2.guid), guid=asset.guid)
+            )
+            # Doing this should be fine
+            patch_ops.append(
+                utils.patch_remove_op('tags', str(tag2.guid), guid=asset.guid)
+            )
+        else:
+            raise RuntimeError()
+
+    # patch to remove (and modify) tags
+    asset_utils.patch_asset_bulk(
+        flask_app_client,
+        researcher_1,
+        patch_ops,
+    )
+
+    for index, asset in enumerate(assets):
+        kw = asset.get_tags()
+        assert len(kw) == 0
+
+    # the delete_asset above should take the un-reference tag with it [DEX-347], thus:
+    res = tag_utils.read_all_keywords(flask_app_client, researcher_1)
+    assert len(res.json) == kwct - 1

--- a/tests/modules/assets/resources/utils.py
+++ b/tests/modules/assets/resources/utils.py
@@ -11,23 +11,24 @@ SRC_PATH = '/api/v1/assets/src/'
 RAW_SRC_PATH = 'api/v1/assets/src_raw/'
 
 
-def patch_asset(flask_app_client, asset_guid, user, data, expected_status_code=200):
-    with flask_app_client.login(user, auth_scopes=('assets:write',)):
-        response = flask_app_client.patch(
-            '%s%s' % (PATH, asset_guid),
-            content_type='application/json',
-            data=json.dumps(data),
-        )
-
-    if expected_status_code == 200:
-        test_utils.validate_dict_response(
-            response, 200, {'git_store', 'src', 'guid', 'filename'}
-        )
-    else:
-        test_utils.validate_dict_response(
-            response, expected_status_code, {'status', 'message'}
-        )
-    return response
+def patch_asset(
+    flask_app_client,
+    asset_guid,
+    user,
+    data,
+    expected_status_code=200,
+    expected_error=None,
+):
+    return test_utils.patch_via_flask(
+        flask_app_client,
+        user,
+        scopes='assets:write',
+        path=f'{PATH}{asset_guid}',
+        data=data,
+        expected_status_code=expected_status_code,
+        response_200={'git_store', 'src', 'guid', 'filename'},
+        expected_error=expected_error,
+    )
 
 
 def patch_asset_bulk(flask_app_client, user, data, expected_status_code=200):


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- AG test clones no longer retained
- Test that use the clone reduced to those that need it and no more 

---
All test changes. Mostly just removing the use of the clone but also some refactoring to remove the try/finally clause that was previously used for catching failed tests and is now replaced by the addfinalizer concept
