### PR TITLE
Add USE_RELOADER environment variable for flask reloading

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,8 +157,8 @@ For development purposes, this setup exposes each of the services as follows:
 - EDM - http://localhost:81/
 - Sage (Wildbook-IA) - http://localhost:82/
 - Houston - http://localhost:83/houston/
-- CODEX (frontend) - http://localhost:84/
-- CODEX (api docs) - http://localhost:84/api/v1/
+- CODEX (frontend) - http://localhost/
+- CODEX (api docs) - http://localhost/api/v1/
 - GitLab - http://localhost:85
 
 See also the results of `docker-compose ps -a`, which will list the services and the ports exposed on those services.
@@ -338,7 +338,7 @@ There are some environment variables you can set for the integration tests:
 
 | Variable           | Default value          |                           |
 |--------------------|------------------------|---------------------------|
-| `CODEX_URL`        | `http://localhost:84/` | The url of the site to test |
+| `CODEX_URL`        | `http://localhost/`    | The url of the site to test |
 | `ADMIN_EMAIL`      | `root@example.org`     | The email of the first admin user |
 | `ADMIN_PASSWORD`   | `password`             | The password of the first admin user |
 | `ADMIN_NAME`       | `Test admin`           | The name of the first admin user |

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ docker-compose up
 docker-compose -f docker-compose.codex.yml --env-file .env.codex up
 ```
 
-Surf to http://localhost:84/
+Surf to http://localhost/
 
 
 ### Installing from source

--- a/config/base.py
+++ b/config/base.py
@@ -85,6 +85,8 @@ class BaseConfig(FlaskConfigOverrides, RedisConfig):
     PROJECT_ROOT = PROJECT_ROOT
     PROJECT_DATABASE_PATH = str(DATA_ROOT)
 
+    USE_RELOADER = os.getenv('USE_RELOADER', 'false').lower() != 'false'
+
     # Mapping to file type taken from
     # https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types
     ASSET_MIME_TYPE_WHITELIST_EXTENSION = {

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,5 +1,28 @@
 # Development
 
+## Automatically reloading flask when code changes
+
+This is useful during development so houston is always serving the most
+up to date code.  The alternative is to manually restart the houston
+server by doing `docker-compose restart houston`.
+
+By default, reloading is turned off.  To turn this on, you can do this
+in your `docker-compose.override.yml`:
+
+```yaml
+services:
+  houston:
+    environment: &houston-environment
+      USE_RELOADER: "true"
+```
+
+After this change you would need to recreate the houston container:
+
+```
+docker-compose rm -f --stop houston
+docker-compose up -d houston
+```
+
 ## Module Structure
 
 Once you added a module name into `config.ENABLED_MODULES`, it is required to

--- a/tasks/app/run.py
+++ b/tasks/app/run.py
@@ -110,7 +110,7 @@ def run(
     # Turn off logging the access log for noisy endpoints (like the heartbeat)
     hide_noisy_endpoint_logs()
 
-    use_reloader = app.debug
+    use_reloader = app.config.get('USE_RELOADER', False)
 
     if uwsgi:
         uwsgi_args = [


### PR DESCRIPTION
- Change localhost:84 to localhost in documentation

  After the SERVER_NAME PR, we have changed the server url to localhost
  instead of localhost:84.

- Add USE_RELOADER environment variable for flask reloading

  Instead of reloading in the development environment, use `USE_RELOADER`
  environment variable to turn on and off automatic reloading.
  
  The reason for this change is because if a file is saved with syntax
  errors, flask reloads and fails with an exception, the houston container
  dies and this kills all the shell in the container and so not everyone
  wants that behavior.

