### PR TITLE
QA feedback name validation changes

### DIFF
--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -789,7 +789,8 @@ class FlatfileNameValidation(Resource):
     # values passed in from flatfile are val/index pairs:
     # [
     #   ["Zebulon", 1],
-    #   ["Zebrucifer", 2],
+    #   ["Zebulon", 2],
+    #   ["Zebrandon", 3],
     #   ["Zebrelda", 300],
     #   ["Zesus", 46]
     # ]
@@ -807,11 +808,9 @@ class FlatfileNameValidation(Resource):
                 code=500,
             )
 
-        query_index_dict = {
-            val_id_pair[0]: val_id_pair[1] for val_id_pair in request.json
-        }
         # want to preserve order here
         query_name_vals = [val_id_pair[0] for val_id_pair in request.json]
+        query_indices = [val_id_pair[1] for val_id_pair in request.json]
 
         db_names = Name.query.filter(
             Name.value.in_(query_name_vals), Name.context == DEFAULT_NAME_CONTEXT
@@ -822,7 +821,7 @@ class FlatfileNameValidation(Resource):
             db_name_lookup[name.value].append(str(name.individual_guid))
 
         rtn_json = []
-        for name_val in query_name_vals:
+        for name_val, index in zip(query_name_vals, query_indices):
             if name_val in db_name_lookup and len(db_name_lookup[name_val]) == 1:
                 name_info = {
                     'message': f'Corresponds to existing individual {db_name_lookup[name_val][0]}.',
@@ -840,6 +839,6 @@ class FlatfileNameValidation(Resource):
                 }
 
             name_json = {'value': name_val, 'info': [name_info]}
-            rtn_json.append([name_json, query_index_dict[name_val]])
+            rtn_json.append([name_json, index])
 
         return rtn_json

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -822,7 +822,9 @@ class FlatfileNameValidation(Resource):
 
         rtn_json = []
         for name_val, index in zip(query_name_vals, query_indices):
-            if name_val in db_name_lookup and len(db_name_lookup[name_val]) == 1:
+            if not name_val or name_val.strip() == '':
+                continue
+            elif name_val in db_name_lookup and len(db_name_lookup[name_val]) == 1:
                 name_info = {
                     'message': f'Corresponds to existing individual {db_name_lookup[name_val][0]}.',
                     'level': 'info',
@@ -834,10 +836,9 @@ class FlatfileNameValidation(Resource):
                 }
             else:
                 name_info = {
-                    'message': 'This is a new name and submission will create a new individual',
-                    'level': 'warning',
+                    'message': 'ERROR: cannot resolve this name to an existing individual. New name creation is not yet supported in bulk upload.',
+                    'level': 'error',
                 }
-
             name_json = {'value': name_val, 'info': [name_info]}
             rtn_json.append([name_json, index])
 

--- a/tests/modules/individuals/resources/test_individual_names.py
+++ b/tests/modules/individuals/resources/test_individual_names.py
@@ -414,7 +414,10 @@ def test_name_validation(
         ['Zebra Prime', 0],
         ['Big Dog', 1],
         ['Big Dog', 2],
-        ['Zebra Omega', 4],
+        ['', 3],
+        [None, 4],
+        ['  ', 5],
+        ['Zebra Omega', 6],
         ['Jennifer', 100],
     ]
 
@@ -444,8 +447,8 @@ def test_name_validation(
                 'value': 'Big Dog',
                 'info': [
                     {
-                        'message': 'This is a new name and submission will create a new individual',
-                        'level': 'warning',
+                        'message': 'ERROR: cannot resolve this name to an existing individual. New name creation is not yet supported in bulk upload.',
+                        'level': 'error',
                     }
                 ],
             },
@@ -456,8 +459,8 @@ def test_name_validation(
                 'value': 'Big Dog',
                 'info': [
                     {
-                        'message': 'This is a new name and submission will create a new individual',
-                        'level': 'warning',
+                        'message': 'ERROR: cannot resolve this name to an existing individual. New name creation is not yet supported in bulk upload.',
+                        'level': 'error',
                     }
                 ],
             },
@@ -473,15 +476,15 @@ def test_name_validation(
                     }
                 ],
             },
-            4,
+            6,
         ],
         [
             {
                 'value': 'Jennifer',
                 'info': [
                     {
-                        'message': 'This is a new name and submission will create a new individual',
-                        'level': 'warning',
+                        'message': 'ERROR: cannot resolve this name to an existing individual. New name creation is not yet supported in bulk upload.',
+                        'level': 'error',
                     }
                 ],
             },

--- a/tests/modules/individuals/resources/test_individual_names.py
+++ b/tests/modules/individuals/resources/test_individual_names.py
@@ -413,6 +413,7 @@ def test_name_validation(
     flatfile_query = [
         ['Zebra Prime', 0],
         ['Big Dog', 1],
+        ['Big Dog', 2],
         ['Zebra Omega', 4],
         ['Jennifer', 100],
     ]
@@ -449,6 +450,18 @@ def test_name_validation(
                 ],
             },
             1,
+        ],
+        [
+            {
+                'value': 'Big Dog',
+                'info': [
+                    {
+                        'message': 'This is a new name and submission will create a new individual',
+                        'level': 'warning',
+                    }
+                ],
+            },
+            2,
         ],
         [
             {


### PR DESCRIPTION
Ben has already QA'd this branch and approved it, and it's only affecting the one name validation endpoint and its one test, so this is a candidate for a quick merge into `main`.

Three changes have been made to the old name validation logic:

1. Fixes a bug where a name that appears on N rows was returned with the final row's index on every row, rather than the correct N indices.
2. Allows the passing-in of blank names, for which no validation result is returned
3. Throws an error rather than a warning for new names, with the updated assumption that we aren't creating new names on bulk uploads.