### PR TITLE
Add autoheal to automatically restart unhealthy Docker services

### DIFF
--- a/docker-compose.codex.yml
+++ b/docker-compose.codex.yml
@@ -9,6 +9,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     user: postgres
     volumes:
       - db-pgdata-var:/var/lib/postgresql/data
@@ -36,6 +38,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes:
       - redis-var:/data
       - .dockerfiles/redis/redis.conf:/redis.conf
@@ -53,6 +57,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes:
       - es-var1:/usr/share/elasticsearch/data
     ulimits:
@@ -81,6 +87,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes:
       - es-var2:/usr/share/elasticsearch/data
     ulimits:
@@ -105,6 +113,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes:
       - es-var3:/usr/share/elasticsearch/data
     ulimits:
@@ -130,6 +140,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     networks:
       - intranet
     ports:
@@ -144,7 +156,9 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    # healthcheck:  # WBIA defines it's own health check
+    # healthcheck:  # WBIA defines it's own health check and is already labeled for autoheal
+    # labels:
+    #   - autoheal=true
     volumes:
       - acm-database-var:/data/db
       - acm-cache-var:/cache
@@ -171,6 +185,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes:
       - edm-var:/data/wildbook_data_dir
     networks:
@@ -206,6 +222,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes: &houston-volumes
       - houston-var:/data
       # These are added for development. Do not mount these in production.
@@ -269,6 +287,8 @@ services:
       interval: 30s
       timeout: 15s
       retries: 60
+    labels:
+      - autoheal=true
     volumes: *houston-volumes
     networks:
       - intranet
@@ -282,6 +302,8 @@ services:
       houston:
         condition: service_healthy
     healthcheck: *celery-healthcheck
+    labels:
+      - autoheal=true
     volumes: *houston-volumes
     networks:
       - intranet
@@ -295,6 +317,8 @@ services:
       houston:
         condition: service_healthy
     healthcheck: *celery-healthcheck
+    labels:
+      - autoheal=true
     volumes: *houston-volumes
     networks:
       - intranet
@@ -308,6 +332,8 @@ services:
       houston:
         condition: service_healthy
     healthcheck: *celery-healthcheck
+    labels:
+      - autoheal=true
     volumes: *houston-volumes
     networks:
       - intranet
@@ -325,6 +351,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes: *houston-volumes
     networks:
       - intranet
@@ -342,6 +370,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes:
       - .dockerfiles/dev-frontend/docker-entrypoint.sh:/docker-entrypoint.sh
       - ./:/code
@@ -369,6 +399,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes:
       - .dockerfiles/www/nginx.conf:/etc/nginx/conf.d/default.conf
     networks:
@@ -378,6 +410,17 @@ services:
       - "80:80"
       # BBB deprecated in favor or port 80, remains for backward compat
       - "84:80"
+
+  autoheal:
+    image: willfarrell/autoheal
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      AUTOHEAL_CONTAINER_LABEL: "autoheal"
+      AUTOHEAL_INTERVAL: 15
+      AUTOHEAL_START_PERIOD: 600
+      AUTOHEAL_DEFAULT_STOP_TIMEOUT: 60
+    restart: always
 
 networks:
   intranet:

--- a/docker-compose.mws.yml
+++ b/docker-compose.mws.yml
@@ -9,6 +9,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     user: postgres
     volumes:
       - db-pgdata-var:/var/lib/postgresql/data
@@ -36,6 +38,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes:
       - redis-var:/data
       - .dockerfiles/redis/redis.conf:/redis.conf
@@ -53,6 +57,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes:
       - es-var1:/usr/share/elasticsearch/data
     ulimits:
@@ -81,6 +87,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes:
       - es-var2:/usr/share/elasticsearch/data
     ulimits:
@@ -105,6 +113,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes:
       - es-var3:/usr/share/elasticsearch/data
     ulimits:
@@ -130,6 +140,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     networks:
       - intranet
     ports:
@@ -144,7 +156,9 @@ services:
     depends_on:
       db:
         condition: service_healthy
-    # healthcheck:  # WBIA defines it's own health check
+    # healthcheck:  # WBIA defines it's own health check and is already labeled for autoheal
+    # labels:
+    #   - autoheal=true
     volumes:
       - acm-database-var:/data/db
       - acm-cache-var:/cache
@@ -175,6 +189,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes: &houston-volumes
       - houston-var:/data
       # These are added for development. Do not mount these in production.
@@ -233,6 +249,8 @@ services:
       interval: 30s
       timeout: 15s
       retries: 60
+    labels:
+      - autoheal=true
     volumes: *houston-volumes
     networks:
       - intranet
@@ -246,6 +264,8 @@ services:
       houston:
         condition: service_healthy
     healthcheck: *celery-healthcheck
+    labels:
+      - autoheal=true
     volumes: *houston-volumes
     networks:
       - intranet
@@ -259,6 +279,8 @@ services:
       houston:
         condition: service_healthy
     healthcheck: *celery-healthcheck
+    labels:
+      - autoheal=true
     volumes: *houston-volumes
     networks:
       - intranet
@@ -272,6 +294,8 @@ services:
       houston:
         condition: service_healthy
     healthcheck: *celery-healthcheck
+    labels:
+      - autoheal=true
     volumes: *houston-volumes
     networks:
       - intranet
@@ -289,6 +313,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes: *houston-volumes
     networks:
       - intranet
@@ -306,6 +332,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes:
       - .dockerfiles/dev-frontend/docker-entrypoint.sh:/docker-entrypoint.sh
       - ./:/code
@@ -331,6 +359,8 @@ services:
       interval: 10s
       timeout: 5s
       retries: 60
+    labels:
+      - autoheal=true
     volumes:
       - .dockerfiles/www/nginx.conf:/etc/nginx/conf.d/default.conf
     networks:
@@ -340,6 +370,17 @@ services:
       - "80:80"
       # BBB deprecated in favor or port 80, remains for backward compat
       - "84:80"
+
+  autoheal:
+    image: willfarrell/autoheal
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      AUTOHEAL_CONTAINER_LABEL: "autoheal"
+      AUTOHEAL_INTERVAL: 15
+      AUTOHEAL_START_PERIOD: 600
+      AUTOHEAL_DEFAULT_STOP_TIMEOUT: 60
+    restart: always
 
 networks:
   intranet:


### PR DESCRIPTION
This service has been used for restarting WBIA instances that go unhealthy with the Docker health checks.  I'm adding it as a very lightweight service for Houston that will check periodically for unhealthy services and restart them.  This is mostly going to be a benefit for the QA server.