### PR TITLE
Fix TypeError calling sightings/<guid>/id_result API

### DIFF
--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -975,7 +975,7 @@ class Sighting(db.Model, FeatherModel):
             response['annotation_data'][str(annot.guid)] = {
                 'viewpoint': annot.viewpoint,
                 'encounter_location': encounter_location,
-                'individual_guid': individual_guid,
+                'individual_guid': str(individual_guid),
                 'image_url': annot.asset.get_image_url(),
                 'asset_dimensions': annot.asset.get_dimensions(),
                 'bounds': annot.bounds,
@@ -989,7 +989,14 @@ class Sighting(db.Model, FeatherModel):
             assert individual
             # add individual data
             response['individual_data'][str(individual_guid)] = {
-                'names': individual.get_names(),
+                'names': [
+                    {
+                        'guid': str(name.guid),
+                        'context': name.context,
+                        'value': name.value,
+                    }
+                    for name in individual.get_names()
+                ],
                 'last_seen': str(individual.get_last_seen_time()),
                 'image': individual.get_featured_image_url(),
             }


### PR DESCRIPTION
```
           INFO     [werkzeug] 172.20.0.3 - - [26/Apr/2022 20:13:17] "[1m[35mGET /api/v1/sightings/bf4f6915-e51b-4eb5-bb9c-5009946ff6e7/id_result HTTP/1.0[0m" 500 -                    _internal.py:122
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 2464, in __call__
    return self.wsgi_app(environ, start_response)
  File "/usr/local/lib/python3.9/site-packages/flask/app.py", line 2450, in wsgi_app
    response = self.handle_exception(e)
...
  File "/usr/local/lib/python3.9/json/encoder.py", line 438, in _iterencode
    o = _default(o)
  File "/usr/local/lib/python3.9/site-packages/flask/json/__init__.py", line 100, in default
    return _json.JSONEncoder.default(self, o)
  File "/usr/local/lib/python3.9/json/encoder.py", line 179, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
TypeError: Object of type Name is not JSON serializable
```

The reason is `sighting.get_id_result()` returns something like this:

```
{'query_annotations': [{'guid': 'd3ba8001-aae9-4a0f-aa9a-d64fb14133bb',
   'status': 'complete',
   'individual_guid': None,
...
 'individual_data': {'0abe0335-e075-4654-a628-5d8b07fe853a': {'names': [<Name(guid=667befc0-5aed-4119-a12c-61a9356dc771, context='FirstName', value=M2021_018 )>],
   'last_seen': '2022-01-13 23:48:34.865442',
...
```

So we have these `Name` objects that can't be serialized.

