### PR TITLE
Catch exceptions in JobControl.check_jobs so all jobs are checked

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -457,7 +457,10 @@ class AssetGroupSighting(db.Model, HoustonModel):
                     f'{self.guid} is detecting but no detection jobs are running, '
                     'assuming Celery error and starting them again'
                 )
-            self.rerun_detection(background=False)
+            try:
+                self.rerun_detection(background=False)
+            except Exception:
+                log.exception('{self} rerun_detection failed')
             return
         for job_id in jobs.keys():
             job = jobs[job_id]

--- a/app/modules/job_control/models.py
+++ b/app/modules/job_control/models.py
@@ -12,15 +12,27 @@ class JobControl(object):
     # Called by a periodic background task,
     @classmethod
     def check_jobs(cls):
+        last_error = None
         if is_module_enabled('asset_groups'):
-            from app.modules.asset_groups.models import AssetGroupSighting
+            try:
+                from app.modules.asset_groups.models import AssetGroupSighting
 
-            AssetGroupSighting.check_jobs()
+                AssetGroupSighting.check_jobs()
+            except Exception as e:
+                last_error = e
+                log.error('AssetGroupSighting.check_jobs() error')
 
         if is_module_enabled('sightings'):
-            from app.modules.sightings.models import Sighting
+            try:
+                from app.modules.sightings.models import Sighting
 
-            Sighting.check_jobs()
+                Sighting.check_jobs()
+            except Exception as e:
+                last_error = e
+                log.error('Sighting.check_jobs() error')
+
+        if last_error:
+            raise last_error
 
     # Central point for all "job" related things to be accessed.
     @classmethod

--- a/tests/modules/job_control/test_models.py
+++ b/tests/modules/job_control/test_models.py
@@ -45,3 +45,39 @@ def test_job_control(flask_app, researcher_1, test_root, db):
     finally:
         if asset_group:
             asset_group.delete()
+
+
+@pytest.mark.skipif(
+    module_unavailable('asset_groups'), reason='Asset Group module disabled'
+)
+@pytest.mark.skipif(module_unavailable('sightings'), reason='Sightings module disabled')
+def test_check_jobs():
+    from app.modules.job_control.models import JobControl
+
+    AssetGroupSighting = 'app.modules.asset_groups.models.AssetGroupSighting'
+    Sighting = 'app.modules.sightings.models.Sighting'
+    with mock.patch(f'{AssetGroupSighting}.check_jobs') as ags_check_jobs:
+        with mock.patch(f'{Sighting}.check_jobs') as s_check_jobs:
+            # No errors
+            JobControl.check_jobs()
+            assert ags_check_jobs.called
+            assert s_check_jobs.called
+
+            ags_check_jobs.reset_mock()
+            s_check_jobs.reset_mock()
+
+            # AssetGroupSighting.check_jobs raises an error
+            ags_check_jobs.side_effect = lambda: 1 / 0
+            with pytest.raises(ZeroDivisionError):
+                JobControl.check_jobs()
+            # Sighting.check_jobs is still called
+            assert s_check_jobs.called
+
+            ags_check_jobs.reset_mock()
+            s_check_jobs.reset_mock()
+
+            # Both AssetGroupSighting.check_jobs and Sighting.check_jobs raise
+            # errors, only the last one is reraised
+            s_check_jobs.side_effect = lambda: len(None)
+            with pytest.raises(TypeError):
+                JobControl.check_jobs()


### PR DESCRIPTION
Right now on codex-qa, we are seeing this error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 450, in trace_task
    R = retval = fun(*args, **kwargs)                                                                                                                File "/code/app/__init__.py", line 141, in __call__
    return self.run(*args, **kwargs)                                                                                                                 File "/code/app/modules/job_control/tasks.py", line 17, in check_jobs
    JobControl.check_jobs()                                                                                                                          File "/code/app/modules/job_control/models.py", line 18, in check_jobs
    AssetGroupSighting.check_jobs()
  File "/code/app/modules/asset_groups/models.py", line 447, in check_jobs
    asset_group_sighting.check_all_job_status(all_scheduled)
  File "/code/app/modules/asset_groups/models.py", line 459, in check_all_job_status                                                                   self.rerun_detection(background=False)
  File "/code/app/modules/asset_groups/models.py", line 753, in rerun_detection                                                                        self.start_detection(background=background)
  File "/code/app/modules/asset_groups/models.py", line 777, in start_detection                                                                        sage_detection(str(self.guid), config)
  File "/usr/local/lib/python3.9/site-packages/celery/local.py", line 188, in __call__
    return self._get_current_object()(*a, **kw)
  File "/code/app/__init__.py", line 141, in __call__
    return self.run(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/celery/app/autoretry.py", line 34, in run
    return task._orig_run(*args, **kwargs)
  File "/code/app/modules/asset_groups/tasks.py", line 89, in sage_detection
    asset_group_sighting.send_detection_to_sage(model)
  File "/code/app/modules/asset_groups/models.py", line 565, in send_detection_to_sage
    detection_request = self.build_detection_request(job_id, model)
  File "/code/app/modules/asset_groups/models.py", line 546, in build_detection_request
    assert asset
AssertionError
```

All the other jobs are not checked because of this error.  Catch it and move on
instead.

