### PR TITLE
691 image upload validate

### DIFF
--- a/app/modules/fileuploads/resources.py
+++ b/app/modules/fileuploads/resources.py
@@ -36,3 +36,72 @@ api = Namespace('fileuploads', description='FileUploads')  # pylint: disable=inv
 class FileUploadSrcUByID(Resource):
     def get(self, fileupload, format):
         return send_file(fileupload.get_absolute_path(), fileupload.mime_type)
+
+
+@api.route('/validate')
+class FlatfileImageNameValidate(Resource):
+    # values passed in from flatfile are val/index pairs:
+    # [
+    #   ["1.jpg", 1],
+    #   ["86.jpg,zebra.jpg", 2],
+    #   ["55.jpg, giraffe.jpg", ", 15],
+    # ]
+    def post(self):
+        from app.modules.names.models import Name, DEFAULT_NAME_CONTEXT
+
+        from flask_login import current_user
+        from collections import defaultdict
+
+        if not current_user or current_user.is_anonymous:
+            abort(code=401)
+        if not isinstance(request.json, list):
+            abort(
+                message='Must be passed a list of flatfile-formatted image names-index pairs',
+                code=500,
+            )
+
+        fnames_index_dict = {
+            val_id_pair[0]: val_id_pair[1] for val_id_pair in request.json
+        }
+        fnames_lists = [_comma_separated_fnames_to_list(fname) for fname in fnames_index_dict.keys()]
+        fnames_list = [fname for fname in fname_list for fname_list in fname_lists]
+        # want to preserve order here
+        query_name_vals = [val_id_pair[0] for val_id_pair in request.json]
+
+
+        db_names = Name.query.filter(
+            Name.value.in_(query_name_vals), Name.context == DEFAULT_NAME_CONTEXT
+        )
+        # maps a name value to list of individuals with that name value
+        db_name_lookup = defaultdict(list)
+        for name in db_names:
+            db_name_lookup[name.value].append(str(name.individual_guid))
+
+        rtn_json = []
+        for name_val in query_name_vals:
+            if name_val in db_name_lookup and len(db_name_lookup[name_val]) == 1:
+                name_info = {
+                    'message': f'Corresponds to existing individual {db_name_lookup[name_val][0]}.',
+                    'level': 'info',
+                }
+            elif name_val in db_name_lookup and len(db_name_lookup[name_val]) > 1:
+                name_info = {
+                    'message': f'ERROR: cannot resolve this name to a unique individual. Individuals sharing this name are {db_name_lookup[name_val]}.',
+                    'level': 'error',
+                }
+            else:
+                name_info = {
+                    'message': 'This is a new name and submission will create a new individual',
+                    'level': 'warning',
+                }
+
+            name_json = {'value': name_val, 'info': [name_info]}
+            rtn_json.append([name_json, query_index_dict[name_val]])
+
+        return rtn_json
+
+    def _comma_separated_fnames_to_list(fnames_str):
+        fname_list = fnames_str.split(",")
+        # remove whitespace
+        fname_list = [fname.strip() for fname in fnames]
+        return fname_list

--- a/app/modules/fileuploads/resources.py
+++ b/app/modules/fileuploads/resources.py
@@ -8,14 +8,13 @@ which will set FileUpload values as properties on other objects.
 """
 
 import logging
+import pathlib
 
-from flask import send_file
+from flask import send_file, request, current_app
 from flask_login import current_user  # NOQA
 from flask_restx_patched import Resource
 from flask_restx_patched._http import HTTPStatus
-
-from app.extensions.api import Namespace
-
+from app.extensions.api import Namespace, abort
 
 from .models import FileUpload
 
@@ -38,7 +37,7 @@ class FileUploadSrcUByID(Resource):
         return send_file(fileupload.get_absolute_path(), fileupload.mime_type)
 
 
-@api.route('/validate')
+@api.route('/image_validate')
 class FlatfileImageNameValidate(Resource):
     # values passed in from flatfile are val/index pairs:
     # [
@@ -47,61 +46,62 @@ class FlatfileImageNameValidate(Resource):
     #   ["55.jpg, giraffe.jpg", ", 15],
     # ]
     def post(self):
-        from app.modules.names.models import Name, DEFAULT_NAME_CONTEXT
-
-        from flask_login import current_user
-        from collections import defaultdict
+        from app.utils import get_stored_filename
+        from os.path import is_file
 
         if not current_user or current_user.is_anonymous:
             abort(code=401)
+
+        # TODO: make sure user is logged in?
         if not isinstance(request.json, list):
             abort(
                 message='Must be passed a list of flatfile-formatted image names-index pairs',
                 code=500,
             )
 
-        fnames_index_dict = {
-            val_id_pair[0]: val_id_pair[1] for val_id_pair in request.json
-        }
-        fnames_lists = [_comma_separated_fnames_to_list(fname) for fname in fnames_index_dict.keys()]
-        fnames_list = [fname for fname in fname_list for fname_list in fname_lists]
-        # want to preserve order here
-        query_name_vals = [val_id_pair[0] for val_id_pair in request.json]
+        fnames_strs = [val_id_pair[0] for val_id_pair in request.json]
+        fnames_ids = [val_id_pair[1] for val_id_pair in request.json]
 
+        transaction_id = current_user.get_bulk_tus_transaction_id
+        assert (
+            transaction_id
+        ), f'could not find an active bulk transaction_id for {current_user}'
 
-        db_names = Name.query.filter(
-            Name.value.in_(query_name_vals), Name.context == DEFAULT_NAME_CONTEXT
+        fileupload_base_path = pathlib.Path(
+            current_app.config.get('FILEUPLOAD_BASE_PATH')
         )
-        # maps a name value to list of individuals with that name value
-        db_name_lookup = defaultdict(list)
-        for name in db_names:
-            db_name_lookup[name.value].append(str(name.individual_guid))
+        user_dir = f'{fileupload_base_path}/trans-{transaction_id}'
 
         rtn_json = []
-        for name_val in query_name_vals:
-            if name_val in db_name_lookup and len(db_name_lookup[name_val]) == 1:
-                name_info = {
-                    'message': f'Corresponds to existing individual {db_name_lookup[name_val][0]}.',
+        for fnames_str, index in zip(fnames_strs, fnames_ids):
+
+            # parse comma-separated, possibly whitespace-separated filenames
+            fname_list = fnames_str.split(',')
+            fname_list = [fname.strip() for fname in fname_list]
+
+            hashed_fnames = [get_stored_filename(fname) for fname in fname_list]
+            missing_images = [
+                fname
+                for fname, hashed_fname in zip(fname_list, hashed_fnames)
+                if not is_file(f'{user_dir}/{hashed_fname}')
+            ]
+
+            if len(missing_images) == 0:
+                row_json = {
+                    'message': 'images uploaded successfully.',
                     'level': 'info',
                 }
-            elif name_val in db_name_lookup and len(db_name_lookup[name_val]) > 1:
-                name_info = {
-                    'message': f'ERROR: cannot resolve this name to a unique individual. Individuals sharing this name are {db_name_lookup[name_val]}.',
+            elif len(missing_images) == 1:
+                row_json = {
+                    'message': f'missing image: {missing_images[0]}. please return to image upload stage and upload this image.',
                     'level': 'error',
                 }
             else:
-                name_info = {
-                    'message': 'This is a new name and submission will create a new individual',
-                    'level': 'warning',
+                row_json = {
+                    'message': f'missing images: {missing_images}. please return to image upload stage and upload these images.',
+                    'level': 'error',
                 }
 
-            name_json = {'value': name_val, 'info': [name_info]}
-            rtn_json.append([name_json, query_index_dict[name_val]])
+            rtn_json.append([row_json, index])
 
         return rtn_json
-
-    def _comma_separated_fnames_to_list(fnames_str):
-        fname_list = fnames_str.split(",")
-        # remove whitespace
-        fname_list = [fname.strip() for fname in fnames]
-        return fname_list

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -18,7 +18,6 @@ from app.extensions.api.parameters import _get_is_static_role_property
 from app.extensions.email import Email
 import app.extensions.logging as AuditLog
 
-
 log = logging.getLogger(__name__)
 
 
@@ -675,24 +674,24 @@ class User(db.Model, FeatherModel, UserEDMMixin):
         return ags
 
     @module_required('asset_groups', resolve='warn', default=[])
-    def get_bulk_asset_group_sighting(self):
-        bulk_agses = [
-            ags
-            for ags in self.get_unprocessed_asset_group_sightings()
-            if ags.config and ags.config.bulk_upload
+    def get_bulk_asset_group(self):
+        ags = [
+            group
+            for group in self.get_unprocessed_asset_groups()
+            if group.get_config_field('uploadType') == 'bulk'
         ]
-        assert len(bulk_agses) < 2, f'multiple bulk uploads in progress for user {self}'
-        if len(bulk_agses) == 0:
-            bulk_ags = None
+        assert len(ags) < 2, f'multiple bulk asset groups found for user {self}'
+        if len(ags) == 0:
+            group = None
         else:
-            bulk_ags = bulk_agses[0]
-        return bulk_ags
+            group = ags[0]
+        return group
 
     @module_required('asset_groups', resolve='warn', default=[])
     def get_bulk_tus_transaction_id(self):
-        bulk_ags = self.get_bulk_asset_group_sighting()
-        if bulk_ags:
-            transaction_id = bulk_ags.transaction_id
+        bulk_ag = self.get_bulk_asset_group()
+        if bulk_ag and bulk_ag.config and 'transactionId' in bulk_ag.config:
+            transaction_id = bulk_ag.config['transactionId']
         else:
             transaction_id = None
         return transaction_id

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -107,6 +107,7 @@ if is_extension_enabled('edm'):
             # TODO is this actually needed
             log.warning('User._process_edm_user_organization() not implemented yet')
 
+
 else:
     UserEDMMixin = object
 
@@ -672,6 +673,29 @@ class User(db.Model, FeatherModel, UserEDMMixin):
             new_ags = [ags for ags in group.get_unprocessed_asset_group_sightings()]
             ags.extend(new_ags)
         return ags
+
+    @module_required('asset_groups', resolve='warn', default=[])
+    def get_bulk_asset_group_sighting(self):
+        bulk_agses = [
+            ags
+            for ags in self.get_unprocessed_asset_group_sightings()
+            if ags.config and ags.config.bulk_upload
+        ]
+        assert len(bulk_agses) < 2, f'multiple bulk uploads in progress for user {self}'
+        if len(bulk_agses) == 0:
+            bulk_ags = None
+        else:
+            bulk_ags = bulk_agses[0]
+        return bulk_ags
+
+    @module_required('asset_groups', resolve='warn', default=[])
+    def get_bulk_tus_transaction_id(self):
+        bulk_ags = self.get_bulk_asset_group_sighting()
+        if bulk_ags:
+            transaction_id = bulk_ags.transaction_id
+        else:
+            transaction_id = None
+        return transaction_id
 
     @module_required('sightings', resolve='warn', default=[])
     def unprocessed_sightings(self):

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -578,6 +578,19 @@ def create_asset_group(
     return response
 
 
+def validate_image_endpoint(
+    flask_app_client, user, valid_data_in, expected_status_code=200, expected_error=''
+):
+
+    with flask_app_client.login(user, auth_scopes=('asset_groups:write',)):
+        response = flask_app_client.post(
+            '/api/v1/fileuploads/image_validate/',
+            content_type='application/json',
+            data=json.dumps(valid_data_in),
+        )
+    return response
+
+
 # As for method above but simulate a successful initial response from Sage and do some minimal validation
 # Note this is just the ack to say that Sage has received the request, not the detection response itself
 def create_asset_group_sim_sage_init_resp(


### PR DESCRIPTION
If you saw the name validation PR, this one is very similar.

Adds a new endpoint where a user can validate that a list of images in their personal in-progress bulk upload exists on the server. The input and output formats are dictated by flatfile. The endpoint is at /fileupload/image_validate.

The test is in the AssetGroup tests, next to other bulk upload-related AG and AGS tests. There were a few places where the existing bulk upload tests surprised me in how they work, breaking some assumptions I had about uploads. I'm copying theses here so you can double check:

1. During the bulk upload test, the images the user uploads automatically get into an AssetGroup. I thought they would only have an AGS at this point. The AG contains the AGS which contains the images. Again, just double-checking this is right.
2. tus transaction-ids and image directories with `trans-<transaction-id>` do not factor into this at all. I was able to locate the bulk upload images just by using `find` inside the houston container and then based the image validation logic on the directories I found there.

If that sounds right and the code looks good to you, ready to merge. I'm now working on a related bulk upload PR so I'll learn more soon, hah.