### PR TITLE
DEX-678 Expose relationships for given individual in GET API

### DIFF
--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -134,7 +134,13 @@ class ExtraValidationSchema(Schema):
         if cleaned_data is None:  # Wrong type given, nothing to validate
             return
         valid_fields = sorted(self.fields.keys())
-        unknown = set(original_data) - set(valid_fields)
+        if isinstance(original_data, list):
+            original_data_keys = set(
+                sum((list(data.keys()) for data in original_data), start=[])
+            )
+        else:
+            original_data_keys = set(original_data)
+        unknown = original_data_keys - set(valid_fields)
         if unknown:
             raise ValidationError(
                 f'Unknown field(s): {", ".join(unknown)}, options are {", ".join(valid_fields)}.'
@@ -172,10 +178,10 @@ class ExtraValidationSchema(Schema):
                 if isinstance(errors[key], dict):
                     if key == '_schema':
                         get_error(errors[key], results, _keys)
-                    get_error(errors[key], results, _keys + [key])
+                    get_error(errors[key], results, _keys + [str(key)])
                 else:
                     if key != '_schema':
-                        _keys.append(key)
+                        _keys.append(str(key))
                     message = ' '.join(errors[key])
                     if not _keys:
                         results.append(message)

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -123,7 +123,18 @@ class Individual(db.Model, FeatherModel):
     #     order_by='SocialGroupIndividualMembership.individual_guid',
     # )
 
-    # there is a backref'd 'relationships' list of RelationshipIndividualMember accessible here
+    # there is a backref'd 'relationship_memberships' list of RelationshipIndividualMember accessible here
+
+    @property
+    def relationships(self):
+        from app.modules.relationships.models import (
+            Relationship,
+            RelationshipIndividualMember,
+        )
+
+        return Relationship.query.join(Relationship.individual_members).filter(
+            RelationshipIndividualMember.individual == self
+        )
 
     @classmethod
     def get_elasticsearch_schema(cls):
@@ -876,8 +887,8 @@ class Individual(db.Model, FeatherModel):
             while self.social_groups:
                 db.session.delete(self.social_groups.pop())
 
-            if self.relationships:
-                for relationship_membership in self.relationships:
+            if self.relationship_memberships:
+                for relationship_membership in self.relationship_memberships:
                     relationship_membership.delete()
 
             db.session.delete(self)

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -14,6 +14,7 @@ from app.modules.encounters.schemas import (
     DetailedEncounterSchema,
     ElasticsearchEncounterSchema,
 )
+from app.modules.relationships.schemas import DetailedRelationshipSchema
 
 
 class BaseIndividualSchema(ModelSchema):
@@ -52,6 +53,20 @@ class NamedIndividualSchema(BaseIndividualSchema):
         fields = BaseIndividualSchema.Meta.fields + ('names',)
 
 
+class IndividualRelationshipSchema(DetailedRelationshipSchema):
+    """
+    Relationship schema used in the individual API
+    """
+
+    class Meta(DetailedRelationshipSchema.Meta):
+        fields = (
+            'guid',
+            'type_label',
+            'type_guid',
+            'individual_members',
+        )
+
+
 class DetailedIndividualSchema(NamedIndividualSchema):
     """
     Detailed Individual schema exposes all useful fields.
@@ -59,6 +74,7 @@ class DetailedIndividualSchema(NamedIndividualSchema):
 
     featuredAssetGuid = base_fields.Function(Individual.get_featured_asset_guid)
     social_groups = base_fields.Function(Individual.get_social_groups_json)
+    relationships = base_fields.Nested(IndividualRelationshipSchema, many=True)
 
     class Meta(NamedIndividualSchema.Meta):
         fields = NamedIndividualSchema.Meta.fields + (
@@ -66,10 +82,12 @@ class DetailedIndividualSchema(NamedIndividualSchema):
             Individual.updated.key,
             'featuredAssetGuid',
             'social_groups',
+            'relationships',
         )
         dump_only = NamedIndividualSchema.Meta.dump_only + (
             Individual.created.key,
             Individual.updated.key,
+            'relationships',
         )
 
 

--- a/app/modules/notifications/schemas.py
+++ b/app/modules/notifications/schemas.py
@@ -14,14 +14,14 @@ from .models import Notification, NotificationType, NotificationChannel
 class NotificationChannelSchema(ExtraValidationSchema):
     def __new__(cls, *args, **kwargs):
         for notification_channel in NotificationChannel.__members__.values():
-            cls._declared_fields[notification_channel] = base_fields.Bool()
+            cls._declared_fields[notification_channel.value] = base_fields.Bool()
         return super().__new__(cls)
 
 
 class NotificationPreferenceSchema(ExtraValidationSchema):
     def __new__(cls, *args, **kwargs):
         for notification_type in NotificationType.__members__.values():
-            cls._declared_fields[notification_type] = base_fields.Nested(
+            cls._declared_fields[notification_type.value] = base_fields.Nested(
                 NotificationChannelSchema
             )
         return super().__new__(cls)

--- a/app/modules/relationships/models.py
+++ b/app/modules/relationships/models.py
@@ -29,12 +29,43 @@ class RelationshipIndividualMember(db.Model, HoustonModel):
     individual_guid = db.Column(db.GUID, db.ForeignKey('individual.guid'))
     individual = db.relationship('Individual', backref=db.backref('relationships'))
 
-    individual_role = db.Column(db.String, nullable=False)
+    individual_role_guid = db.Column(db.GUID, nullable=False)
 
-    def __init__(self, individual, individual_role, **kwargs):
+    def __init__(self, individual, individual_role_guid, type_guid=None, **kwargs):
         self.individual = individual
-        self.individual_role = individual_role
+        self.individual_role_guid = individual_role_guid
         self.individual_guid = individual.guid
+
+        from app.modules.site_settings.models import SiteSetting
+
+        relationship_type_roles = SiteSetting.get_value(
+            'relationship_type_roles', {}
+        ).values()
+
+        valid_role_guids = []
+        for relationship_type in relationship_type_roles:
+            if type_guid is None or relationship_type.get('guid') == type_guid:
+                for role in relationship_type.get('roles', []):
+                    if role.get('guid'):
+                        valid_role_guids.append(role['guid'])
+
+        if individual_role_guid not in valid_role_guids:
+            raise ValueError(
+                f'Role guid "{individual_role_guid}" not found in site setting "relationship_type_roles" for relationship type guid "{type_guid}"'
+            )
+
+    @property
+    def individual_role_label(self):
+        from app.modules.site_settings.models import SiteSetting
+
+        relationship_type_roles = SiteSetting.get_value(
+            'relationship_type_roles', {}
+        ).values()
+
+        for relationship_type in relationship_type_roles:
+            for role in relationship_type.get('roles', []):
+                if role.get('guid') == str(self.individual_role_guid):
+                    return role.get('label')
 
     def delete(self):
         relationship = Relationship.query.get(self.relationship_guid)
@@ -55,7 +86,7 @@ class Relationship(db.Model, HoustonModel):
     )
     end_date = db.Column(db.DateTime, index=True, default=datetime.utcnow, nullable=True)
 
-    type = db.Column(db.String, nullable=True)
+    type_guid = db.Column(db.GUID, nullable=True)
 
     @classmethod
     def get_elasticsearch_schema(cls):
@@ -67,15 +98,16 @@ class Relationship(db.Model, HoustonModel):
         self,
         individual_1_guid,
         individual_2_guid,
-        individual_1_role,
-        individual_2_role,
-        **kwargs
+        individual_1_role_guid,
+        individual_2_role_guid,
+        type_guid=None,
+        **kwargs,
     ):
         if (
             individual_1_guid
             and individual_2_guid
-            and individual_1_role
-            and individual_2_role
+            and individual_1_role_guid
+            and individual_2_role_guid
         ):
 
             from app.modules.individuals.models import Individual
@@ -84,16 +116,33 @@ class Relationship(db.Model, HoustonModel):
             individual_2 = Individual.query.get(individual_2_guid)
 
             if individual_1 and individual_2:
-                member_1 = RelationshipIndividualMember(individual_1, individual_1_role)
-                member_2 = RelationshipIndividualMember(individual_2, individual_2_role)
+                member_1 = RelationshipIndividualMember(
+                    individual_1, individual_1_role_guid, type_guid=type_guid
+                )
+                member_2 = RelationshipIndividualMember(
+                    individual_2, individual_2_role_guid, type_guid=type_guid
+                )
                 self.individual_members.append(member_1)
                 self.individual_members.append(member_2)
             else:
                 raise ValueError(
                     'One of the Individual guids used to attempt Relationship creation was invalid.'
                 )
+            self.type_guid = type_guid
         else:
-            raise ValueError('Relationship needs two individuals, each with a role.')
+            raise ValueError('Relationship needs two individuals, each with a role guid.')
+
+    @property
+    def type_label(self):
+        from app.modules.site_settings.models import SiteSetting
+
+        relationship_type_roles = SiteSetting.get_value(
+            'relationship_type_roles', {}
+        ).values()
+
+        for relationship_type in relationship_type_roles:
+            if relationship_type.get('guid') == str(self.type_guid):
+                return relationship_type.get('label')
 
     def has_individual(self, individual_guid):
         if self._get_membership_for_guid(individual_guid):
@@ -105,7 +154,10 @@ class Relationship(db.Model, HoustonModel):
         if membership:
             for individual_member in self.individual_members:
                 if individual_member.individual_guid == individual_guid:
-                    return individual_member.individual_role
+                    return (
+                        individual_member.individual_role_label,
+                        individual_member.individual_role_guid,
+                    )
         return None
 
     def _get_membership_for_guid(self, individual_guid):

--- a/app/modules/relationships/models.py
+++ b/app/modules/relationships/models.py
@@ -27,7 +27,9 @@ class RelationshipIndividualMember(db.Model, HoustonModel):
     )
 
     individual_guid = db.Column(db.GUID, db.ForeignKey('individual.guid'))
-    individual = db.relationship('Individual', backref=db.backref('relationships'))
+    individual = db.relationship(
+        'Individual', backref=db.backref('relationship_memberships')
+    )
 
     individual_role_guid = db.Column(db.GUID, nullable=False)
 

--- a/app/modules/relationships/resources.py
+++ b/app/modules/relationships/resources.py
@@ -87,8 +87,8 @@ class Relationships(Resource):
         if (
             request_in['individual_1_guid']
             and request_in['individual_2_guid']
-            and request_in['individual_1_role']
-            and request_in['individual_2_role']
+            and request_in['individual_1_role_guid']
+            and request_in['individual_2_role_guid']
         ):
 
             if _user_has_write_permission_on_both_individuals(
@@ -98,11 +98,10 @@ class Relationships(Resource):
                     relationship = Relationship(
                         uuid.UUID(request_in['individual_1_guid']),
                         uuid.UUID(request_in['individual_2_guid']),
-                        request_in['individual_1_role'],
-                        request_in['individual_2_role'],
+                        request_in['individual_1_role_guid'],
+                        request_in['individual_2_role_guid'],
+                        type_guid=request_in.get('type_guid'),
                     )
-                    if 'type' in request_in:
-                        relationship.type = request_in['type']
                     if 'start_date' in request_in:
                         try:
                             relationship.start_date = dateutil.parser.parse(

--- a/app/modules/relationships/schemas.py
+++ b/app/modules/relationships/schemas.py
@@ -32,15 +32,19 @@ class BaseRelationshipIndividualMemberSchema(ModelSchema):
     BaseRelationshipIndividualMemberSchema exposes useful fields about a relationships members..
     """
 
+    individual_role_label = base_fields.String()
+
     class Meta:
         # pylint: disable=missing-docstring
         model = RelationshipIndividualMember
         fields = (
-            RelationshipIndividualMember.individual_role.key,
+            RelationshipIndividualMember.individual_role_guid.key,
+            'individual_role_label',
             RelationshipIndividualMember.individual_guid.key,
         )
         dump_only = (
-            RelationshipIndividualMember.individual_role.key,
+            RelationshipIndividualMember.individual_role_guid.key,
+            'individual_role_label',
             RelationshipIndividualMember.individual_guid.key,
         )
 
@@ -53,7 +57,7 @@ class DetailedRelationshipSchema(BaseRelationshipSchema):
     individual_members = base_fields.Nested(
         'BaseRelationshipIndividualMemberSchema',
         many=True,
-        only=('guid', 'individual_guid', 'individual_role'),
+        only=('guid', 'individual_guid', 'individual_role_label', 'individual_role_guid'),
     )
 
     class Meta(BaseRelationshipSchema.Meta):
@@ -62,7 +66,8 @@ class DetailedRelationshipSchema(BaseRelationshipSchema):
             Relationship.updated.key,
             Relationship.start_date.key,
             Relationship.end_date.key,
-            Relationship.type.key,
+            Relationship.type_guid.key,
+            'type_label',
             'individual_members',
         )
         dump_only = BaseRelationshipSchema.Meta.dump_only + (
@@ -70,6 +75,7 @@ class DetailedRelationshipSchema(BaseRelationshipSchema):
             Relationship.updated.key,
             Relationship.start_date.key,
             Relationship.end_date.key,
-            Relationship.type.key,
+            Relationship.type_guid.key,
+            'type_label',
             'individual_members',
         )

--- a/app/modules/site_settings/schemas.py
+++ b/app/modules/site_settings/schemas.py
@@ -3,8 +3,10 @@
 Serialization schemas for Site Settings resources RESTful API
 ----------------------------------------------------
 """
+from flask_marshmallow import base_fields
 
 from flask_restx_patched import ModelSchema
+from app.extensions import ExtraValidationSchema
 
 from .models import SiteSetting
 
@@ -41,3 +43,13 @@ class DetailedSiteSettingFileSchema(BaseSiteSettingFileSchema):
             SiteSetting.created.key,
             SiteSetting.updated.key,
         )
+
+
+class RelationshipTypeSchema(ExtraValidationSchema):
+    class RelationshipTypeRolesSchema(ExtraValidationSchema):
+        guid = base_fields.UUID(required=True)
+        label = base_fields.String(required=True)
+
+    guid = base_fields.UUID(required=True)
+    label = base_fields.String(required=True)
+    roles = base_fields.Nested(RelationshipTypeRolesSchema, required=True, many=True)

--- a/migrations/versions/272bc58baeff_relationship_type_roles_guid.py
+++ b/migrations/versions/272bc58baeff_relationship_type_roles_guid.py
@@ -1,0 +1,208 @@
+# -*- coding: utf-8 -*-
+"""empty message
+
+Revision ID: 272bc58baeff
+Revises: 9a6d8b560a5a
+Create Date: 2022-04-12 15:51:41.958648
+
+"""
+import json
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+import app
+import app.extensions
+
+
+# revision identifiers, used by Alembic.
+revision = '272bc58baeff'
+down_revision = '9a6d8b560a5a'
+
+
+def upgrade():
+    """
+    Upgrade Semantic Description:
+        ENTER DESCRIPTION HERE
+    """
+    conn = op.get_bind()
+    relationship_type_roles = conn.execute(
+        """
+    SELECT data
+    FROM site_setting
+    WHERE key = 'relationship_type_roles'
+    """
+    ).first()
+    if relationship_type_roles:
+        relationship_type_roles = json.loads(relationship_type_roles.data)
+    else:
+        relationship_type_roles = {}
+
+    # e.g. [('Family', ['Mother', 'Daughter'])]
+    relationship_types = conn.execute(
+        """
+    SELECT relationship.type, array_agg(relationship_individual_member.individual_role)
+    FROM relationship JOIN relationship_individual_member ON relationship.guid = relationship_individual_member.relationship_guid
+    GROUP BY relationship.type
+    """
+    ).fetchall()
+    relationship_types = dict(relationship_types)
+
+    # Add new roles to existing relationship types
+    for type_guid, type_def in relationship_type_roles.items():
+        if type_def.get('label') in relationship_types:
+            roles = relationship_types.pop(type_def['label'])
+            roles_labels = [
+                r.get('label') for r in type_def.get('roles', []) if 'label' in r
+            ]
+            for role in roles:
+                if role not in roles_labels:
+                    type_def.setdefault('roles', []).append(
+                        {
+                            'guid': str(uuid.uuid4()),
+                            'label': role,
+                        }
+                    )
+
+    # Create relationship types that don't exist
+    for type_, roles in relationship_types.items():
+        type_guid = str(uuid.uuid4())
+        relationship_type_roles[type_guid] = {
+            'guid': type_guid,
+            'label': type_,
+            'roles': [{'guid': str(uuid.uuid4()), 'label': role} for role in roles],
+        }
+
+    # Update site setting
+    conn.execute(
+        sa.sql.text(
+            """
+    UPDATE site_setting
+    SET data = :data
+    WHERE key = 'relationship_type_roles'
+    """
+        ),
+        {'data': json.dumps(json.dumps(relationship_type_roles))},
+    )
+    # ^ Doing json.dumps twice to be consistent with the current broken
+    # json storage, for example, we are storing an empty dict as '"{}"'
+
+    with op.batch_alter_table('relationship', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('type_guid', app.extensions.GUID(), nullable=True))
+
+    with op.batch_alter_table('relationship_individual_member', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('individual_role_guid', app.extensions.GUID(), nullable=True)
+        )
+
+    # Change relationship.type and individual_role to use guids
+    for type_guid, type_def in relationship_type_roles.items():
+        type_label = type_def.get('label')
+        conn.execute(
+            sa.sql.text(
+                """
+        UPDATE relationship
+        SET type_guid = :type_guid
+        WHERE type = :type
+        """
+            ),
+            {'type_guid': type_guid, 'type': type_label},
+        )
+        for role in type_def.get('roles', []):
+            conn.execute(
+                sa.sql.text(
+                    """
+            UPDATE relationship_individual_member
+            SET individual_role_guid = :individual_role_guid
+            WHERE individual_role = :individual_role
+            AND relationship_guid IN (
+              SELECT guid
+              FROM relationship
+              WHERE type = :type)
+            """
+                ),
+                {
+                    'individual_role_guid': role.get('guid'),
+                    'individual_role': role.get('label'),
+                    'type': type_label,
+                },
+            )
+
+    with op.batch_alter_table('relationship', schema=None) as batch_op:
+        batch_op.drop_column('type')
+
+    with op.batch_alter_table('relationship_individual_member', schema=None) as batch_op:
+        batch_op.alter_column('individual_role_guid', nullable=False)
+        batch_op.drop_column('individual_role')
+
+
+def downgrade():
+    """
+    Downgrade Semantic Description:
+        ENTER DESCRIPTION HERE
+    """
+    conn = op.get_bind()
+    relationship_type_roles = conn.execute(
+        """
+    SELECT data
+    FROM site_setting
+    WHERE key = 'relationship_type_roles'
+    """
+    ).first()
+    if relationship_type_roles:
+        relationship_type_roles = json.loads(relationship_type_roles.data)
+    else:
+        relationship_type_roles = {}
+
+    with op.batch_alter_table('relationship_individual_member', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('individual_role', sa.VARCHAR(), autoincrement=False, nullable=True)
+        )
+
+    with op.batch_alter_table('relationship', schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column('type', sa.VARCHAR(), autoincrement=False, nullable=True)
+        )
+
+    # Populate individual_role and relationship.type
+    for type_guid, type_def in relationship_type_roles.items():
+        type_label = type_def.get('label')
+        conn.execute(
+            sa.sql.text(
+                """
+        UPDATE relationship
+        SET type = :type
+        WHERE type_guid = :type_guid
+        """
+            ),
+            {'type': type_label, 'type_guid': type_guid},
+        )
+        for role in type_def.get('roles', []):
+            conn.execute(
+                sa.sql.text(
+                    """
+            UPDATE relationship_individual_member
+            SET individual_role = :individual_role
+            WHERE individual_role_guid = :individual_role_guid
+            AND relationship_guid IN (
+              SELECT guid
+              FROM relationship
+              WHERE type_guid = :type_guid)
+            """
+                ),
+                {
+                    'individual_role': role.get('label'),
+                    'individual_role_guid': role.get('guid'),
+                    'type_guid': type_guid,
+                },
+            )
+
+    with op.batch_alter_table('relationship_individual_member', schema=None) as batch_op:
+        batch_op.alter_column('individual_role', nullable=False)
+        batch_op.drop_column('individual_role_guid')
+
+    with op.batch_alter_table('relationship', schema=None) as batch_op:
+        batch_op.drop_column('type_guid')
+
+    # ### end Alembic commands ###

--- a/tests/modules/relationships/resources/test_relationship_crud.py
+++ b/tests/modules/relationships/resources/test_relationship_crud.py
@@ -186,3 +186,28 @@ def test_create_read_delete_relationship(
         relationship_1.start_date.date()
         == (relationship_1.end_date - timedelta(days=1)).date()
     )
+
+    response = individual_utils.read_individual(
+        flask_app_client, researcher_1, individual_1_guid
+    )
+    for relationship in response.json['relationships']:
+        relationship['individual_members'].sort(key=lambda a: a['individual_role_guid'])
+    assert response.json['relationships'] == [
+        {
+            'guid': str(relationship_1.guid),
+            'type_label': 'Family',
+            'type_guid': family_type_guid,
+            'individual_members': [
+                {
+                    'individual_role_label': 'Mother',
+                    'individual_role_guid': mother_role_guid,
+                    'individual_guid': str(individual_1_guid),
+                },
+                {
+                    'individual_role_label': 'Calf',
+                    'individual_role_guid': calf_role_guid,
+                    'individual_guid': str(individual_2_guid),
+                },
+            ],
+        }
+    ]

--- a/tests/modules/relationships/resources/utils.py
+++ b/tests/modules/relationships/resources/utils.py
@@ -25,7 +25,7 @@ def create_relationship(flask_app_client, user, expected_status_code=200, data_i
     assert response.status_code == expected_status_code
     if response.status_code == 200:
         test_utils.validate_dict_response(
-            response, 200, {'start_date', 'guid', 'type', 'individual_members'}
+            response, 200, {'start_date', 'guid', 'type_guid', 'individual_members'}
         )
 
     return response
@@ -43,7 +43,7 @@ def read_relationship(
         test_utils.validate_dict_response(
             response,
             200,
-            {'guid', 'individual_members', 'start_date', 'end_date', 'type'},
+            {'guid', 'individual_members', 'start_date', 'end_date', 'type_guid'},
         )
     return response
 

--- a/tests/modules/relationships/test_relationship_model.py
+++ b/tests/modules/relationships/test_relationship_model.py
@@ -12,9 +12,25 @@ import uuid
 )
 def test_relationship_instantiation(db, staff_user, flask_app_client, request, test_root):
     from app.modules.relationships.models import Relationship
+    from app.modules.site_settings.models import SiteSetting
 
     from tests.modules.individuals.resources import utils as indiv_utils
     from tests.modules.relationships.resources import utils as relationship_utils
+
+    family_type_guid = '49e85f81-c11a-42be-9097-d22c61345ed8'
+    mother_role_guid = '1b62eb1a-0b80-4c2d-b914-923beba8863c'
+    calf_role_guid = 'ea5dbbb3-cc47-4d44-b460-2518a25dcb13'
+    relationship_type_roles = {
+        family_type_guid: {
+            'guid': family_type_guid,
+            'label': 'Family',
+            'roles': [
+                {'guid': mother_role_guid, 'label': 'Mother'},
+                {'guid': calf_role_guid, 'label': 'Calf'},
+            ],
+        },
+    }
+    SiteSetting.set_key_value('relationship_type_roles', relationship_type_roles)
 
     response_1 = indiv_utils.create_individual_and_sighting(
         flask_app_client, staff_user, request, test_root
@@ -27,20 +43,20 @@ def test_relationship_instantiation(db, staff_user, flask_app_client, request, t
     individual_1_guid = uuid.UUID(response_1['individual'])
     individual_2_guid = uuid.UUID(response_2['individual'])
 
-    relationship_role_1 = 'Mother'
-    relationship_role_2 = 'Calf'
-
     relationship = Relationship(
-        individual_1_guid, individual_2_guid, relationship_role_1, relationship_role_2
+        individual_1_guid, individual_2_guid, mother_role_guid, calf_role_guid
     )
 
     assert relationship.has_individual(individual_1_guid)
     assert relationship.has_individual(individual_2_guid)
 
     assert (
-        relationship.get_relationship_role_for_individual(individual_1_guid) == 'Mother'
+        relationship.get_relationship_role_for_individual(individual_1_guid)[0]
+        == 'Mother'
     )
-    assert relationship.get_relationship_role_for_individual(individual_2_guid) == 'Calf'
+    assert (
+        relationship.get_relationship_role_for_individual(individual_2_guid)[0] == 'Calf'
+    )
 
     relationship_utils.delete_relationship(
         flask_app_client, staff_user, relationship.guid

--- a/tests/modules/site_settings/resources/test_relationship_type_roles.py
+++ b/tests/modules/site_settings/resources/test_relationship_type_roles.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+from tests.modules.site_settings.resources import utils
+
+
+def test_relationship_type_roles(flask_app_client, admin_user):
+    relationship_type_roles = {
+        '49e85f81-c11a-42be-9097-d22c61345ed8': {
+            'guid': '49e85f81-c11a-42be-9097-d22c61345ed8',
+            'label': 'familial',
+            'roles': [
+                {
+                    'guid': '1b62eb1a-0b80-4c2d-b914-923beba8863c',
+                    'label': 'mother',
+                },
+                {'guid': 'ea5dbbb3-cc47-4d44-b460-2518a25dcb13', 'label': 'father'},
+                {'guid': '4e38325a-46de-47e8-bb02-8ef0dbf54860', 'label': 'son'},
+                {'guid': '8299f080-22ed-40da-8c06-af57ada64644', 'label': 'daughter'},
+            ],
+        },
+    }
+    # Update relationship_type_roles
+    utils.modify_main_settings(
+        flask_app_client,
+        admin_user,
+        {'_value': relationship_type_roles},
+        conf_key='relationship_type_roles',
+    )
+    # Get all settings
+    response = utils.read_main_settings(flask_app_client, admin_user)
+    assert (
+        response.json['response']['configuration']['relationship_type_roles']['value']
+        == relationship_type_roles
+    )
+
+    # Check relationship_type_roles validation
+    utils.modify_main_settings(
+        flask_app_client,
+        admin_user,
+        {'_value': []},
+        conf_key='relationship_type_roles',
+        expected_status_code=400,
+        expected_error='relationship_type_roles needs to be a dictionary',
+    )
+
+    utils.modify_main_settings(
+        flask_app_client,
+        admin_user,
+        {
+            '_value': {
+                '49e85f81-c11a-42be-9097-d22c61345ed8': {
+                    'guid': '49e85f81-c11a-42be-9097-d22c61345ed8',
+                    'label': 'Family',
+                    'roles': [
+                        {'label': 'Mother'},
+                    ],
+                },
+            },
+        },
+        conf_key='relationship_type_roles',
+        expected_status_code=400,
+        expected_error='"roles.0.guid": Missing data for required field.',
+    )
+
+    utils.modify_main_settings(
+        flask_app_client,
+        admin_user,
+        {
+            '_value': {
+                '49e85f81-c11a-42be-9097-d22c61345ed8': {
+                    'guid': '49e85f81-c11a-42be-9097-d22c61345ed8',
+                    'label': 'Family',
+                    'roles': [
+                        {
+                            'guid': '1b62eb1a',
+                            'label': 'Mother',
+                        },
+                    ],
+                },
+            },
+        },
+        conf_key='relationship_type_roles',
+        expected_status_code=400,
+        expected_error='"roles.0.guid": Not a valid UUID.',
+    )


### PR DESCRIPTION
- Add validation for relationship_type_roles site setting

  Check that the structure of the relationship_type_roles follows
  something like:
  
  ```
  {
    "318cd874-4f52-45b3-9b6e-37fce007f40d": {
      "guid": "318cd874-4f52-45b3-9b6e-37fce007f40d",
      "label": "familial",
      "roles": [
        {
          "guid": "d68e45a9-ad60-44e1-9490-d8435e924c8c",
          "label": "mother"
        },
        {
          "guid": "64fd3382-47d4-42bb-8c88-df627981a49e",
          "label": "son"
        }
      ]
    },
  ```
  
  Update ExtraValidationSchema to handle nested many fields (like "roles").
  
  Update Notification*Schema so it no longer uses
  `<NotificationChannel.rest: 'restAPI'>` as the field name, instead use
  the value `"restAPI"` as the field name.

- Change relationship type and individual role to be guid

  We have this "relationship_type_roles" site setting which defines
  relationships that can be used for the site:
  
  ```
  {
      "49e85f81-c11a-42be-9097-d22c61345ed8": {
          "guid": "49e85f81-c11a-42be-9097-d22c61345ed8",
          "label": "familial",
          "roles": [
              {"guid": "1b62eb1a-0b80-4c2d-b914-923beba8863c", "label": "mother"},
              {"guid": "ea5dbbb3-cc47-4d44-b460-2518a25dcb13", "label": "father"},
              {"guid": "4e38325a-46de-47e8-bb02-8ef0dbf54860", "label": "son"},
              {"guid": "8299f080-22ed-40da-8c06-af57ada64644", "label": "daughter"}
          ]
      }
  }
  ```
  
  Ben said we want to use the guid instead of strings for the relationship
  type and individual role.
  
  So instead of creating relationship like this:
  
  ```
  {
      "individual_1_guid": <guid>,
      "individual_2_guid": <guid>,
      "individual_1_role": "mother",
      "individual_2_role": "son",
      "type": "familial"
  }
  ```
  
  we are changing to this:
  
  ```
  {
      "individual_1_guid": <guid>,
      "individual_2_guid": <guid>,
      "individual_1_role_guid": "1b62eb1a-0b80-4c2d-b914-923beba8863c",
      "individual_2_role_guid": "4e38325a-46de-47e8-bb02-8ef0dbf54860",
      "type_guid": "49e85f81-c11a-42be-9097-d22c61345ed8"
  }
  ```
  
  For GET relationship API, we would return the guids and labels:
  
  ```
  {
      ...
      "type_guid": "49e85f81-c11a-42be-9097-d22c61345ed8"
      "type_label": "familial",
      "individual_members": [
          {
              "individual_guid": <guid>,
              "individual_role_label": "mother",
              "individual_1_role_guid": "1b62eb1a-0b80-4c2d-b914-923beba8863c",
          },
          {
              "individual_guid": <guid>,
              "individual_role_label": "son",
              "individual_2_role_guid": "4e38325a-46de-47e8-bb02-8ef0dbf54860",
          }
      ]
  }
  ```

- DEX-678 Expose relationships for given individual in GET API

  "relationships" is now included in the GET individuals API:
  

  ```
  GET /api/v1/individuals/<guid>
  
  {
    ...
    "relationships": [
      {
        "type_guid": "49e85f81-c11a-42be-9097-d22c61345ed8",
        "guid": "3b7c529c-0fbb-4e22-afbf-fccfe72ff394",
        "type_label": "Family",
        "individual_members": [
          {
            "individual_role_label": "Mother",
            "individual_guid": "fd1aa69c-5335-446e-9743-ba54298a8f74",
            "individual_role_guid": "1b62eb1a-0b80-4c2d-b914-923beba8863c"
          },
          {
            "individual_role_label": "Calf",
            "individual_guid": "5a96ac3a-66b5-447c-be9b-6cf57c2f0777",
            "individual_role_guid": "ea5dbbb3-cc47-4d44-b460-2518a25dcb13"
          }
        ]
      }
    ],
    "guid": "2a4bd2ed-9622-49a8-ac62-f8ac8d7b119b",
    "updated": "2022-04-07T13:52:39.202409+00:00"
  }
  ```
