### PR TITLE
fixes a logic bug on names that appear on multiple rows

### DIFF
--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -789,7 +789,8 @@ class FlatfileNameValidation(Resource):
     # values passed in from flatfile are val/index pairs:
     # [
     #   ["Zebulon", 1],
-    #   ["Zebrucifer", 2],
+    #   ["Zebulon", 2],
+    #   ["Zebrandon", 3],
     #   ["Zebrelda", 300],
     #   ["Zesus", 46]
     # ]
@@ -807,11 +808,9 @@ class FlatfileNameValidation(Resource):
                 code=500,
             )
 
-        query_index_dict = {
-            val_id_pair[0]: val_id_pair[1] for val_id_pair in request.json
-        }
         # want to preserve order here
         query_name_vals = [val_id_pair[0] for val_id_pair in request.json]
+        query_indices = [val_id_pair[1] for val_id_pair in request.json]
 
         db_names = Name.query.filter(
             Name.value.in_(query_name_vals), Name.context == DEFAULT_NAME_CONTEXT
@@ -822,7 +821,7 @@ class FlatfileNameValidation(Resource):
             db_name_lookup[name.value].append(str(name.individual_guid))
 
         rtn_json = []
-        for name_val in query_name_vals:
+        for name_val, index in zip(query_name_vals, query_indices):
             if name_val in db_name_lookup and len(db_name_lookup[name_val]) == 1:
                 name_info = {
                     'message': f'Corresponds to existing individual {db_name_lookup[name_val][0]}.',
@@ -840,6 +839,6 @@ class FlatfileNameValidation(Resource):
                 }
 
             name_json = {'value': name_val, 'info': [name_info]}
-            rtn_json.append([name_json, query_index_dict[name_val]])
+            rtn_json.append([name_json, index])
 
         return rtn_json

--- a/tests/modules/individuals/resources/test_individual_names.py
+++ b/tests/modules/individuals/resources/test_individual_names.py
@@ -413,6 +413,7 @@ def test_name_validation(
     flatfile_query = [
         ['Zebra Prime', 0],
         ['Big Dog', 1],
+        ['Big Dog', 2],
         ['Zebra Omega', 4],
         ['Jennifer', 100],
     ]
@@ -449,6 +450,18 @@ def test_name_validation(
                 ],
             },
             1,
+        ],
+        [
+            {
+                'value': 'Big Dog',
+                'info': [
+                    {
+                        'message': 'This is a new name and submission will create a new individual',
+                        'level': 'warning',
+                    }
+                ],
+            },
+            2,
         ],
         [
             {


### PR DESCRIPTION
While doing frontend QA Ben found a logic bug in the individual name validation endpoint. That is fixed here, and the case is now covered in the name validation test.

The bug was that if a name appeared on multiple rows (ie, multiple encounters of the same individual), we returned only the final row's index for each row, rather than the correct index. The fix simplifies the code (hooray!). Instead of keeping track of a {name: index} dict, we just keep two parallel lists, one of names, one of indices.