### PR TITLE
Add dummy index and elasticsearch methods when elasticsearch is disabled

### DIFF
--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -361,6 +361,12 @@ if elasticsearch is None:
         elasticsearchable = False
         index_name = None
 
+        def index(self, *args, **kwargs):
+            pass
+
+        def elasticsearch(self, *args, **kwargs):
+            return []
+
 else:
 
     def register_elasticsearch_model(*args, **kwargs):

--- a/tests/modules/users/resources/test_modifying_users_info.py
+++ b/tests/modules/users/resources/test_modifying_users_info.py
@@ -9,6 +9,7 @@ import uuid
 
 from app.modules.users.models import User
 from app.modules.fileuploads.models import FileUpload
+from flask_restx_patched import is_extension_enabled
 from PIL import Image
 
 from tests.utils import (
@@ -283,6 +284,10 @@ def test_modifying_user_info_with_misformatted_data_must_fail(
             response.json['messages']['0']['_schema'][0]
             == 'Individual PATCH operations must be JSON objects'
         )
+
+    if not is_extension_enabled('elasticsearch'):
+        # Skip the rest of the test if elasticsearch is not enabled
+        return
 
     index, guid, body = regular_user.serialize()
     with flask_app_client.login(regular_user, auth_scopes=('users:write',)):


### PR DESCRIPTION
When elasticsearch extension is not enabled, tests failed:

```
tests/modules/asset_groups/resources/test_commit_asset_group.py:157 test_commit_individual_asset_group[None-False]
tests/modules/users/resources/test_modifying_users_info.py:242 test_modifying_user_info_with_misformatted_data_must_fail[None-False]
tests/modules/asset_groups/resources/test_commit_asset_group.py:11 test_commit_asset_group[None-False]
tests/modules/asset_groups/resources/test_commit_asset_group.py:115 test_commit_asset_group_ia[None-False]
tests/modules/test_ia_pipeline.py:13 test_ia_pipeline_sim_detect_response[None-False]
```

Add dummy `ElasticsearchModel.index` and
`ElasticsearchModel.elasticsearch` so code that uses those methods won't
raise an AttributeError.

Skip part of the
`test_modifying_user_info_with_misformatted_data_must_fail` if
elasticsearch extension is disabled.

