### PR TITLE
Add individual_first_name to relationships in individual GET API

### DIFF
--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -14,7 +14,10 @@ from app.modules.encounters.schemas import (
     DetailedEncounterSchema,
     ElasticsearchEncounterSchema,
 )
-from app.modules.relationships.schemas import DetailedRelationshipSchema
+from app.modules.relationships.schemas import (
+    DetailedRelationshipSchema,
+    BaseRelationshipIndividualMemberSchema,
+)
 
 
 class BaseIndividualSchema(ModelSchema):
@@ -57,6 +60,29 @@ class IndividualRelationshipSchema(DetailedRelationshipSchema):
     """
     Relationship schema used in the individual API
     """
+
+    class RelationshipIndividualMemberSchema(BaseRelationshipIndividualMemberSchema):
+        individual_first_name = base_fields.String()
+
+        class Meta(BaseRelationshipIndividualMemberSchema.Meta):
+            fields = BaseRelationshipIndividualMemberSchema.Meta.fields + (
+                'individual_first_name',
+            )
+            dump_only = BaseRelationshipIndividualMemberSchema.Meta.dump_only + (
+                'individual_first_name',
+            )
+
+    individual_members = base_fields.Nested(
+        RelationshipIndividualMemberSchema,
+        many=True,
+        only=(
+            'guid',
+            'individual_guid',
+            'individual_role_label',
+            'individual_role_guid',
+            'individual_first_name',
+        ),
+    )
 
     class Meta(DetailedRelationshipSchema.Meta):
         fields = (

--- a/app/modules/relationships/models.py
+++ b/app/modules/relationships/models.py
@@ -57,6 +57,16 @@ class RelationshipIndividualMember(db.Model, HoustonModel):
             )
 
     @property
+    def individual_first_name(self):
+        from app.modules.names.models import Name
+
+        first_name = Name.query.filter_by(
+            individual=self.individual, context='FirstName'
+        ).first()
+        if first_name:
+            return first_name.value
+
+    @property
     def individual_role_label(self):
         from app.modules.site_settings.models import SiteSetting
 

--- a/tests/modules/relationships/resources/test_relationship_crud.py
+++ b/tests/modules/relationships/resources/test_relationship_crud.py
@@ -67,7 +67,10 @@ def test_create_read_delete_relationship(
 
     temp_enc_1 = Encounter.query.get(temp_enc_1_guid)
 
-    enc_1_json = {'encounters': [{'id': str(temp_enc_1_guid)}]}
+    enc_1_json = {
+        'names': [{'context': 'FirstName', 'value': 'Mommy'}],
+        'encounters': [{'id': str(temp_enc_1_guid)}],
+    }
     temp_enc_1.owner = researcher_1
     response = individual_utils.create_individual(
         flask_app_client, researcher_1, expected_status_code=200, data_in=enc_1_json
@@ -202,11 +205,13 @@ def test_create_read_delete_relationship(
                     'individual_role_label': 'Mother',
                     'individual_role_guid': mother_role_guid,
                     'individual_guid': str(individual_1_guid),
+                    'individual_first_name': 'Mommy',
                 },
                 {
                     'individual_role_label': 'Calf',
                     'individual_role_guid': calf_role_guid,
                     'individual_guid': str(individual_2_guid),
+                    'individual_first_name': None,
                 },
             ],
         }


### PR DESCRIPTION
For example if the mother's first name is "Mommy", and the calf doesn't have a
first name, this would be returned:

```json
[
 {"individual_first_name": "Mommy",
  "individual_guid": "f28c2393-cb6c-4504-8b2c-1619df284d5d",
  "individual_role_guid": "1b62eb1a-0b80-4c2d-b914-923beba8863c",
  "individual_role_label": "Mother"},
 {"individual_first_name": null,
  "individual_guid": "156b5bb6-7a80-46c2-8252-3659da153497",
  "individual_role_guid": "ea5dbbb3-cc47-4d44-b460-2518a25dcb13",
  "individual_role_label": "Calf"},
]
```
