### PR TITLE
Rerun detection in foreground in celery, fixup for 0e315a0c

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -750,7 +750,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
                     log,
                     'Cannot rerun detection on AssetGroupSighting in detection stage with active jobs',
                 )
-            self.start_detection()
+            self.start_detection(background=background)
         else:
             raise HoustonException(
                 log, f'Cannot rerun detection on AssetGroupSighting in {self.stage} stage'


### PR DESCRIPTION
We have periodic jobs that check if detection or identification should
rerun, since the checking is already done in celery we can just call the
sage detection or identification API in the foreground instead of
queueing them.

This is to bypass a problem on codex-qa I see right now where queued
jobs are not being picked up but periodic jobs are still working in
celery.

