### PR TITLE
893 site settings bug fixes and enhancements

### DIFF
--- a/tests/modules/individuals/resources/test_individual_crud.py
+++ b/tests/modules/individuals/resources/test_individual_crud.py
@@ -468,7 +468,7 @@ def test_edm_custom_field_patch(
         flask_app_client,
         admin_user,
         'personality (test custom field)',
-        cls='MarkedIndividual',
+        cls='Individual',
     )
     assert custom_field_id is not None
 

--- a/tests/modules/sightings/resources/test_custom_fields.py
+++ b/tests/modules/sightings/resources/test_custom_fields.py
@@ -22,7 +22,9 @@ def test_custom_fields_on_sighting(
     from app.modules.sightings.models import Sighting
     import datetime
 
-    cfd_id = setting_utils.custom_field_create(flask_app_client, admin_user, 'test_cfd')
+    cfd_id = setting_utils.custom_field_create(
+        flask_app_client, admin_user, 'test_cfd', cls='Sighting'
+    )
     assert cfd_id is not None
     cfd_multi_id = setting_utils.custom_field_create(
         flask_app_client, admin_user, 'test_multi_cfd', multiple=True

--- a/tests/modules/site_settings/resources/test_read_configurations.py
+++ b/tests/modules/site_settings/resources/test_read_configurations.py
@@ -123,6 +123,9 @@ def test_alter_custom_fields(flask_app_client, admin_user):
 
     assert 'value' in occ_cf_rsp.json['response']
     occ_cfs = occ_cf_rsp.json['response']['value']
+    if 'definitions' not in occ_cfs:
+        occ_cfs['definitions'] = []
+
     occ_cfs['definitions'].append(
         {
             'className': 'org.ecocean.Occurrence',

--- a/tests/modules/site_settings/resources/utils.py
+++ b/tests/modules/site_settings/resources/utils.py
@@ -78,7 +78,7 @@ def _modify_setting(
         expected_error=expected_error,
     )
     if expected_status_code == 200:
-        assert res.json['success']
+        assert res.json['success'], res.json
     elif expected_status_code:
         if 'success' in res.json.keys():
             assert not res.json['success']
@@ -133,6 +133,29 @@ def custom_field_create(
     cfd_list = response.json.get('updatedCustomFieldDefinitionIds', None)
     assert cfd_list
     return cfd_list[0]
+
+
+def patch_main_setting(
+    flask_app_client,
+    user,
+    conf_key,
+    data,
+    expected_status_code=200,
+):
+    if conf_key == 'block':
+        path = f'{SETTING_PATH}/main'
+    else:
+        path = f'{SETTING_PATH}/main/{conf_key}'
+
+    return test_utils.patch_via_flask(
+        flask_app_client,
+        user,
+        scopes='site-settings:write',
+        path=path,
+        data=data,
+        expected_status_code=expected_status_code,
+        response_200={'success'},
+    )
 
 
 def _delete_setting(


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- SiteSettings now allows get and set of Sighting and Individual CustomFields and maps them to the EDM names of Occurrence and MarkedIndividual
- EDM POST now handles error correctly.
- Patch remove and delete now removes some limited fields on EDM
- Refactored so that fields that start with 'site' are edm settings and everything else is houston. If HOUSTON_SETTING entry not present, the code now uses defaults (previously fields were getting mishandled/ignored) 
 

---




