### PR TITLE
Fix AssetGroupSighting.detection and curation start time

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -295,7 +295,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
     # Don't store detection start time directly. It's either the creation time if we ever had detection
     # jobs or None if no detection was done (and hence no jobs exist)
     def get_detection_start_time(self):
-        if self.jobs:
+        if self.jobs or self.stage == AssetGroupSightingStage.detection:
             return self.created.isoformat() + 'Z'
         return None
 
@@ -303,7 +303,8 @@ class AssetGroupSighting(db.Model, HoustonModel):
     # Either detection has completed or no detection jobs were run
     def get_curation_start_time(self):
         if (
-            not self.any_jobs_active()
+            self.stage != AssetGroupSightingStage.detection
+            and not self.any_jobs_active()
             and 'assetReferences' in self.config.keys()
             and len(self.config['assetReferences']) != 0
         ):

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -611,7 +611,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
                 f'code: {ex.status_code}, acm_status_code: {acm_status_code}, giving up'
             )
             # Assuming some sort of persisten error in Sage
-            self.stage = AssetGroupSightingStage.curation
+            self.set_stage(AssetGroupSightingStage.curation)
 
     def check_job_status(self, job_id):
         if str(job_id) not in self.jobs:
@@ -743,7 +743,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
     def rerun_detection(self, background=True):
         log.info('Rerunning Sage detection')
         if self.stage == AssetGroupSightingStage.curation:
-            self.stage = AssetGroupSightingStage.detection
+            self.set_stage(AssetGroupSightingStage.detection)
             self.start_detection(background=background)
         elif self.stage == AssetGroupSightingStage.detection:
             if self.any_jobs_active():


### PR DESCRIPTION
- Fix AssetGroupSighting detection and curation start time

  Frontend is using detection and curation to determine what state the
  object is in.  If detection start time is none and curation start time
  is not none, detection is shown as "skipped".
  
  That was exactly the situation we were in on codex-qa because
  detection start time was only returned if `self.jobs` was populated, and
  `self.jobs` wasn't populated for a few minutes because of celery
  problems.  In the mean time, curation start time was returned because
  there were no active jobs.
  
  Change the code to check `self.stage` in addition to the original logic.

- Persist changes to AssetGroupSighting.stage

  A few times in the code that changes `AssetGroupSighting.stage`, there's
  a possibility that the change isn't persisted to the database.  Change
  the code to use `AssetGroupSighting.set_stage` instead.
