### PR TITLE
836 manager collab revoked notif

### DIFF
--- a/app/modules/collaborations/models.py
+++ b/app/modules/collaborations/models.py
@@ -381,8 +381,7 @@ class Collaboration(db.Model, HoustonModel):
             association.read_approval_state, state
         ):
             association.read_approval_state = state
-            # If a user revokes view and previously allowed edit, they automatically
-            # revoke edit too
+            # If a user revokes view and previously allowed edit, revoke edit too
             if (
                 state == CollaborationUserState.REVOKED
                 and association.edit_approval_state == CollaborationUserState.APPROVED

--- a/app/modules/collaborations/resources.py
+++ b/app/modules/collaborations/resources.py
@@ -105,7 +105,7 @@ class Collaborations(Resource):
             users = [other_user, second_user]
 
         for collab_assoc in users[0].get_collaboration_associations():
-            if collab_assoc.read_approval_state == CollaborationUserState.CREATOR:
+            if collab_assoc.read_approval_state == CollaborationUserState.MANAGER_CREATOR:
                 # Dont check associations where the current user is the creator
                 continue
             if users[1] in collab_assoc.collaboration.get_users():

--- a/app/modules/notifications/models.py
+++ b/app/modules/notifications/models.py
@@ -34,6 +34,7 @@ class NotificationType(str, enum.Enum):
     collab_manager_create = 'collaboration_manager_create'
     # A user manager has revoked a collaboration for you with another user
     collab_manager_revoke = 'collaboration_manager_revoke'
+    collab_manager_edit_revoke = 'collaboration_manager_edit_revoke'
     individual_merge_request = 'individual_merge_request'
     individual_merge_complete = 'individual_merge_complete'
 
@@ -82,6 +83,10 @@ NOTIFICATION_DEFAULTS = {
         NotificationChannel.email: False,
     },
     NotificationType.collab_manager_revoke: {
+        NotificationChannel.rest: True,
+        NotificationChannel.email: False,
+    },
+    NotificationType.collab_manager_edit_revoke: {
         NotificationChannel.rest: True,
         NotificationChannel.email: False,
     },
@@ -155,6 +160,18 @@ NOTIFICATION_CONFIG = {
     NotificationType.collab_manager_revoke: {
         'email_template_name': 'collaboration_manger_revoke',
         'email_digest_content_template': 'collaboration_manager_revoke_digest',
+        'mandatory_fields': {
+            'collaboration_guid',
+            'user1_name',
+            'user2_name',
+            'manager_name',
+        },
+        'allow_multiple': True,
+        'resolve_on_read': True,
+    },
+    NotificationType.collab_manager_edit_revoke: {
+        'email_template_name': 'collaboration_manger_edit_revoke',
+        'email_digest_content_template': 'collaboration_manager_edit_revoke_digest',
         'mandatory_fields': {
             'collaboration_guid',
             'user1_name',

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -420,7 +420,7 @@ class ObjectActionRule(DenyAbortMixin, Rule):
         )
 
         for collab_assoc in user.get_collaboration_associations():
-            if collab_assoc.read_approval_state != CollaborationUserState.CREATOR:
+            if collab_assoc.read_approval_state != CollaborationUserState.MANAGER_CREATOR:
                 collab_users = collab_assoc.collaboration.get_users()
                 for other_user in collab_users:
                     if other_user not in tried_users:

--- a/app/templates/email/en_us/notifications/collaboration_manager_edit_revoke.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_manager_edit_revoke.jinja2
@@ -1,0 +1,10 @@
+<html>
+        <body>
+                <p>Hello {{ site_name }} user,</p>
+
+                <p>We are writing to inform you that {{ manager_name }} downgraded the collaboration between {{user1_name}} and {{user2_name}} from edit access to read-only access. You can view your collaborations on your <a href="{{ site_url_prefix }}">homepage</a>.</p>
+
+                <p>Best,<br />
+                The {{ site_name }} team</p>
+        </body>
+</html>

--- a/app/templates/email/en_us/notifications/collaboration_manager_edit_revoke_subject.jinja2
+++ b/app/templates/email/en_us/notifications/collaboration_manager_edit_revoke_subject.jinja2
@@ -1,0 +1,1 @@
+{{ manager_name }} downgraded the collaboration between {{user1_name}} and {{user2_name}} to read-only

--- a/integration_tests/test_collaborations.py
+++ b/integration_tests/test_collaborations.py
@@ -2,6 +2,7 @@
 import uuid
 
 from .utils import create_new_user
+from app.modules.collaborations.models import CollaborationUserState
 
 
 def test_collaboration(session, codex_url, login, logout, admin_email):
@@ -74,7 +75,7 @@ def test_collaboration(session, codex_url, login, logout, admin_email):
     assert response.status_code == 409
     assert (
         response.json()['message']
-        == 'State "True" not in allowed states: denied, approved, pending, not_initiated, revoked, creator'
+        == f'State "True" not in allowed states: {", ".join(CollaborationUserState.ALLOWED_STATES)}'
     )
 
     # Approve collaboration
@@ -108,7 +109,7 @@ def test_collaboration(session, codex_url, login, logout, admin_email):
     assert response.status_code == 409
     assert (
         response.json()['message']
-        == 'State "False" not in allowed states: denied, approved, pending, not_initiated, revoked, creator'
+        == f'State "False" not in allowed states: {", ".join(CollaborationUserState.ALLOWED_STATES)}'
     )
 
     # Reject collaboration for edit

--- a/integration_tests/test_collaborations.py
+++ b/integration_tests/test_collaborations.py
@@ -2,7 +2,6 @@
 import uuid
 
 from .utils import create_new_user
-from app.modules.collaborations.models import CollaborationUserState
 
 
 def test_collaboration(session, codex_url, login, logout, admin_email):
@@ -75,7 +74,7 @@ def test_collaboration(session, codex_url, login, logout, admin_email):
     assert response.status_code == 409
     assert (
         response.json()['message']
-        == f'State "True" not in allowed states: denied, approved, pending, not_initiated, revoked, manager_creator, manager_revoked'
+        == 'State "True" not in allowed states: denied, approved, pending, not_initiated, revoked, manager_creator, manager_revoked'
     )
 
     # Approve collaboration

--- a/integration_tests/test_collaborations.py
+++ b/integration_tests/test_collaborations.py
@@ -75,7 +75,7 @@ def test_collaboration(session, codex_url, login, logout, admin_email):
     assert response.status_code == 409
     assert (
         response.json()['message']
-        == f'State "True" not in allowed states: {", ".join(CollaborationUserState.ALLOWED_STATES)}'
+        == f'State "True" not in allowed states: denied, approved, pending, not_initiated, revoked, manager_creator, manager_revoked'
     )
 
     # Approve collaboration
@@ -109,7 +109,7 @@ def test_collaboration(session, codex_url, login, logout, admin_email):
     assert response.status_code == 409
     assert (
         response.json()['message']
-        == f'State "False" not in allowed states: {", ".join(CollaborationUserState.ALLOWED_STATES)}'
+        == 'State "False" not in allowed states: denied, approved, pending, not_initiated, revoked, manager_creator, manager_revoked'
     )
 
     # Reject collaboration for edit

--- a/integration_tests/test_notifications.py
+++ b/integration_tests/test_notifications.py
@@ -26,6 +26,7 @@ def test_notification_preferences(session, login, logout, codex_url):
         'collaboration_edit_revoke': {'email': False, 'restAPI': True},
         'collaboration_manager_create': {'email': False, 'restAPI': True},
         'collaboration_manager_revoke': {'email': False, 'restAPI': True},
+        'collaboration_manager_edit_revoke': {'email': False, 'restAPI': True},
         'individual_merge_request': {'restAPI': True, 'email': False},
         'individual_merge_complete': {'restAPI': True, 'email': False},
     }
@@ -63,6 +64,7 @@ def test_notification_preferences(session, login, logout, codex_url):
         'collaboration_edit_revoke': {'email': False, 'restAPI': True},
         'collaboration_manager_create': {'email': False, 'restAPI': True},
         'collaboration_manager_revoke': {'email': False, 'restAPI': True},
+        'collaboration_manager_edit_revoke': {'email': False, 'restAPI': True},
         'individual_merge_request': {'restAPI': False, 'email': False},
         'individual_merge_complete': {'restAPI': True, 'email': False},
     }

--- a/tasks/codex/collaborations.py
+++ b/tasks/codex/collaborations.py
@@ -35,7 +35,7 @@ def list_user_collabs(context, email):
 
     for collab_assoc in user.get_collaboration_associations():
         users = collab_assoc.collaboration.get_users()
-        if collab_assoc.read_approval_state == CollaborationUserState.CREATOR:
+        if collab_assoc.read_approval_state == CollaborationUserState.MANAGER_CREATOR:
             print(f'Created Collaboration: {collab_assoc.collaboration} Users: {users}')
         else:
             print(f'Collaboration : {collab_assoc.collaboration} Users: {users} ')

--- a/tests/modules/collaborations/resources/test_collaboration_notification.py
+++ b/tests/modules/collaborations/resources/test_collaboration_notification.py
@@ -227,10 +227,10 @@ def test_manager_creator_revoke(
 
     assert len(researcher_1_notifs) == 2
     assert (
-        researcher_1_notifs[0]['message_type'] == NotificationType.collab_manager_create
+        researcher_1_notifs[1]['message_type'] == NotificationType.collab_manager_create
     )
     assert (
-        researcher_1_notifs[1]['message_type'] == NotificationType.collab_manager_revoke
+        researcher_1_notifs[0]['message_type'] == NotificationType.collab_manager_revoke
     )
 
 
@@ -256,7 +256,7 @@ def test_manager_revoke(
 
     # should have collab_approved *and* collab_revoked
     assert len(researcher_1_notifs) == 2
-    assert researcher_1_notifs[0]['message_type'] == NotificationType.collab_approved
+    assert researcher_1_notifs[1]['message_type'] == NotificationType.collab_approved
     assert (
-        researcher_1_notifs[1]['message_type'] == NotificationType.collab_manager_revoke
+        researcher_1_notifs[0]['message_type'] == NotificationType.collab_manager_revoke
     )

--- a/tests/modules/collaborations/resources/test_collaboration_patch.py
+++ b/tests/modules/collaborations/resources/test_collaboration_patch.py
@@ -4,6 +4,7 @@ import tests.modules.collaborations.resources.utils as collab_utils
 from tests import utils
 import pytest
 import uuid
+from app.modules.collaborations.models import CollaborationUserState
 
 from tests.utils import module_unavailable
 
@@ -22,7 +23,7 @@ def test_patch_collaboration(flask_app_client, researcher_1, researcher_2, reque
 
     # should not work
     patch_data = [utils.patch_replace_op('view_permission', 'ambivalence')]
-    resp = 'State "ambivalence" not in allowed states: denied, approved, pending, not_initiated, revoked, creator'
+    resp = f'State "ambivalence" not in allowed states: {", ".join(CollaborationUserState.ALLOWED_STATES)}'
     collab_utils.patch_collaboration(
         flask_app_client, collab_guid, researcher_2, patch_data, 409, resp
     )
@@ -132,8 +133,8 @@ def test_patch_collaboration_states(
     request.addfinalizer(collab.delete)
 
     # should not work
-    patch_data = [utils.patch_replace_op('view_permission', 'creator')]
-    resp = 'unable to set /view_permission to creator'
+    patch_data = [utils.patch_replace_op('view_permission', 'manager_creator')]
+    resp = 'unable to set /view_permission to manager_creator'
     collab_utils.patch_collaboration(
         flask_app_client, collab_guid, researcher_2, patch_data, 400, resp
     )
@@ -141,7 +142,7 @@ def test_patch_collaboration_states(
 
     # also should not
     patch_data = [utils.patch_replace_op('view_permission', 'ambivalence')]
-    resp = 'State "ambivalence" not in allowed states: denied, approved, pending, not_initiated, revoked, creator'
+    resp = f'State "ambivalence" not in allowed states: {", ".join(CollaborationUserState.ALLOWED_STATES)}'
     collab_utils.patch_collaboration(
         flask_app_client, collab_guid, researcher_2, patch_data, 409, resp
     )

--- a/tests/modules/collaborations/test_models.py
+++ b/tests/modules/collaborations/test_models.py
@@ -43,7 +43,7 @@ def test_collaboration_create_with_members(
     for association in manager_collab.collaboration_user_associations:
 
         if association.user == user_manager_user:
-            assert association.read_approval_state == 'creator'
+            assert association.read_approval_state == 'manager_creator'
         else:
             assert association.read_approval_state == 'approved'
 


### PR DESCRIPTION
Fixes collab notification so that when a manager revokes two users' collab, it sends a manager_revoke notification, not a standard/indistinguishable normal revoke notification. A big PR for that little behavior, was a rabbit hole.

Adds a CollaborationUserState, manager_revoked. As a quality of life improvement, renames the CollabUserState "creator" to "manager_creator." The code was confusing with just "creator" since the creator only gets that state if they are a manager as well.

The main logic changes are in `collaborations/models.py::set_read_approval_state_for_user` and `set_edit_approval_state_for_user` and are straightforward once you get there. As another quality of life improvement, I bumped the notification logics here up two indentation levels, by moving if conditions (eg, "if we have a user guid") up to error conditions (eg, error if we don't have a user guid). Does not affect behavior or tests.