### PR TITLE
Replace http redirects with https in RestManager (for acm)

### DIFF
--- a/tests/extensions/edm/test_edm.py
+++ b/tests/extensions/edm/test_edm.py
@@ -41,7 +41,9 @@ def test_edm_version(flask_app):
 def test_reauthentication(flask_app):
     flask_app.edm._ensure_initialized()
     original_get = flask_app.edm.sessions['default'].get
-    mock_401 = mock.Mock(status_code=401, ok=False, content=b'')
+    mock_401 = mock.Mock(
+        status_code=401, ok=False, content=b'', is_redirect=False, headers={}
+    )
     edm_uri = flask_app.config['EDM_URIS']['default']
 
     def mock_get(url, *args, call_count=[], **kwargs):
@@ -65,7 +67,9 @@ def test_reauthentication(flask_app):
 @pytest.mark.skipif(extension_unavailable('edm'), reason='EDM extension disabled')
 def test_reauthentication_fails(flask_app):
     flask_app.edm._ensure_initialized()
-    mock_401 = mock.Mock(status_code=401, ok=False, content=b'')
+    mock_401 = mock.Mock(
+        status_code=401, ok=False, content=b'', is_redirect=False, headers={}
+    )
 
     def mock_get(url, *args, **kwargs):
         return mock_401

--- a/tests/extensions/test_acm.py
+++ b/tests/extensions/test_acm.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from unittest import mock
+
+import pytest
+
+from tests.utils import extension_unavailable
+
+
+@pytest.mark.skipif(extension_unavailable('acm'), reason='ACM extension disabled')
+def test_https_url_redirect(flask_app):
+    # Even if acm responds with a redirect to http url, force it to be
+    # https instead
+    flask_app.acm._ensure_initialized()
+    mock_308 = mock.Mock(
+        status_code=308,
+        is_redirect=True,
+        headers={'location': 'http://acm:5000/api/'},
+    )
+    mock_200 = mock.Mock(
+        status_code=200,
+        is_redirect=False,
+        ok=True,
+        text='{"ok": true}',
+    )
+    flask_app.acm.uris['default'] = 'https://acm:5000/'
+
+    def mock_post(url, *args, call_count=[], **kwargs):
+        if not call_count:
+            call_count.append(1)
+            return mock_308
+        return mock_200
+
+    with mock.patch.object(
+        flask_app.acm.sessions['default'], 'post', side_effect=mock_post
+    ) as acm_post:
+        flask_app.acm._request(
+            'post',
+            'job.detect_request',
+            'cnn',
+            passthrough_kwargs={
+                'params': {
+                    'endpoint': '/api/engine/detect/cnn/lightnet/',
+                    'jobid': '1bab866c-cc2e-4ac3-a7e9-ae400a2922ea',
+                },
+            },
+        )
+        assert [call_args[0][0] for call_args in acm_post.call_args_list] == [
+            'https://acm:5000/api/engine/detect/cnn',
+            # Even if acm wants to redirect us to http://acm:5000/api/,
+            # use https://acm:5000/api/
+            'https://acm:5000/api/',
+        ]


### PR DESCRIPTION
This was to fix a problem we saw with codex-qa using kaiju acm:

```
WARNING  [app.extensions.restManager.RestManager] Non-OK (400) response on post                                       RestManager.py:313
         https://kaiju/api/engine/detect/cnn/lightnet: b'<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML
         2.0//EN">\n<html><head>\n<title>400 Bad Request</title>\n</head><body>\n<h1>Bad Request</h1>\n<p>Your
         browser sent a request that this server could not understand.<br />\nReason: You\'re speaking plain HTTP to
         an SSL-enabled server port.<br />\n Instead use the HTTPS scheme to access this URL, please.<br
         />\n</p>\n<hr>\n<address>Apache/2.4.41 (Ubuntu) Server at kaiju Port
         80</address>\n</body></html>\n'
```

Turns out when we call
https://kaiju/api/engine/detect/cnn/lightnet, kaiju tried to
redirect us with a 308 to
http://kaiju/api/engine/detect/cnn/lightnet/?endpoint=%2Fapi%2Fengine%2Fdetect%2Fcnn%2Flightnet%2F

This can be fixed by replacing http with https.

