### PR TITLE
Modernize Python with pyupgrade and isort pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,19 @@ repos:
   #   hooks:
   #     - id: black
   #       language_version: python3.6
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.32.0
+    hooks:
+      - id: pyupgrade
+        name: pyupgrade
+        description: Run PyUpgrade on Python code.
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        args: [--settings-path setup.cfg]
+        name: isort
+        description: Run import sorting (isort) on Python code.
   - repo: local
     hooks:
       - id: brunette

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,14 +6,13 @@ import functools
 import logging
 import os
 
-from app.modules import is_module_enabled
+import sqlalchemy
 from celery import Celery
 from flask import Flask
-import sqlalchemy
 from werkzeug.contrib.fixers import ProxyFix
 
+from app.modules import is_module_enabled
 from config import configure_app
-
 
 log = logging.getLogger(__name__)
 

--- a/app/extensions/api/__init__.py
+++ b/app/extensions/api/__init__.py
@@ -4,17 +4,16 @@ API extension
 =============
 """
 
+import logging
 from copy import deepcopy
 
 from flask import Blueprint, current_app  # NOQA
 
-from .api import Api  # NOQA
-from .namespace import Namespace  # NOQA
-from .http_exceptions import abort  # NOQA
-
 from app.version import version
 
-import logging
+from .api import Api  # NOQA
+from .http_exceptions import abort  # NOQA
+from .namespace import Namespace  # NOQA
 
 log = logging.getLogger(__name__)
 
@@ -22,7 +21,7 @@ log = logging.getLogger(__name__)
 api_v1_blueprint = Blueprint('api', __name__, url_prefix='/api/v1')
 api_v1 = Api(  # pylint: disable=invalid-name
     api_v1_blueprint,
-    version='Version: %s' % (version,),
+    version='Version: {}'.format(version),
     contact='info@wildme.org',
     # license='Apache License 2.0',
     # license_url='https://www.apache.org/licenses/LICENSE-2.0',

--- a/app/extensions/api/http_exceptions.py
+++ b/app/extensions/api/http_exceptions.py
@@ -4,9 +4,8 @@ HTTP exceptions collection
 --------------------------
 """
 
-from flask_restx_patched.errors import abort as restplus_abort
 from flask_restx_patched._http import HTTPStatus
-
+from flask_restx_patched.errors import abort as restplus_abort
 
 API_DEFAULT_HTTP_CODE_MESSAGES = {
     HTTPStatus.UNAUTHORIZED.value: (

--- a/app/extensions/api/namespace.py
+++ b/app/extensions/api/namespace.py
@@ -3,22 +3,21 @@
 Extended Api Namespace implementation with an application-specific helpers
 --------------------------------------------------------------------------
 """
+import logging
 from contextlib import contextmanager
 from functools import wraps
-import logging
 
 import flask_marshmallow
 import flask_sqlalchemy
-from sqlalchemy.inspection import inspect
 import sqlalchemy
+from marshmallow import ValidationError
+from sqlalchemy.inspection import inspect
 
-from flask_restx_patched.namespace import Namespace as BaseNamespace
 from flask_restx_patched._http import HTTPStatus
+from flask_restx_patched.namespace import Namespace as BaseNamespace
 
 from . import http_exceptions
 from .webargs_parser import CustomWebargsParser
-
-from marshmallow import ValidationError
 
 log = logging.getLogger(__name__)
 
@@ -177,7 +176,7 @@ class Namespace(BaseNamespace):
                                 rel_cls = relationship.mapper.class_
                                 column_names = list(rel_cls.__table__.columns)
                                 for column in column_names:
-                                    column_name = '%s.%s' % (
+                                    column_name = '{}.{}'.format(
                                         attribute,
                                         column.name.lower(),
                                     )

--- a/app/extensions/api/parameters.py
+++ b/app/extensions/api/parameters.py
@@ -4,9 +4,9 @@ Common reusable Parameters classes
 ----------------------------------
 """
 
+from flask_marshmallow import base_fields
 from marshmallow import validate
 
-from flask_marshmallow import base_fields
 from flask_restx_patched import Parameters
 
 

--- a/app/extensions/auth/oauth2.py
+++ b/app/extensions/auth/oauth2.py
@@ -15,15 +15,13 @@ import datetime
 import functools
 import logging
 
-
+import sqlalchemy
 from flask import request, session
 from flask_login import current_user
 from flask_oauthlib import provider
-from flask_restx_patched._http import HTTPStatus
-import sqlalchemy
 
 from app.extensions import api, db
-
+from flask_restx_patched._http import HTTPStatus
 
 log = logging.getLogger(__name__)
 

--- a/app/extensions/celery.py
+++ b/app/extensions/celery.py
@@ -2,8 +2,9 @@
 # This file is meant for celery command lines, for example:
 #    celery -A app.extensions.celery.celery worker
 from flask import current_app
-from flask_restx_patched import is_extension_enabled, is_module_enabled
+
 from config import get_preliminary_config
+from flask_restx_patched import is_extension_enabled, is_module_enabled
 
 config = get_preliminary_config()
 

--- a/app/extensions/edm/__init__.py
+++ b/app/extensions/edm/__init__.py
@@ -4,20 +4,20 @@
 Ecological Data Management (EDM) manager.
 
 """
+import keyword
 import logging
-from flask import current_app, request, session, render_template  # NOQA
+import types
+import uuid
+
+import sqlalchemy
+import tqdm
+from flask import current_app, render_template, request, session  # NOQA
 from flask_login import current_user  # NOQA
+
+import app.extensions.logging as AuditLog  # NOQA
 from app.extensions import db
 from app.extensions.restManager.RestManager import RestManager
 from app.utils import HoustonException
-
-import types
-import tqdm
-import keyword
-import uuid
-import sqlalchemy
-import app.extensions.logging as AuditLog  # NOQA
-
 from flask_restx_patched import is_extension_enabled
 
 if not is_extension_enabled('edm'):
@@ -219,7 +219,7 @@ class EDMManager(RestManager):
 class EDMObjectMixin(object):
     @classmethod
     def edm_sync_all(cls, verbose=True, refresh=False):
-        edm_items = current_app.edm.get_list('%s.list' % (cls.EDM_NAME,))
+        edm_items = current_app.edm.get_list('{}.list'.format(cls.EDM_NAME))
 
         if verbose:
             log.info(
@@ -286,7 +286,7 @@ class EDMObjectMixin(object):
             set(sorted(data._fields)) - set(self.EDM_ATTRIBUTE_MAPPING)
         )
         if len(unmapped_attributes) > 0:
-            log.warning('Unmapped attributes: %r' % (unmapped_attributes,))
+            log.warning('Unmapped attributes: {!r}'.format(unmapped_attributes))
 
         found_version = None
         for edm_attribute in self.EDM_ATTRIBUTE_MAPPING:
@@ -296,7 +296,7 @@ class EDMObjectMixin(object):
                 attribute = self.EDM_ATTRIBUTE_MAPPING[edm_attribute]
                 if attribute is None:
                     log.warning(
-                        'Ignoring mapping for EDM attribute %r' % (edm_attribute,)
+                        'Ignoring mapping for EDM attribute {!r}'.format(edm_attribute)
                     )
                     continue
 
@@ -336,12 +336,12 @@ class EDMObjectMixin(object):
             db.session.merge(self)
 
         if found_version is None:
-            log.info('Updating to claimed version %r' % (claimed_version,))
+            log.info('Updating to claimed version {!r}'.format(claimed_version))
         else:
-            log.info('Updating to found version %r' % (found_version,))
+            log.info('Updating to found version {!r}'.format(found_version))
 
     def _sync_item(self, guid, version):
-        response = current_app.edm.get_data_item(guid, '%s.data' % (self.EDM_NAME,))
+        response = current_app.edm.get_data_item(guid, '{}.data'.format(self.EDM_NAME))
 
         assert response.success
         data = response.result

--- a/app/extensions/elasticsearch/resources.py
+++ b/app/extensions/elasticsearch/resources.py
@@ -6,11 +6,10 @@ RESTful API User resources
 """
 
 import logging
-from flask_restx_patched import Resource
-from app.extensions.api import Namespace
 
 from app.extensions import is_extension_enabled
-
+from app.extensions.api import Namespace
+from flask_restx_patched import Resource
 
 log = logging.getLogger(__name__)
 api = Namespace('search', description='Searching via Elasticsearch')

--- a/app/extensions/elasticsearch/tasks.py
+++ b/app/extensions/elasticsearch/tasks.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 import logging
-
 import uuid
-from app.extensions.celery import celery
 
+from app.extensions.celery import celery
 
 ELASTICSEARCH_MAXIMUM_SESSION_LENGTH = 60 * 15
 ELASTICSEARCH_UPDATE_FREQUENCY = 60 * 60 * 1
@@ -32,11 +31,12 @@ def es_task_setup_periodic_tasks(sender, **kwargs):
 
 @celery.task
 def es_task_refresh_index_all(force=False):
-    from app.extensions import elasticsearch as es
     from flask import current_app
 
+    from app.extensions import elasticsearch as es
+
     testing = current_app.testing and not force
-    log.info('Running Refresh Index All (testing = %r)' % (testing,))
+    log.info('Running Refresh Index All (testing = {!r})'.format(testing))
     if testing:
         log.info('...skipping')
         return True
@@ -53,7 +53,7 @@ def es_task_refresh_index_all(force=False):
 
     # Check on the status of the DB relative to ES
     status = es.es_status(app=current_app)
-    log.info('Elasticsearch status = %r' % (status,))
+    log.info('Elasticsearch status = {!r}'.format(status))
 
     # Ignore any active jobs
     status.pop('active', None)
@@ -62,11 +62,12 @@ def es_task_refresh_index_all(force=False):
 
 @celery.task
 def es_task_invalidate_indexed_timestamps(force=False):
-    from app.extensions import elasticsearch as es
     from flask import current_app
 
+    from app.extensions import elasticsearch as es
+
     testing = current_app.testing and not force
-    log.info('Running Invalidate Indexed Timestamps (testing = %r)' % (testing,))
+    log.info('Running Invalidate Indexed Timestamps (testing = {!r})'.format(testing))
     if testing:
         log.info('...skipping')
         return True
@@ -79,8 +80,9 @@ def es_task_invalidate_indexed_timestamps(force=False):
 
 @celery.task
 def es_task_index_bulk(index, items):
-    from app.extensions import elasticsearch as es
     from flask import current_app
+
+    from app.extensions import elasticsearch as es
 
     app = current_app
     cls = es.es_index_class(index)
@@ -139,8 +141,9 @@ def es_task_index_bulk(index, items):
 
 @celery.task
 def es_task_delete_guid_bulk(index, guids):
-    from app.extensions import elasticsearch as es
     from flask import current_app
+
+    from app.extensions import elasticsearch as es
 
     app = current_app
     cls = es.es_index_class(index)

--- a/app/extensions/email/__init__.py
+++ b/app/extensions/email/__init__.py
@@ -1,19 +1,19 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=no-self-use
 import datetime
-from io import StringIO
 import logging
 import re
+from io import StringIO
 
+import cssutils
+import htmlmin
 from flask import current_app, render_template, url_for
 from flask_mail import Mail, Message, email_dispatched
 from jinja2 import TemplateNotFound
 from premailer import Premailer
-import cssutils
-import htmlmin
+
 import app.version
 from app.utils import to_ascii
-
 from flask_restx_patched import is_extension_enabled
 
 if not is_extension_enabled('mail'):
@@ -106,8 +106,9 @@ def _format_datetime(dt, verbose=False):
 
 class Email(Message):
     def __init__(self, **kwargs):
-        from app.modules.site_settings.models import SiteSetting
         import uuid
+
+        from app.modules.site_settings.models import SiteSetting
 
         if 'recipients' not in kwargs:
             raise AttributeError('Email() must have recipients= argument')
@@ -276,7 +277,7 @@ class Email(Message):
         ]
         webfonts_html = ''.join(webfonts)
         minified_html = minified_html.replace(
-            '</head>', '%s</head>' % (WEBFONTS_PLACEHOLDER_CODE,)
+            '</head>', '{}</head>'.format(WEBFONTS_PLACEHOLDER_CODE)
         )
         final_html = minified_html.replace(WEBFONTS_PLACEHOLDER_CODE, webfonts_html)
         self.html = final_html

--- a/app/extensions/flask_sqlalchemy/__init__.py
+++ b/app/extensions/flask_sqlalchemy/__init__.py
@@ -5,8 +5,8 @@ Flask-SQLAlchemy adapter
 """
 import uuid
 
-from sqlalchemy import MetaData
 from flask_sqlalchemy import SQLAlchemy as BaseSQLAlchemy
+from sqlalchemy import MetaData
 
 
 class AlembicDatabaseMigrationConfig(object):

--- a/app/extensions/git_store/schemas.py
+++ b/app/extensions/git_store/schemas.py
@@ -5,8 +5,8 @@ Serialization schemas for Assets resources RESTful API
 """
 
 from flask_marshmallow import base_fields
-from app.extensions.git_store import GitStore
 
+from app.extensions.git_store import GitStore
 from flask_restx_patched import ModelSchema
 
 

--- a/app/extensions/git_store/tasks.py
+++ b/app/extensions/git_store/tasks.py
@@ -2,9 +2,9 @@
 import logging
 
 import git
-from flask import current_app
 import requests.exceptions
 import sqlalchemy.exc
+from flask import current_app
 
 from app.extensions.celery import celery
 from app.extensions.gitlab import GitlabInitializationError

--- a/app/extensions/gitlab.py
+++ b/app/extensions/gitlab.py
@@ -4,13 +4,12 @@
 Gitlab Management.
 
 """
+import keyword
 import logging
 
-from flask import current_app, request, session, render_template  # NOQA
-from flask_login import current_user  # NOQA
 import gitlab
-
-import keyword
+from flask import current_app, render_template, request, session  # NOQA
+from flask_login import current_user  # NOQA
 
 from flask_restx_patched import is_extension_enabled
 
@@ -148,7 +147,7 @@ class GitlabManager(object):
             )
         else:
             tag_list = [
-                'type:%s' % (project_type,),
+                'type:{}'.format(project_type),
             ]
             for tag in additional_tags:
                 if isinstance(tag, str):

--- a/app/extensions/intelligent_agent/models.py
+++ b/app/extensions/intelligent_agent/models.py
@@ -4,16 +4,16 @@ IntelligentAgent (and subclass) models
 --------------------------------------
 """
 import datetime
+import enum
 import gettext
+import logging
 import traceback
 import uuid
-import enum
-import logging
 
-from app.extensions import db
-import app.extensions.logging as AuditLog  # NOQA
-from app.extensions import HoustonModel
 from flask import current_app, url_for
+
+import app.extensions.logging as AuditLog  # NOQA
+from app.extensions import HoustonModel, db
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 _ = gettext.gettext
@@ -415,9 +415,11 @@ class IntelligentAgentContent(db.Model, HoustonModel):
     def prepare_media_transaction(self, media_data):
         if not isinstance(media_data, list) or not media_data:
             raise ValueError('invalid or empty media_data')
-        import requests
-        import uuid
         import os
+        import uuid
+
+        import requests
+
         from app.extensions.tus import tus_upload_dir, tus_write_file_metadata
         from app.utils import get_stored_filename
 
@@ -492,8 +494,9 @@ class IntelligentAgentContent(db.Model, HoustonModel):
         db.session.refresh(self)
 
     def detection_complete(self):
-        from app.modules.assets.models import Asset
         import traceback
+
+        from app.modules.assets.models import Asset
 
         annots = []
         jobs = []
@@ -1086,8 +1089,9 @@ class TwitterTweet(IntelligentAgentContent):
     # this override is only to satisify the deadline hack of not using real user.linked_account process FIXME
     #   remove it (to let baseclass method run) when hack is gone
     def find_author_user(self):
-        from app.modules.users.models import User
         from sqlalchemy import func
+
+        from app.modules.users.models import User
 
         username = self.get_author_username()
         if not username:

--- a/app/extensions/intelligent_agent/tasks.py
+++ b/app/extensions/intelligent_agent/tasks.py
@@ -52,8 +52,9 @@ def twitterbot_collect():
     max_retries=None,  # keep trying forever
 )
 def twitterbot_create_tweet_queued(text, in_reply_to, media_paths):
-    from app.extensions.intelligent_agent.models import TwitterBot
     import time
+
+    from app.extensions.intelligent_agent.models import TwitterBot
 
     if not TwitterBot.is_enabled():
         log.info(

--- a/app/extensions/logging/__init__.py
+++ b/app/extensions/logging/__init__.py
@@ -3,9 +3,10 @@
 Logging adapter
 ---------------
 """
-import logging
-from flask_login import current_user  # NOQA
 import enum
+import logging
+
+from flask_login import current_user  # NOQA
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/app/extensions/restManager/RestManager.py
+++ b/app/extensions/restManager/RestManager.py
@@ -5,16 +5,17 @@ Rest Manager base class, to be used for any entity (EDM/Sage) where we need to i
 system using REST API
 
 """
-import logging
-from werkzeug.exceptions import BadRequest
-from flask import current_app, request, session, render_template  # NOQA
-from flask_login import current_user  # NOQA
-import requests
-from collections import namedtuple
-import utool as ut
 import json
 import keyword
+import logging
 import uuid
+from collections import namedtuple
+
+import requests
+import utool as ut
+from flask import current_app, render_template, request, session  # NOQA
+from flask_login import current_user  # NOQA
+from werkzeug.exceptions import BadRequest
 
 KEYWORD_SET = set(keyword.kwlist)
 
@@ -27,7 +28,7 @@ def _json_object_hook(data):
     keys_ = []
     for key in keys:
         if key in KEYWORD_SET:
-            key_ = '%s_' % (key,)
+            key_ = '{}_'.format(key)
             assert key_ not in keys_set
         else:
             key_ = key
@@ -92,7 +93,7 @@ class RestManager(RestManagerUserMixin):
         assert self.ENDPOINTS is not None
 
         # Start with all contents as empty structures
-        self.targets = set([])
+        self.targets = set()
         self.sessions = {}
         self.uris = {}
         self.auths = {}
@@ -362,7 +363,7 @@ class RestManager(RestManagerUserMixin):
         # Check target
         targets = list(self.targets)
         if target not in targets:
-            raise BadRequest('The specified target %r is invalid.' % (target,))
+            raise BadRequest('The specified target {!r} is invalid.'.format(target))
 
         headers = passthrough_kwargs.get('headers', {})
         allowed_header_key_list = [

--- a/app/extensions/sage/tasks.py
+++ b/app/extensions/sage/tasks.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from app.extensions.celery import celery
 from flask import current_app
 
+from app.extensions.celery import celery
 
 SAGE_SYNC_FREQUENCY = 60 * 60
 
@@ -23,8 +23,8 @@ def sage_task_setup_periodic_tasks(sender, **kwargs):
 
 @celery.task
 def sage_task_sync():
-    from app.modules.assets.models import Asset
     from app.modules.annotations.models import Annotation
+    from app.modules.assets.models import Asset
 
     # Sync all Assets
     Asset.sync_all_with_sage(ensure=True, prune=True)

--- a/app/extensions/tus/flask_tus_cont.py
+++ b/app/extensions/tus/flask_tus_cont.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
-from flask import Blueprint, request, make_response, url_for
 import base64
 import os
-import redis
 import uuid
+
+import redis
+from flask import Blueprint, make_response, request, url_for
+
 from app.utils import get_stored_filename
 
 # Find the stack on which we want to store the database connection.

--- a/app/extensions/tus/tasks.py
+++ b/app/extensions/tus/tasks.py
@@ -3,7 +3,6 @@ import logging
 
 from app.extensions.celery import celery
 
-
 TUS_CLEANUP_FREQUENCY = 60 * 15
 
 

--- a/app/modules/__init__.py
+++ b/app/modules/__init__.py
@@ -29,8 +29,8 @@ def init_app(app, force_enable=False, force_disable=None, **kwargs):
         force_disable = []
 
     if force_enable:
-        import os
         import glob
+        import os
 
         skip_module_names = [
             'ia_config_reader',
@@ -38,7 +38,7 @@ def init_app(app, force_enable=False, force_disable=None, **kwargs):
         ]
 
         module_path = os.path.join(app.config['PROJECT_ROOT'], 'app', 'modules')
-        module_paths = glob.glob('%s/*' % (module_path,))
+        module_paths = glob.glob('{}/*'.format(module_path))
         module_names = []
         for module_path in module_paths:
             _, module_name_raw = os.path.split(module_path)
@@ -73,4 +73,4 @@ def init_app(app, force_enable=False, force_disable=None, **kwargs):
             )
             import_module('.%s' % module_name, package=__name__).init_app(app, **kwargs)
         else:
-            logging.info('Skipped module %r (force disabled)' % (module_name,))
+            logging.info('Skipped module {!r} (force disabled)'.format(module_name))

--- a/app/modules/annotations/__init__.py
+++ b/app/modules/annotations/__init__.py
@@ -4,9 +4,8 @@ Annotations module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('annotations'):

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -4,13 +4,14 @@ Annotations database models
 --------------------
 """
 
-from app.extensions import db, HoustonModel, SageModel
-from app.modules import is_module_enabled
-from app.utils import HoustonException
+import logging
+import uuid
+
 from flask import current_app
 
-import uuid
-import logging
+from app.extensions import HoustonModel, SageModel, db
+from app.modules import is_module_enabled
+from app.utils import HoustonException
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -142,11 +143,7 @@ class Annotation(db.Model, HoustonModel, SageModel):
     def sync_with_sage(
         self, ensure=False, force=False, bulk_sage_uuids=None, skip_asset=False, **kwargs
     ):
-        from app.extensions.sage import (
-            to_sage_uuid,
-            from_sage_uuid,
-            SAGE_UNKNOWN_NAME,
-        )
+        from app.extensions.sage import SAGE_UNKNOWN_NAME, from_sage_uuid, to_sage_uuid
 
         # First, ensure that the annotation's asset has been synced with Sage
         if not skip_asset:
@@ -233,7 +230,7 @@ class Annotation(db.Model, HoustonModel, SageModel):
                 return
 
         progress = Progress(
-            description='Sage identification for Annotation %r' % (self.guid,)
+            description='Sage identification for Annotation {!r}'.format(self.guid)
         )
         with db.session.begin():
             db.session.add(progress)
@@ -278,7 +275,7 @@ class Annotation(db.Model, HoustonModel, SageModel):
         return self.get_keywords()
 
     def get_keywords(self):
-        return sorted([ref.keyword for ref in self.keyword_refs])
+        return sorted(ref.keyword for ref in self.keyword_refs)
 
     def add_keyword(self, keyword):
         with db.session.begin(subtransactions=True):
@@ -447,7 +444,7 @@ class Annotation(db.Model, HoustonModel, SageModel):
     def get_keyword_values(self):
         if not self.keyword_refs:
             return []
-        return sorted([ref.keyword.value for ref in self.keyword_refs])
+        return sorted(ref.keyword.value for ref in self.keyword_refs)
 
     def delete(self):
         with db.session.begin(subtransactions=True):

--- a/app/modules/annotations/parameters.py
+++ b/app/modules/annotations/parameters.py
@@ -3,15 +3,17 @@
 Input arguments (Parameters) for Annotations resources RESTful API
 -----------------------------------------------------------
 """
+from flask_login import current_user
 from flask_marshmallow import base_fields
 from marshmallow import validates_schema
-from flask_restx_patched import Parameters, PatchJSONParameters
-from flask_login import current_user
+
+from app.extensions.api import abort
 from app.modules.users.permissions import rules
+from flask_restx_patched import Parameters, PatchJSONParameters
+from flask_restx_patched._http import HTTPStatus
+
 from . import schemas
 from .models import Annotation
-from app.extensions.api import abort
-from flask_restx_patched._http import HTTPStatus
 
 
 class CreateAnnotationParameters(Parameters, schemas.BaseAnnotationSchema):

--- a/app/modules/annotations/resources.py
+++ b/app/modules/annotations/resources.py
@@ -5,23 +5,22 @@ RESTful API Annotations resources
 --------------------------
 """
 
-import logging
 import json
+import logging
 
 from flask import request
-from flask_restx_patched import Resource
 from flask_restx._http import HTTPStatus
 
+import app.extensions.logging as AuditLog
 from app.extensions import db
 from app.extensions.api import Namespace, abort
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
-import app.extensions.logging as AuditLog
 from app.utils import HoustonException
+from flask_restx_patched import Resource
 
 from . import parameters, schemas
 from .models import Annotation
-
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace('annotations', description='Annotations')  # pylint: disable=invalid-name
@@ -65,10 +64,10 @@ class Annotations(Resource):
         """
         Create a new instance of Annotation.
         """
-        from app.modules.assets.models import Asset
-        from app.modules.asset_groups.models import AssetGroup, AssetGroupSightingStage
-        from app.modules.encounters.models import Encounter
         from app.extensions.elapsed_time import ElapsedTime
+        from app.modules.asset_groups.models import AssetGroup, AssetGroupSightingStage
+        from app.modules.assets.models import Asset
+        from app.modules.encounters.models import Encounter
 
         timer = ElapsedTime()
 

--- a/app/modules/annotations/schemas.py
+++ b/app/modules/annotations/schemas.py
@@ -5,8 +5,10 @@ Serialization schemas for Annotations resources RESTful API
 """
 
 from flask_marshmallow import base_fields
-from flask_restx_patched import ModelSchema
+
 from app.modules import is_module_enabled
+from flask_restx_patched import ModelSchema
+
 from .models import Annotation
 
 

--- a/app/modules/app_ui.py
+++ b/app/modules/app_ui.py
@@ -15,17 +15,14 @@ from flask import (
     request,
     url_for,
 )
-from flask_login import login_user, logout_user, login_required, current_user
+from flask_login import current_user, login_required, login_user, logout_user
 
-from app.modules.auth.views import (
-    _is_safe_url,
-)
 from app.modules.auth.utils import (
     create_session_oauth2_token,
     delete_session_oauth2_token,
 )
+from app.modules.auth.views import _is_safe_url
 from app.modules.users.models import User
-
 
 log = logging.getLogger(__name__)
 
@@ -125,7 +122,7 @@ def user_login(email=None, password=None, remember=None, refer=None, *args, **kw
 
     if refer is not None:
         if not _is_safe_url(refer):
-            log.error('User gave insecure next URL: %r' % (refer,))
+            log.error('User gave insecure next URL: {!r}'.format(refer))
             refer = None
 
     failure_refer = 'backend.home'
@@ -186,11 +183,11 @@ def user_logout(refer=None, *args, **kwargs):
 
     if refer is not None:
         if not _is_safe_url(refer):
-            log.error('User gave insecure next URL: %r' % (refer,))
+            log.error('User gave insecure next URL: {!r}'.format(refer))
             refer = None
 
     # Delete the Oauth2 token for this session
-    log.info('Logging out User: %r' % (current_user,))
+    log.info('Logging out User: {!r}'.format(current_user))
 
     delete_session_oauth2_token()
 

--- a/app/modules/asset_groups/__init__.py
+++ b/app/modules/asset_groups/__init__.py
@@ -4,9 +4,8 @@ Asset_groups module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('asset_groups'):

--- a/app/modules/asset_groups/metadata.py
+++ b/app/modules/asset_groups/metadata.py
@@ -11,6 +11,7 @@ import os
 
 from flask import current_app
 from flask_login import current_user  # NOQA
+
 from app.utils import HoustonException
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name

--- a/app/modules/asset_groups/parameters.py
+++ b/app/modules/asset_groups/parameters.py
@@ -6,15 +6,16 @@ Input arguments (Parameters) for Asset_groups resources RESTful API
 import logging
 import uuid
 
-from app.modules.sightings.parameters import PatchSightingDetailsParameters
-from app.modules.encounters.parameters import PatchEncounterDetailsParameters
-from .metadata import AssetGroupMetadata, AssetGroupMetadataError
-from flask_restx_patched import Parameters, PatchJSONParameters
 from flask_login import current_user  # NOQA
 
-from . import schemas
-from .models import AssetGroup
+from app.modules.encounters.parameters import PatchEncounterDetailsParameters
+from app.modules.sightings.parameters import PatchSightingDetailsParameters
 from app.modules.users.permissions import rules
+from flask_restx_patched import Parameters, PatchJSONParameters
+
+from . import schemas
+from .metadata import AssetGroupMetadata, AssetGroupMetadataError
+from .models import AssetGroup
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -5,14 +5,12 @@ RESTful API Asset_groups resources
 --------------------------
 """
 
-import logging
-import werkzeug
-import uuid
 import json
+import logging
+import uuid
 
+import werkzeug
 from flask import request
-from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 
 from app.extensions import db
 from app.extensions.api import Namespace, abort
@@ -20,9 +18,11 @@ from app.modules.auth.utils import recaptcha_required
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 from app.utils import HoustonException
+from flask_restx_patched import Resource
+from flask_restx_patched._http import HTTPStatus
 
 from . import parameters, schemas
-from .metadata import AssetGroupMetadataError, AssetGroupMetadata
+from .metadata import AssetGroupMetadata, AssetGroupMetadataError
 from .models import AssetGroup, AssetGroupSighting
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -88,8 +88,8 @@ class AssetGroups(Resource):
         """
         Create a new instance of Asset_group.
         """
-        from app.extensions.elapsed_time import ElapsedTime
         import app.extensions.logging as AuditLog  # NOQA
+        from app.extensions.elapsed_time import ElapsedTime
         from app.modules.users.models import User
 
         timer = ElapsedTime()
@@ -467,8 +467,8 @@ class AssetGroupSightingByID(Resource):
     @api.parameters(parameters.PatchAssetGroupSightingDetailsParameters())
     @api.response(schemas.DetailedAssetGroupSightingSchema())
     def patch(self, args, asset_group_sighting):
-        from app.extensions.elapsed_time import ElapsedTime
         import app.extensions.logging as AuditLog  # NOQA
+        from app.extensions.elapsed_time import ElapsedTime
 
         timer = ElapsedTime()
         context = api.commit_or_abort(
@@ -580,8 +580,8 @@ class AssetGroupSightingAsSighting(Resource):
     @api.parameters(parameters.PatchAssetGroupSightingAsSightingParameters())
     @api.response(schemas.AssetGroupSightingAsSightingSchema())
     def patch(self, args, asset_group_sighting):
-        from app.extensions.elapsed_time import ElapsedTime
         import app.extensions.logging as AuditLog  # NOQA
+        from app.extensions.elapsed_time import ElapsedTime
 
         timer = ElapsedTime()
 
@@ -645,8 +645,8 @@ class AssetGroupSightingEncounterByID(Resource):
     @api.parameters(parameters.PatchAssetGroupSightingEncounterDetailsParameters())
     @api.response(schemas.DetailedAssetGroupSightingSchema())
     def patch(self, args, asset_group_sighting, encounter_guid):
-        from app.extensions.elapsed_time import ElapsedTime
         import app.extensions.logging as AuditLog  # NOQA
+        from app.extensions.elapsed_time import ElapsedTime
 
         timer = ElapsedTime()
         context = api.commit_or_abort(
@@ -690,8 +690,8 @@ class AssetGroupSightingAsSightingEncounterByID(Resource):
     @api.login_required(oauth_scopes=['asset_group_sightings:write'])
     @api.parameters(parameters.PatchAssetGroupSightingEncounterDetailsParameters())
     def patch(self, args, asset_group_sighting, encounter_guid):
-        from app.extensions.elapsed_time import ElapsedTime
         import app.extensions.logging as AuditLog  # NOQA
+        from app.extensions.elapsed_time import ElapsedTime
 
         timer = ElapsedTime()
         context = api.commit_or_abort(

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -5,13 +5,14 @@ Serialization schemas for Asset_groups resources RESTful API
 """
 
 from flask_marshmallow import base_fields
-from flask_restx_patched import ModelSchema
-from app.modules.assets.schemas import ExtendedAssetDetailedAnnotationsSchema
+
 from app.extensions.git_store.schemas import (
     BaseGitStoreSchema,
     CreateGitStoreSchema,
     DetailedGitStoreSchema,
 )
+from app.modules.assets.schemas import ExtendedAssetDetailedAnnotationsSchema
+from flask_restx_patched import ModelSchema
 
 from .models import AssetGroup, AssetGroupSighting
 

--- a/app/modules/assets/__init__.py
+++ b/app/modules/assets/__init__.py
@@ -4,9 +4,8 @@ Assets module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('assets'):

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -3,21 +3,19 @@
 Assets database models
 --------------------
 """
-from flask import current_app, url_for
-from functools import total_ordering
-import pathlib
-
-from app.extensions import db, HoustonModel, SageModel
-from app.modules import module_required
-from app.utils import HoustonException
-from app.modules.users.models import User
-
-from PIL import Image
-
-import uuid
 import logging
 import os
+import pathlib
+import uuid
+from functools import total_ordering
 
+from flask import current_app, url_for
+from PIL import Image
+
+from app.extensions import HoustonModel, SageModel, db
+from app.modules import module_required
+from app.modules.users.models import User
+from app.utils import HoustonException
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -197,7 +195,7 @@ class Asset(db.Model, HoustonModel, SageModel):
         return jobs
 
     def get_tags(self):
-        return sorted([ref.tag for ref in self.tag_refs])
+        return sorted(ref.tag for ref in self.tag_refs)
 
     def add_tag(self, tag):
         with db.session.begin(subtransactions=True):
@@ -313,7 +311,7 @@ class Asset(db.Model, HoustonModel, SageModel):
                     db.session.merge(self)
                 db.session.refresh(self)
         else:
-            log.error('Asset %r is missing on disk, cannot send to Sage' % (self,))
+            log.error('Asset {!r} is missing on disk, cannot send to Sage'.format(self))
 
     # this property is so that schema can output { "filename": "original_filename.jpg" }
     @property
@@ -537,7 +535,9 @@ class Asset(db.Model, HoustonModel, SageModel):
         target_path.parent.mkdir(parents=True, exist_ok=True)
         if target_path.exists():
             return target_path
-        log.info('make_master_format() creating master format as %r' % (target_path,))
+        log.info(
+            'make_master_format() creating master format as {!r}'.format(target_path)
+        )
         with Image.open(source_path) as source_image:
             source_image.thumbnail(self.FORMATS['master'])
             rgb = source_image.convert('RGB')

--- a/app/modules/assets/parameters.py
+++ b/app/modules/assets/parameters.py
@@ -4,9 +4,9 @@ Input arguments (Parameters) for Assets resources RESTful API
 -------------------------------------------------------------
 """
 
+from app.extensions.api import abort
 from flask_restx_patched import PatchJSONParameters
 from flask_restx_patched._http import HTTPStatus
-from app.extensions.api import abort
 
 from . import schemas
 

--- a/app/modules/assets/resources.py
+++ b/app/modules/assets/resources.py
@@ -7,20 +7,18 @@ RESTful API Assets resources
 
 import logging
 
-from flask import send_file, request
+import werkzeug
+from flask import request, send_file
 
-from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 from app.extensions import db
 from app.extensions.api import Namespace
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
-import werkzeug
+from flask_restx_patched import Resource
+from flask_restx_patched._http import HTTPStatus
 
+from . import parameters, schemas
 from .models import Asset
-
-from . import schemas, parameters
-
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace('assets', description='Assets')  # pylint: disable=invalid-name

--- a/app/modules/assets/schemas.py
+++ b/app/modules/assets/schemas.py
@@ -7,11 +7,10 @@ Serialization schemas for Assets resources RESTful API
 from flask_marshmallow import base_fields
 from marshmallow import ValidationError
 
-from flask_restx_patched import ModelSchema
 from app.extensions import ExtraValidationSchema
-from app.modules import is_module_enabled
 from app.extensions.git_store.schemas import BaseGitStoreSchema
-
+from app.modules import is_module_enabled
+from flask_restx_patched import ModelSchema
 
 from .models import Asset
 

--- a/app/modules/audit_logs/__init__.py
+++ b/app/modules/audit_logs/__init__.py
@@ -4,9 +4,8 @@ Audit Logs module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('audit_logs'):

--- a/app/modules/audit_logs/models.py
+++ b/app/modules/audit_logs/models.py
@@ -4,11 +4,12 @@ Audit Logs database models
 --------------------
 """
 
-from flask_login import current_user  # NOQA
-from app.extensions import db, HoustonModel
 import logging
-
 import uuid
+
+from flask_login import current_user  # NOQA
+
+from app.extensions import HoustonModel, db
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -47,8 +48,8 @@ class AuditLog(db.Model, HoustonModel):
 
     @classmethod
     def query_search_term_hook(cls, term):
-        from sqlalchemy_utils.functions import cast_if
         from sqlalchemy import String
+        from sqlalchemy_utils.functions import cast_if
 
         return (
             cast_if(cls.guid, String).contains(term),

--- a/app/modules/audit_logs/resources.py
+++ b/app/modules/audit_logs/resources.py
@@ -6,18 +6,18 @@ RESTful API Audit Logs resources
 """
 
 import logging
-from flask_restx_patched import Resource
-from flask_restx._http import HTTPStatus
 
 from flask import request
+from flask_restx._http import HTTPStatus
+
 from app.extensions.api import Namespace
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
+from flask_restx_patched import Resource
 
 from . import schemas
 from .models import AuditLog
-from .parameters import GetAuditLogParameters, GetAuditLogFaultsParameters
-
+from .parameters import GetAuditLogFaultsParameters, GetAuditLogParameters
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace('audit_logs', description='Audit_logs')  # pylint: disable=invalid-name

--- a/app/modules/auth/__init__.py
+++ b/app/modules/auth/__init__.py
@@ -4,7 +4,6 @@ Auth module
 ===========
 """
 from app.extensions.api import api_v1
-
 from app.modules import is_module_enabled
 
 if not is_module_enabled('auth'):
@@ -21,7 +20,7 @@ def init_app(app, **kwargs):
     api_v1.add_oauth_scope('auth:write', 'Provide write access to auth details')
 
     # Touch underlying modules
-    from . import models, views, resources  # pylint: disable=unused-import  # NOQA
+    from . import models, resources, views  # pylint: disable=unused-import  # NOQA
 
     # Mount authentication routes
     api_v1.add_namespace(resources.api)

--- a/app/modules/auth/models.py
+++ b/app/modules/auth/models.py
@@ -9,20 +9,20 @@ More details are available here:
 * http://flask-oauthlib.readthedocs.org/en/latest/oauth2.html
 * http://lepture.com/en/2013/create-oauth-server
 """
-import logging
+import datetime
 import enum
+import logging
+import random
+import uuid
 
+import pytz
+from flask import current_app
 from sqlalchemy import or_
 from sqlalchemy_utils.types import ScalarListType
 
-from app.extensions import db, HoustonModel
+from app.extensions import HoustonModel, db
 from app.extensions.auth import security
 from app.modules.users.models import User
-from flask import current_app
-import datetime
-import pytz
-import random
-import uuid
 
 log = logging.getLogger(__name__)
 
@@ -316,7 +316,9 @@ class Code(db.Model, HoustonModel):
     ):
         """Replace will automatically invalidate any codes previously issued (above the replace_ttl value, in minutes)"""
         code_settings = CODE_SETTINGS.get(code_type, None)
-        assert code_settings is not None, 'Code type was unrecognized: %r' % (code_type,)
+        assert code_settings is not None, 'Code type was unrecognized: {!r}'.format(
+            code_type
+        )
 
         # Get any codes that fit this request
         valid_codes = cls.valid_codes(user, code_type)
@@ -363,10 +365,14 @@ class Code(db.Model, HoustonModel):
                     # Found unique codes
                     break
                 log.warning('Finding alternate codes, there was a conflict:')
-                log.warning('\tCandidate   Accept Code  : %r' % (accept_code,))
-                log.warning('\tConflicting Accept Codes : %r' % (existing_accept_codes,))
-                log.warning('\tCandidate   Reject Code  : %r' % (reject_code,))
-                log.warning('\tConflicting Reject Codes : %r' % (existing_reject_codes,))
+                log.warning('\tCandidate   Accept Code  : {!r}'.format(accept_code))
+                log.warning(
+                    '\tConflicting Accept Codes : {!r}'.format(existing_accept_codes)
+                )
+                log.warning('\tCandidate   Reject Code  : {!r}'.format(reject_code))
+                log.warning(
+                    '\tConflicting Reject Codes : {!r}'.format(existing_reject_codes)
+                )
 
             ttl_days = code_settings.get('ttl')
             if ttl_days is None or ttl_days < 0:

--- a/app/modules/auth/parameters.py
+++ b/app/modules/auth/parameters.py
@@ -6,11 +6,11 @@ Input arguments (Parameters) for Auth resources
 """
 from flask_login import current_user
 from flask_marshmallow import base_fields
-from flask_restx_patched import Parameters
-from marshmallow import validates, ValidationError
+from marshmallow import ValidationError, validates
 
 from app.extensions import api
 from app.extensions.api.parameters import PaginationParameters
+from flask_restx_patched import Parameters
 
 
 class ListOAuth2ClientsParameters(PaginationParameters):

--- a/app/modules/auth/resources.py
+++ b/app/modules/auth/resources.py
@@ -8,22 +8,18 @@ import json
 import logging
 from urllib.parse import urlencode
 
-from flask import current_app, request, redirect
+from flask import current_app, redirect, request
 from flask_login import current_user, login_user, logout_user
+
+from app.extensions import oauth2
+from app.extensions.api import Namespace, abort, api_v1
+from app.modules.users.models import User
 from flask_restx_patched import Resource
 from flask_restx_patched._http import HTTPStatus
 
-from app.extensions import oauth2
-from app.extensions.api import Namespace, api_v1, abort
-from app.modules.users.models import User
-
-from . import schemas, parameters
-from .models import db, OAuth2Client, Code, CodeDecisions, CodeTypes
-from .utils import (
-    create_session_oauth2_token,
-    delete_session_oauth2_token,
-)
-
+from . import parameters, schemas
+from .models import Code, CodeDecisions, CodeTypes, OAuth2Client, db
+from .utils import create_session_oauth2_token, delete_session_oauth2_token
 
 log = logging.getLogger(__name__)
 api = Namespace('auth', description='Authentication')
@@ -62,7 +58,7 @@ class OAuth2Sessions(Resource):
             status = login_user(user, remember=False)
 
             if status:
-                log.info('Logged in User via API: %r' % (user,))
+                log.info('Logged in User via API: {!r}'.format(user))
                 create_session_oauth2_token()
             else:
                 failure = 'Account Disabled'
@@ -89,7 +85,7 @@ class OAuth2Sessions(Resource):
         """
         Log-out the active OAuth2 Session.
         """
-        log.info('Logging out User via API: %r' % (current_user,))
+        log.info('Logging out User via API: {!r}'.format(current_user))
 
         delete_session_oauth2_token()
         logout_user()

--- a/app/modules/auth/schemas.py
+++ b/app/modules/auth/schemas.py
@@ -6,9 +6,10 @@ Auth schemas
 """
 
 from flask_marshmallow import base_fields
+
 from flask_restx_patched import ModelSchema, Schema
 
-from .models import OAuth2Client, Code
+from .models import Code, OAuth2Client
 
 
 class BaseOAuth2ClientSchema(ModelSchema):

--- a/app/modules/auth/utils.py
+++ b/app/modules/auth/utils.py
@@ -15,12 +15,11 @@ import json
 import logging
 import time
 
-import requests
 import pytz
+import requests
 import werkzeug.exceptions
-from flask import session, request, current_app
+from flask import current_app, request, session
 from flask_login import current_user
-
 
 log = logging.getLogger(__name__)
 
@@ -55,7 +54,7 @@ def create_session_oauth2_client(user, **kwargs):
         )
         with db.session.begin():
             db.session.add(session_oauth2_client)
-    log.debug('Using session Oauth2 client = %r' % (session_oauth2_client,))
+    log.debug('Using session Oauth2 client = {!r}'.format(session_oauth2_client))
     return session_oauth2_client
 
 

--- a/app/modules/auth/views.py
+++ b/app/modules/auth/views.py
@@ -10,13 +10,12 @@ More details are available here:
 * http://lepture.com/en/2013/create-oauth-server
 """
 
-from urllib.parse import urlparse, urljoin
+from urllib.parse import urljoin, urlparse
 
 import flask
-from flask import request, url_for, flash
+from flask import flash, request, url_for
 
-from app.extensions import oauth2, login_manager
-
+from app.extensions import login_manager, oauth2
 from app.modules.users.models import User
 
 

--- a/app/modules/collaborations/__init__.py
+++ b/app/modules/collaborations/__init__.py
@@ -4,9 +4,8 @@ Collaborations module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('collaborations'):

--- a/app/modules/collaborations/models.py
+++ b/app/modules/collaborations/models.py
@@ -3,14 +3,14 @@
 Collaborations database models
 --------------------
 """
-import uuid
 import logging
+import uuid
+
 from flask_login import current_user
 
-from app.extensions import db, HoustonModel
 import app.extensions.logging as AuditLog
+from app.extensions import HoustonModel, db
 from app.utils import HoustonException
-
 
 log = logging.getLogger(__name__)
 

--- a/app/modules/collaborations/parameters.py
+++ b/app/modules/collaborations/parameters.py
@@ -3,15 +3,17 @@
 Input arguments (Parameters) for Collaborations resources RESTful API
 -----------------------------------------------------------
 """
-from flask_restx_patched import Parameters, PatchJSONParameters
-from flask_marshmallow import base_fields
 import logging
 
-from . import schemas
 from flask_login import current_user
-from app.modules.users.permissions.types import AccessOperation
+from flask_marshmallow import base_fields
+
 from app.modules.users.permissions import rules
+from app.modules.users.permissions.types import AccessOperation
 from app.utils import HoustonException
+from flask_restx_patched import Parameters, PatchJSONParameters
+
+from . import schemas
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/app/modules/collaborations/resources.py
+++ b/app/modules/collaborations/resources.py
@@ -5,27 +5,25 @@ RESTful API Collaborations resources
 --------------------------
 """
 
-import logging
 import json
+import logging
 
 from flask import request
 from flask_login import current_user  # NOQA
-from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
-from app.extensions.api import abort
 from marshmallow import ValidationError
 
+import app.extensions.logging as AuditLog
 from app.extensions import db
-from app.extensions.api import Namespace
+from app.extensions.api import Namespace, abort
+from app.extensions.api.parameters import PaginationParametersLatestFirst
+from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 from app.utils import HoustonException
-from app.modules.users import permissions
-import app.extensions.logging as AuditLog
-from app.extensions.api.parameters import PaginationParametersLatestFirst
+from flask_restx_patched import Resource
+from flask_restx_patched._http import HTTPStatus
 
 from . import parameters, schemas
 from .models import Collaboration
-
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace(

--- a/app/modules/collaborations/schemas.py
+++ b/app/modules/collaborations/schemas.py
@@ -4,9 +4,11 @@ Serialization schemas for Collaborations resources RESTful API
 ----------------------------------------------------
 """
 
+from flask_marshmallow import base_fields
+
 # from flask_marshmallow import base_fields
 from flask_restx_patched import ModelSchema
-from flask_marshmallow import base_fields
+
 from .models import Collaboration
 
 

--- a/app/modules/complex_date_time/__init__.py
+++ b/app/modules/complex_date_time/__init__.py
@@ -5,7 +5,6 @@ ComplexDateTime module
 """
 
 from app.extensions.api import api_v1
-
 from app.modules import is_module_enabled
 
 if not is_module_enabled('complex_date_time'):

--- a/app/modules/complex_date_time/models.py
+++ b/app/modules/complex_date_time/models.py
@@ -5,16 +5,17 @@ A structure for holding a DateTime object with additional complexity
 involving time zone and specificity
 --------------------
 """
-import uuid
+import datetime
 import enum
-from app.extensions import db
 import logging
+import uuid
+
+import pytz
+from dateutil import tz
 
 import app.extensions.logging as AuditLog
-import datetime
-from dateutil import tz
+from app.extensions import db
 from app.utils import normalized_timezone_string
-import pytz
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -196,10 +197,12 @@ class ComplexDateTime(db.Model):
     # used from parameters.py for object which have time/timeSpecifity patches (currently encounter and sighting)
     @classmethod
     def patch_replace_helper(cls, obj, field, value):
+        import pytz
+
         from app.modules.complex_date_time.models import ComplexDateTime, Specificities
         from app.utils import normalized_timezone_string
+
         from .models import db
-        import pytz
 
         # * note: field==time requires `value` is iso8601 **with timezone**
         # this gets a little funky in the event there is *no existing time set* as the patch

--- a/app/modules/complex_date_time/resources.py
+++ b/app/modules/complex_date_time/resources.py
@@ -12,7 +12,6 @@ from flask_login import current_user  # NOQA
 
 from app.extensions.api import Namespace
 
-
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace(
     'complex_date_time', description='ComplexDateTime'

--- a/app/modules/complex_date_time/schemas.py
+++ b/app/modules/complex_date_time/schemas.py
@@ -4,8 +4,9 @@ Serialization schemas for ComplexDateTimes resources RESTful API
 ----------------------------------------------------
 """
 
-from flask_restx_patched import ModelSchema
 from flask_marshmallow import base_fields
+
+from flask_restx_patched import ModelSchema
 
 from .models import ComplexDateTime
 

--- a/app/modules/emails/__init__.py
+++ b/app/modules/emails/__init__.py
@@ -3,9 +3,8 @@
 Auth module
 ===========
 """
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('emails'):

--- a/app/modules/emails/models.py
+++ b/app/modules/emails/models.py
@@ -1,17 +1,14 @@
 # -*- coding: utf-8 -*-
-import logging
-import enum
-
-from flask import current_app, request
-from app.extensions.email import Email  # , _format_datetime
-
-from app.extensions import db, HoustonModel
-
 import datetime
+import enum
+import logging
 import pprint
-
 import uuid
 
+from flask import current_app, request
+
+from app.extensions import HoustonModel, db
+from app.extensions.email import Email  # , _format_datetime
 
 log = logging.getLogger(__name__)
 pp = pprint.PrettyPrinter(indent=2)

--- a/app/modules/encounters/__init__.py
+++ b/app/modules/encounters/__init__.py
@@ -4,9 +4,8 @@ Encounters module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('encounters'):

--- a/app/modules/encounters/models.py
+++ b/app/modules/encounters/models.py
@@ -3,11 +3,11 @@
 Encounters database models
 --------------------
 """
-import uuid
 import logging
-from app.extensions import db, FeatherModel
-import app.extensions.logging as AuditLog
+import uuid
 
+import app.extensions.logging as AuditLog
+from app.extensions import FeatherModel, db
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -127,7 +127,7 @@ class Encounter(db.Model, FeatherModel):
         return str(self.sighting.guid)
 
     def get_assets(self):
-        return set([ann.asset for ann in self.annotations])
+        return {ann.asset for ann in self.annotations}
 
     def get_custom_fields(self):
         return self.get_edm_data_field('customFields')

--- a/app/modules/encounters/parameters.py
+++ b/app/modules/encounters/parameters.py
@@ -3,15 +3,15 @@
 Input arguments (Parameters) for Encounters resources RESTful API
 -----------------------------------------------------------
 """
+import logging
+
 from flask_login import current_user
+
+from app.modules.users.permissions import rules
+from app.utils import HoustonException
 from flask_restx_patched import Parameters, PatchJSONParameters
 
 from . import schemas
-from app.modules.users.permissions import rules
-import logging
-
-
-from app.utils import HoustonException
 
 log = logging.getLogger(__name__)
 
@@ -58,8 +58,9 @@ class PatchEncounterDetailsParameters(PatchJSONParameters):
 
     @classmethod
     def replace(cls, obj, field, value, state):
-        from app.modules.users.models import User
         from app.modules.complex_date_time.models import ComplexDateTime
+        from app.modules.users.models import User
+
         from .models import db
 
         ret_val = False

--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -7,23 +7,20 @@ RESTful API Encounters resources
 
 import logging
 
+from flask import current_app, make_response, request
 from flask_login import current_user  # NOQA
-from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
-from flask import request, current_app, make_response
 
+import app.extensions.logging as AuditLog
 from app.extensions import db
-from app.extensions.api import Namespace
+from app.extensions.api import Namespace, abort
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 from app.utils import HoustonException
-
-from app.extensions.api import abort
+from flask_restx_patched import Resource
+from flask_restx_patched._http import HTTPStatus
 
 from . import parameters, schemas
 from .models import Encounter
-import app.extensions.logging as AuditLog
-
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace('encounters', description='Encounters')  # pylint: disable=invalid-name

--- a/app/modules/encounters/schemas.py
+++ b/app/modules/encounters/schemas.py
@@ -5,6 +5,7 @@ Serialization schemas for Encounters resources RESTful API
 """
 
 from flask_marshmallow import base_fields
+
 from flask_restx_patched import ModelSchema
 
 from .models import Encounter

--- a/app/modules/fileuploads/__init__.py
+++ b/app/modules/fileuploads/__init__.py
@@ -4,9 +4,8 @@ FileUpload module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('fileuploads'):

--- a/app/modules/fileuploads/models.py
+++ b/app/modules/fileuploads/models.py
@@ -4,14 +4,14 @@ FileUploads database models
 --------------------
 """
 import logging
-import uuid
 import os
 import shutil
+import uuid
 
 from flask import current_app, url_for
 from PIL import Image
 
-from app.extensions import db, HoustonModel
+from app.extensions import HoustonModel, db
 
 log = logging.getLogger(__name__)
 

--- a/app/modules/fileuploads/resources.py
+++ b/app/modules/fileuploads/resources.py
@@ -11,14 +11,12 @@ import logging
 
 from flask import send_file
 from flask_login import current_user  # NOQA
+
+from app.extensions.api import Namespace
 from flask_restx_patched import Resource
 from flask_restx_patched._http import HTTPStatus
 
-from app.extensions.api import Namespace
-
-
 from .models import FileUpload
-
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace('fileuploads', description='FileUploads')  # pylint: disable=invalid-name

--- a/app/modules/ia_config_reader.py
+++ b/app/modules/ia_config_reader.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import logging
-import json
 import copy
+import json
+import logging
 import os.path as path
 
 log = logging.getLogger(__name__)

--- a/app/modules/individuals/__init__.py
+++ b/app/modules/individuals/__init__.py
@@ -4,9 +4,8 @@ Individuals module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('individuals'):

--- a/app/modules/individuals/parameters.py
+++ b/app/modules/individuals/parameters.py
@@ -3,15 +3,17 @@
 Input arguments (Parameters) for Individuals resources RESTful API
 -----------------------------------------------------------
 """
-from flask_restx_patched import Parameters, PatchJSONParameters
-from . import schemas
 import logging
-import app.modules.utils as util
-from flask_restx_patched._http import HTTPStatus
-from flask_marshmallow import base_fields
-from app.utils import HoustonException
 from uuid import UUID
 
+from flask_marshmallow import base_fields
+
+import app.modules.utils as util
+from app.utils import HoustonException
+from flask_restx_patched import Parameters, PatchJSONParameters
+from flask_restx_patched._http import HTTPStatus
+
+from . import schemas
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -94,9 +96,10 @@ class PatchIndividualDetailsParameters(PatchJSONParameters):
             and util.is_valid_uuid_string(value['guid'])
             and util.is_valid_uuid_string(value['preferring_user'])
         ):
+            from flask_login import current_user
+
             from app.modules.names.models import Name
             from app.modules.users.models import User
-            from flask_login import current_user
 
             name = Name.query.get(value['guid'])
             if not name or name.individual_guid != obj.guid:
@@ -134,9 +137,10 @@ class PatchIndividualDetailsParameters(PatchJSONParameters):
                     'value must contain keys ("context", "value") or ("guid", "preferring_user")',
                     status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
                 )
+            from flask_login import current_user
+
             from app.modules.names.models import Name
             from app.modules.users.models import User
-            from flask_login import current_user
 
             if 'context' in value:
                 # if add_name fails (e.g. constraint violation due to context duplication) a 409/conflict will be returned

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -5,20 +5,22 @@ RESTful API Individuals resources
 --------------------------
 """
 
-import logging
 import json
-from flask_restx_patched import Resource
+import logging
+
+from flask import current_app, request, send_file
 from flask_restx._http import HTTPStatus
-from flask import request, current_app, send_file
+
+import app.extensions.logging as AuditLog
 from app.extensions import db
 from app.extensions.api import Namespace, abort
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 from app.utils import HoustonException
+from flask_restx_patched import Resource
 
 from . import parameters, schemas
 from .models import Individual, IndividualMergeRequestVote
-import app.extensions.logging as AuditLog
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace('individuals', description='Individuals')  # pylint: disable=invalid-name
@@ -186,6 +188,7 @@ class Individuals(Resource):
         if not names_data or not isinstance(names_data, list):
             return names
         from flask_login import current_user
+
         from app.modules.names.models import Name
 
         for name_json in names_data:
@@ -663,6 +666,7 @@ class IndividualMergeRequestByTaskId(Resource):
 
     def post(self, task_id):
         from flask_login import current_user
+
         from app.modules.notifications.models import NotificationType
 
         vote = request.json.get('vote')
@@ -812,10 +816,11 @@ class FlatfileNameValidation(Resource):
     #   ["Zesus", 46]
     # ]
     def post(self):
-        from app.modules.names.models import Name, DEFAULT_NAME_CONTEXT
+        from collections import defaultdict
 
         from flask_login import current_user
-        from collections import defaultdict
+
+        from app.modules.names.models import DEFAULT_NAME_CONTEXT, Name
 
         if not current_user or current_user.is_anonymous:
             abort(code=401)

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -4,20 +4,20 @@ Serialization schemas for Individuals resources RESTful API
 ----------------------------------------------------
 """
 
-from flask_restx_patched import ModelSchema
 from flask_marshmallow import base_fields
 
-from .models import Individual
-
-from app.modules.names.schemas import DetailedNameSchema
 from app.modules.encounters.schemas import (
     DetailedEncounterSchema,
     ElasticsearchEncounterSchema,
 )
+from app.modules.names.schemas import DetailedNameSchema
 from app.modules.relationships.schemas import (
-    DetailedRelationshipSchema,
     BaseRelationshipIndividualMemberSchema,
+    DetailedRelationshipSchema,
 )
+from flask_restx_patched import ModelSchema
+
+from .models import Individual
 
 
 class BaseIndividualSchema(ModelSchema):

--- a/app/modules/individuals/tasks.py
+++ b/app/modules/individuals/tasks.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+
 from app.extensions.celery import celery
 
 log = logging.getLogger(__name__)

--- a/app/modules/integrity/__init__.py
+++ b/app/modules/integrity/__init__.py
@@ -4,9 +4,8 @@ Integrity module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('integrity'):

--- a/app/modules/integrity/models.py
+++ b/app/modules/integrity/models.py
@@ -4,9 +4,9 @@ Integrity database models
 --------------------
 """
 
-from app.extensions import db, HoustonModel
-
 import uuid
+
+from app.extensions import HoustonModel, db
 
 
 class Integrity(db.Model, HoustonModel):
@@ -31,11 +31,11 @@ class Integrity(db.Model, HoustonModel):
     def __init__(self):
         # Creating an Integrity entry runs the full integrity checks and generates and stores the result
         # for later analysis
-        from app.modules.sightings.models import Sighting
-        from app.modules.individuals.models import Individual
-        from app.modules.asset_groups.models import AssetGroup
         from app.modules.annotations.models import Annotation
+        from app.modules.asset_groups.models import AssetGroup
         from app.modules.assets.models import Asset
+        from app.modules.individuals.models import Individual
+        from app.modules.sightings.models import Sighting
 
         self.result = {
             'asset_groups': AssetGroup.run_integrity(),

--- a/app/modules/integrity/resources.py
+++ b/app/modules/integrity/resources.py
@@ -8,17 +8,16 @@ RESTful API Integrity resources
 import logging
 
 from flask import request
-from flask_restx_patched import Resource
 from flask_restx._http import HTTPStatus
 
 from app.extensions import db
 from app.extensions.api import Namespace
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
+from flask_restx_patched import Resource
 
 from . import parameters, schemas
 from .models import Integrity
-
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace(

--- a/app/modules/job_control/__init__.py
+++ b/app/modules/job_control/__init__.py
@@ -4,8 +4,8 @@ job control module
 ============
 """
 
-from app.modules import is_module_enabled
 from app.extensions.api import api_v1
+from app.modules import is_module_enabled
 
 if not is_module_enabled('job_control'):
     raise RuntimeError('Job Control is not enabled')

--- a/app/modules/job_control/models.py
+++ b/app/modules/job_control/models.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Provides UI space served directly from this application"""
 import logging
+
 from app.modules import is_module_enabled
 
 log = logging.getLogger(__name__)

--- a/app/modules/job_control/resources.py
+++ b/app/modules/job_control/resources.py
@@ -6,12 +6,12 @@ RESTful API JobControl resources
 """
 
 import logging
-from flask_restx_patched import Resource
 
 from app.extensions.api import Namespace
 from app.extensions.api.parameters import PaginationParameters
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
+from flask_restx_patched import Resource
 
 from .models import JobControl
 

--- a/app/modules/job_control/tasks.py
+++ b/app/modules/job_control/tasks.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import logging
+
 from app.extensions.celery import celery
 
 log = logging.getLogger(__name__)

--- a/app/modules/keywords/__init__.py
+++ b/app/modules/keywords/__init__.py
@@ -5,7 +5,6 @@ Keywords module
 """
 
 from app.extensions.api import api_v1
-
 from app.modules import is_module_enabled
 
 if not is_module_enabled('keywords'):

--- a/app/modules/keywords/models.py
+++ b/app/modules/keywords/models.py
@@ -7,7 +7,7 @@ import enum
 import logging
 import uuid
 
-from app.extensions import db, HoustonModel
+from app.extensions import HoustonModel, db
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/app/modules/keywords/parameters.py
+++ b/app/modules/keywords/parameters.py
@@ -4,6 +4,7 @@ Input arguments (Parameters) for Keywords resources RESTful API
 -----------------------------------------------------------
 """
 from flask_restx_patched import Parameters, PatchJSONParameters
+
 from . import schemas
 
 

--- a/app/modules/keywords/resources.py
+++ b/app/modules/keywords/resources.py
@@ -7,17 +7,16 @@ RESTful API Keywords resources
 
 import logging
 
-from flask_restx_patched import Resource
 from flask_restx._http import HTTPStatus
 
 from app.extensions import db
 from app.extensions.api import Namespace
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
+from flask_restx_patched import Resource
 
 from . import parameters, schemas
 from .models import Keyword
-
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace('keywords', description='Keywords')  # pylint: disable=invalid-name

--- a/app/modules/keywords/schemas.py
+++ b/app/modules/keywords/schemas.py
@@ -6,6 +6,7 @@ Serialization schemas for Keywords resources RESTful API
 
 
 from flask_restx_patched import ModelSchema
+
 from .models import Keyword
 
 

--- a/app/modules/missions/__init__.py
+++ b/app/modules/missions/__init__.py
@@ -4,9 +4,8 @@ Missions module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('missions'):

--- a/app/modules/missions/models.py
+++ b/app/modules/missions/models.py
@@ -3,21 +3,16 @@
 Missions database models
 --------------------
 """
-import uuid
-import enum
 import datetime
-
-from app.extensions import (
-    db,
-    HoustonModel,
-    Timestamp,
-    elasticsearch_context,
-)
-from app.extensions.git_store import GitStore
-
-from flask import current_app
-import tqdm
+import enum
 import logging
+import uuid
+
+import tqdm
+from flask import current_app
+
+from app.extensions import HoustonModel, Timestamp, db, elasticsearch_context
+from app.extensions.git_store import GitStore
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -95,8 +90,8 @@ class Mission(db.Model, HoustonModel, Timestamp):
 
     @classmethod
     def query_search_term_hook(cls, term):
-        from sqlalchemy_utils.functions import cast_if
         from sqlalchemy import String
+        from sqlalchemy_utils.functions import cast_if
 
         return (
             cast_if(cls.guid, String).contains(term),
@@ -348,8 +343,8 @@ class MissionCollection(GitStore):
 
     @classmethod
     def query_search_term_hook(cls, term):
-        from sqlalchemy_utils.functions import cast_if
         from sqlalchemy import String
+        from sqlalchemy_utils.functions import cast_if
 
         return (
             cast_if(cls.guid, String).contains(term),
@@ -514,8 +509,8 @@ class MissionTask(db.Model, HoustonModel, Timestamp):
 
     @classmethod
     def query_search_term_hook(cls, term):
-        from sqlalchemy_utils.functions import cast_if
         from sqlalchemy import String
+        from sqlalchemy_utils.functions import cast_if
 
         return (
             cast_if(cls.guid, String).contains(term),

--- a/app/modules/missions/parameters.py
+++ b/app/modules/missions/parameters.py
@@ -4,21 +4,22 @@ Input arguments (Parameters) for Missions resources RESTful API
 -----------------------------------------------------------
 """
 
+import logging
+
 from flask_login import current_user  # NOQA
 from flask_marshmallow import base_fields
+from marshmallow import ValidationError
+
+from app.modules.users.permissions import rules
 from flask_restx_patched import (
     Parameters,
     PatchJSONParameters,
     PatchJSONParametersWithPassword,
     SetOperationsJSONParameters,
 )
-from marshmallow import ValidationError
 
 from . import schemas
 from .models import Mission, MissionCollection, MissionTask
-from app.modules.users.permissions import rules
-import logging
-
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -69,8 +70,8 @@ class PatchMissionDetailsParameters(PatchJSONParametersWithPassword):
 
     @classmethod
     def add(cls, obj, field, value, state):
-        from app.modules.users.models import User
         from app.modules.assets.models import Asset
+        from app.modules.users.models import User
 
         # Check permissions
         super(PatchMissionDetailsParameters, cls).add(obj, field, value, state)
@@ -93,8 +94,8 @@ class PatchMissionDetailsParameters(PatchJSONParametersWithPassword):
 
     @classmethod
     def remove(cls, obj, field, value, state):
-        from app.modules.users.models import User
         from app.modules.assets.models import Asset
+        from app.modules.users.models import User
 
         # Check permissions
         super(PatchMissionDetailsParameters, cls).remove(obj, field, value, state)
@@ -197,8 +198,8 @@ class CreateMissionTaskParameters(SetOperationsJSONParameters):
 
     @classmethod
     def resolve(cls, field, value, obj):
-        from app.modules.missions.models import MissionCollection, MissionTask
         from app.modules.assets.models import Asset
+        from app.modules.missions.models import MissionCollection, MissionTask
 
         def _check(condition):
             if not condition:
@@ -286,8 +287,8 @@ class PatchMissionTaskDetailsParameters(PatchJSONParametersWithPassword):
 
     @classmethod
     def add(cls, obj, field, value, state):
-        from app.modules.users.models import User
         from app.modules.assets.models import Asset
+        from app.modules.users.models import User
 
         super(PatchMissionTaskDetailsParameters, cls).add(obj, field, value, state)
         ret_val = False
@@ -321,8 +322,8 @@ class PatchMissionTaskDetailsParameters(PatchJSONParametersWithPassword):
 
     @classmethod
     def remove(cls, obj, field, value, state):
-        from app.modules.users.models import User
         from app.modules.assets.models import Asset
+        from app.modules.users.models import User
 
         # Check permissions
         super(PatchMissionTaskDetailsParameters, cls).remove(obj, field, value, state)

--- a/app/modules/missions/resources.py
+++ b/app/modules/missions/resources.py
@@ -6,27 +6,26 @@ RESTful API Missions resources
 """
 
 import logging
-import werkzeug
 import uuid
 
+import randomname
+import tqdm
+import werkzeug
 from flask import request
-from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 from flask_login import current_user  # NOQA
+from marshmallow import ValidationError
 
 from app.extensions import db
 from app.extensions.api import Namespace, abort
+from app.modules.assets.schemas import DetailedAssetTableSchema
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
-from app.modules.assets.schemas import DetailedAssetTableSchema
+from app.utils import HoustonException
+from flask_restx_patched import Resource
+from flask_restx_patched._http import HTTPStatus
+
 from . import parameters, schemas
 from .models import Mission, MissionCollection, MissionTask
-from marshmallow import ValidationError
-import randomname
-import tqdm
-
-from app.utils import HoustonException
-
 
 USE_GLOBALLY_UNIQUE_MISSION_TASK_NAMES = True
 
@@ -405,7 +404,7 @@ class MissionTasksForMission(Resource):
                 ),
                 sep=' ',
             ).title()
-            title = 'New Task: %s' % (title,)
+            title = 'New Task: {}'.format(title)
         assert title is not None
         assert title not in titles
 

--- a/app/modules/missions/schemas.py
+++ b/app/modules/missions/schemas.py
@@ -4,8 +4,9 @@ Serialization schemas for Missions resources RESTful API
 ----------------------------------------------------
 """
 
-from flask_restx_patched import ModelSchema
 from flask_marshmallow import base_fields
+
+from flask_restx_patched import ModelSchema
 
 from .models import Mission, MissionCollection, MissionTask
 

--- a/app/modules/missions/tasks.py
+++ b/app/modules/missions/tasks.py
@@ -5,7 +5,6 @@ import requests.exceptions
 
 from app.extensions.celery import celery
 
-
 log = logging.getLogger(__name__)
 
 

--- a/app/modules/names/__init__.py
+++ b/app/modules/names/__init__.py
@@ -4,9 +4,8 @@ Names module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('names'):

--- a/app/modules/names/models.py
+++ b/app/modules/names/models.py
@@ -4,12 +4,11 @@ Names database models
 A structure for holding a (user-provided) name for an Individual.
 --------------------
 """
+import logging
 import uuid
 
-from app.extensions import db, HoustonModel, Timestamp
-
-import logging
 import app.extensions.logging as AuditLog
+from app.extensions import HoustonModel, Timestamp, db
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/app/modules/names/resources.py
+++ b/app/modules/names/resources.py
@@ -12,6 +12,5 @@ from flask_login import current_user  # NOQA
 
 from app.extensions.api import Namespace
 
-
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace('names', description='Names')  # pylint: disable=invalid-name

--- a/app/modules/names/schemas.py
+++ b/app/modules/names/schemas.py
@@ -4,11 +4,12 @@ Serialization schemas for Names resources RESTful API
 ----------------------------------------------------
 """
 
-from flask_restx_patched import ModelSchema
 from flask_marshmallow import base_fields
 
-from .models import Name
 from app.modules.users.schemas import PublicUserSchema
+from flask_restx_patched import ModelSchema
+
+from .models import Name
 
 
 class BaseNameSchema(ModelSchema):

--- a/app/modules/notifications/__init__.py
+++ b/app/modules/notifications/__init__.py
@@ -4,9 +4,8 @@ Notifications module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('notifications'):

--- a/app/modules/notifications/models.py
+++ b/app/modules/notifications/models.py
@@ -4,13 +4,13 @@ Notifications database models
 --------------------
 """
 
-from app.extensions import db, HoustonModel
-from app.utils import HoustonException
 import datetime
-
 import enum
-import uuid
 import logging
+import uuid
+
+from app.extensions import HoustonModel, db
+from app.utils import HoustonException
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/app/modules/notifications/parameters.py
+++ b/app/modules/notifications/parameters.py
@@ -8,7 +8,7 @@ Input arguments (Parameters) for Notifications resources RESTful API
 from flask_restx_patched import Parameters, PatchJSONParameters
 
 from . import schemas
-from .models import Notification, NOTIFICATION_CONFIG  # NOQA
+from .models import NOTIFICATION_CONFIG, Notification  # NOQA
 
 
 class CreateNotificationParameters(Parameters, schemas.DetailedNotificationSchema):

--- a/app/modules/notifications/resources.py
+++ b/app/modules/notifications/resources.py
@@ -9,24 +9,21 @@ import logging
 
 from flask import request
 from flask_login import current_user  # NOQA
-from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 from marshmallow import ValidationError
-from app.extensions.api import abort
 
 from app.extensions import db
-from app.extensions.api import Namespace
+from app.extensions.api import Namespace, abort
 from app.extensions.api.parameters import (
     PaginationParameters,
     PaginationParametersLatestFirst,
 )
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
-
+from flask_restx_patched import Resource
+from flask_restx_patched._http import HTTPStatus
 
 from . import parameters, schemas
 from .models import Notification
-
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace(

--- a/app/modules/notifications/schemas.py
+++ b/app/modules/notifications/schemas.py
@@ -4,11 +4,12 @@ Serialization schemas for Notifications resources RESTful API
 ----------------------------------------------------
 """
 
-from flask_restx_patched import ModelSchema
 from flask_marshmallow import base_fields
 
 from app.extensions import ExtraValidationSchema
-from .models import Notification, NotificationType, NotificationChannel
+from flask_restx_patched import ModelSchema
+
+from .models import Notification, NotificationChannel, NotificationType
 
 
 class NotificationChannelSchema(ExtraValidationSchema):

--- a/app/modules/organizations/__init__.py
+++ b/app/modules/organizations/__init__.py
@@ -4,9 +4,8 @@ Organizations module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('organizations'):

--- a/app/modules/organizations/models.py
+++ b/app/modules/organizations/models.py
@@ -7,11 +7,11 @@ import datetime
 import logging
 import uuid
 
-from flask import current_app
 import pytz
+from flask import current_app
 
+from app.extensions import HoustonModel, db
 from app.extensions.edm import EDMObjectMixin
-from app.extensions import db, HoustonModel
 from app.modules.users.models import User
 
 log = logging.getLogger(__name__)
@@ -96,7 +96,7 @@ class OrganizationEDMMixin(EDMObjectMixin):
 
     def _process_members(self, members):
         for member in members:
-            log.info('Adding Member ID %s' % (member.id,))
+            log.info('Adding Member ID {}'.format(member.id))
             user, is_new = User.ensure_edm_obj(member.id)
             if user not in self.members:
                 enrollment = OrganizationUserMembershipEnrollment(

--- a/app/modules/organizations/resources.py
+++ b/app/modules/organizations/resources.py
@@ -9,18 +9,16 @@ import logging
 
 from flask import request
 from flask_login import current_user  # NOQA
-from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 
 from app.extensions import db
 from app.extensions.api import Namespace
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
-
+from flask_restx_patched import Resource
+from flask_restx_patched._http import HTTPStatus
 
 from . import parameters, schemas
 from .models import Organization
-
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace(

--- a/app/modules/passthroughs/__init__.py
+++ b/app/modules/passthroughs/__init__.py
@@ -5,7 +5,6 @@ Passthroughs module
 """
 
 from app.extensions.api import api_v1
-
 from app.modules import is_module_enabled
 
 if not is_module_enabled('passthroughs'):

--- a/app/modules/passthroughs/parameters.py
+++ b/app/modules/passthroughs/parameters.py
@@ -5,6 +5,7 @@ Input arguments (Parameters) for Passthroughs resources RESTful API
 """
 
 from flask_marshmallow import base_fields
+
 from flask_restx_patched import Parameters
 
 

--- a/app/modules/passthroughs/resources.py
+++ b/app/modules/passthroughs/resources.py
@@ -5,14 +5,13 @@ RESTful API Passthroughs resources
 --------------------------
 """
 
+import json
 import logging
 
 from flask import current_app, request
-from flask_restx_patched import Resource
+
 from app.extensions.api import Namespace
-
-import json
-
+from flask_restx_patched import Resource
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 edm_pass = Namespace(

--- a/app/modules/passthroughs/schemas.py
+++ b/app/modules/passthroughs/schemas.py
@@ -5,6 +5,7 @@ Serialization schemas for Passthroughs resources RESTful API
 """
 
 from flask_marshmallow import base_fields
+
 from flask_restx_patched import ModelSchema
 
 

--- a/app/modules/progress/__init__.py
+++ b/app/modules/progress/__init__.py
@@ -5,7 +5,6 @@ Progress module
 """
 
 from app.extensions.api import api_v1
-
 from app.modules import is_module_enabled
 
 if not is_module_enabled('progress'):

--- a/app/modules/progress/models.py
+++ b/app/modules/progress/models.py
@@ -3,15 +3,14 @@
 Progress database models
 --------------------
 """
+import enum
 import logging
+import uuid
 
-from sqlalchemy_utils import Timestamp
 from etaprogress.eta import ETA
+from sqlalchemy_utils import Timestamp
 
 from app.extensions import db
-
-import uuid
-import enum
 
 log = logging.getLogger(__name__)
 
@@ -143,8 +142,9 @@ class Progress(db.Model, Timestamp):
 
     @property
     def ahead(self):
-        import redis
         import json
+
+        import redis
 
         global BROKER
 
@@ -330,7 +330,7 @@ class Progress(db.Model, Timestamp):
             elif step.completed:
                 self.iterate(chain=chain)
             elif step.failed:
-                message = 'Step %r failure: %r' % (
+                message = 'Step {!r} failure: {!r}'.format(
                     step,
                     step.message,
                 )
@@ -457,6 +457,6 @@ class Progress(db.Model, Timestamp):
         if self.parent:
             self.parent.notify(self.guid, chain=chain)
 
-        log.info('Updated %r' % (self,))
+        log.info('Updated {!r}'.format(self))
 
         return 'set'

--- a/app/modules/progress/resources.py
+++ b/app/modules/progress/resources.py
@@ -7,16 +7,15 @@ RESTful API Progress resources
 
 import logging
 
-from flask_restx_patched import Resource
 from flask_restx._http import HTTPStatus
 
 from app.extensions.api import Namespace
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
+from flask_restx_patched import Resource
 
 from . import schemas
 from .models import Progress
-
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace('progress', description='Progress')  # pylint: disable=invalid-name

--- a/app/modules/projects/__init__.py
+++ b/app/modules/projects/__init__.py
@@ -4,9 +4,8 @@ Projects module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('projects'):

--- a/app/modules/projects/models.py
+++ b/app/modules/projects/models.py
@@ -5,7 +5,7 @@ Projects database models
 """
 import uuid
 
-from app.extensions import db, HoustonModel, Timestamp
+from app.extensions import HoustonModel, Timestamp, db
 
 
 # All many:many associations handled as Houston model classes to give control and history

--- a/app/modules/projects/parameters.py
+++ b/app/modules/projects/parameters.py
@@ -5,10 +5,12 @@ Input arguments (Parameters) for Projects resources RESTful API
 """
 
 from flask_login import current_user  # NOQA
+
+from app.modules.users.permissions import rules
 from flask_restx_patched import Parameters, PatchJSONParametersWithPassword
+
 from . import schemas
 from .models import Project
-from app.modules.users.permissions import rules
 
 
 class CreateProjectParameters(Parameters, schemas.DetailedProjectSchema):
@@ -27,8 +29,8 @@ class PatchProjectDetailsParameters(PatchJSONParametersWithPassword):
 
     @classmethod
     def add(cls, obj, field, value, state):
-        from app.modules.users.models import User
         from app.modules.encounters.models import Encounter
+        from app.modules.users.models import User
 
         super(PatchProjectDetailsParameters, cls).add(obj, field, value, state)
         ret_val = False
@@ -65,8 +67,8 @@ class PatchProjectDetailsParameters(PatchJSONParametersWithPassword):
 
     @classmethod
     def remove(cls, obj, field, value, state):
-        from app.modules.users.models import User
         from app.modules.encounters.models import Encounter
+        from app.modules.users.models import User
 
         super(PatchProjectDetailsParameters, cls).remove(obj, field, value, state)
 

--- a/app/modules/projects/resources.py
+++ b/app/modules/projects/resources.py
@@ -8,17 +8,17 @@ RESTful API Projects resources
 import logging
 
 from flask import request
-from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 from flask_login import current_user  # NOQA
 
 from app.extensions import db
 from app.extensions.api import Namespace
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
+from flask_restx_patched import Resource
+from flask_restx_patched._http import HTTPStatus
+
 from . import parameters, schemas
 from .models import Project
-
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace('projects', description='Projects')  # pylint: disable=invalid-name

--- a/app/modules/relationships/__init__.py
+++ b/app/modules/relationships/__init__.py
@@ -4,9 +4,8 @@ Relationships module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('relationships'):

--- a/app/modules/relationships/models.py
+++ b/app/modules/relationships/models.py
@@ -4,13 +4,12 @@ Relationships database models
 --------------------
 """
 
-from app.extensions import HoustonModel, db
 import datetime
-import app.extensions.logging as AuditLog
-
+import logging
 import uuid
 
-import logging
+import app.extensions.logging as AuditLog
+from app.extensions import HoustonModel, db
 
 log = logging.getLogger(__name__)
 

--- a/app/modules/relationships/resources.py
+++ b/app/modules/relationships/resources.py
@@ -6,21 +6,20 @@ RESTful API Relationships resources
 """
 
 import logging
-
-from flask import request
-from flask_restx_patched import Resource
-from flask_restx._http import HTTPStatus
-import dateutil
 import uuid
+
+import dateutil
+from flask import request
+from flask_restx._http import HTTPStatus
 
 from app.extensions import db
 from app.extensions.api import Namespace
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
+from flask_restx_patched import Resource
 
 from . import parameters, schemas
 from .models import Relationship
-
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace(
@@ -65,8 +64,8 @@ class Relationships(Resource):
         """
         Create a new instance of Relationship.
         """
-        from app.extensions.elapsed_time import ElapsedTime
         import app.extensions.logging as AuditLog  # NOQA
+        from app.extensions.elapsed_time import ElapsedTime
 
         timer = ElapsedTime()
 
@@ -234,8 +233,8 @@ class RelationshipByID(Resource):
         """
         Delete a Relationship by ID.
         """
-        from app.extensions.elapsed_time import ElapsedTime
         import app.extensions.logging as AuditLog  # NOQA
+        from app.extensions.elapsed_time import ElapsedTime
 
         individual_1_guid = relationship.individual_members[0].individual_guid
         individual_2_guid = relationship.individual_members[1].individual_guid

--- a/app/modules/relationships/schemas.py
+++ b/app/modules/relationships/schemas.py
@@ -5,10 +5,10 @@ Serialization schemas for Relationships resources RESTful API
 """
 
 from flask_marshmallow import base_fields
+
 from flask_restx_patched import ModelSchema
 
-from .models import Relationship
-from .models import RelationshipIndividualMember
+from .models import Relationship, RelationshipIndividualMember
 
 
 class BaseRelationshipSchema(ModelSchema):

--- a/app/modules/sightings/__init__.py
+++ b/app/modules/sightings/__init__.py
@@ -4,9 +4,8 @@ Sightings module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('sightings'):

--- a/app/modules/sightings/parameters.py
+++ b/app/modules/sightings/parameters.py
@@ -6,16 +6,16 @@ Input arguments (Parameters) for Sightings resources RESTful API
 
 # from flask_marshmallow import base_fields
 
+from uuid import UUID
+
 from flask_login import current_user
+
+import app.modules.utils as util
+from app.modules.users.permissions import rules
+from app.modules.users.permissions.types import AccessOperation
 from flask_restx_patched import Parameters, PatchJSONParameters
 
 from . import schemas
-
-from app.modules.users.permissions.types import AccessOperation
-from app.modules.users.permissions import rules
-
-import app.modules.utils as util
-from uuid import UUID
 
 
 class CreateSightingParameters(Parameters, schemas.CreateSightingSchema):

--- a/app/modules/sightings/schemas.py
+++ b/app/modules/sightings/schemas.py
@@ -4,8 +4,9 @@ Serialization schemas for Sightings resources RESTful API
 ----------------------------------------------------
 """
 
-from flask_restx_patched import ModelSchema
 from flask_marshmallow import base_fields
+
+from flask_restx_patched import ModelSchema
 
 from .models import Sighting
 

--- a/app/modules/sightings/tasks.py
+++ b/app/modules/sightings/tasks.py
@@ -14,8 +14,8 @@ def send_identification(
     algorithm_id,
     matching_set_query=None,
 ):
-    from app.modules.sightings.models import Sighting
     from app.modules.annotations.models import Annotation
+    from app.modules.sightings.models import Sighting
 
     sighting = Sighting.query.get(sighting_guid)
     annotation = Annotation.query.get(annotation_guid)

--- a/app/modules/site_settings/__init__.py
+++ b/app/modules/site_settings/__init__.py
@@ -5,7 +5,6 @@ Site Settings module
 """
 
 from app.extensions.api import api_v1
-
 from app.modules import is_module_enabled
 
 if not is_module_enabled('site_settings'):

--- a/app/modules/site_settings/models.py
+++ b/app/modules/site_settings/models.py
@@ -3,14 +3,14 @@
 Site Settings database models
 --------------------
 """
-from app.extensions import db, Timestamp, extension_required, is_extension_enabled
+import logging
+
 from flask import current_app
 from flask_login import current_user  # NOQA
 
+from app.extensions import Timestamp, db, extension_required, is_extension_enabled
 from app.modules import is_module_enabled
 from app.utils import HoustonException
-
-import logging
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -744,7 +744,7 @@ class Regions(dict):
     def find_fuzzy_list(self, possible):
         matches = []
         # reduces to unique (and lowercase first)
-        for p in set([a.lower() for a in possible]):
+        for p in {a.lower() for a in possible}:
             fz = self.find_fuzzy(p)
             if fz:
                 matches.append(fz)
@@ -835,7 +835,7 @@ class Taxonomy:
     def find_fuzzy_list(cls, possible):
         matches = []
         # reduces to unique (and lowercase first)
-        for p in set([a.lower() for a in possible]):
+        for p in {a.lower() for a in possible}:
             fz = cls.find_fuzzy(p)
             if fz:
                 matches.append(fz)

--- a/app/modules/site_settings/resources.py
+++ b/app/modules/site_settings/resources.py
@@ -5,27 +5,26 @@ RESTful API Site Settings resources
 --------------------------
 """
 
+import json
 import logging
 from pathlib import Path
 
+from flask import current_app, redirect, request, url_for
 from flask_login import current_user  # NOQA
-from flask import current_app, request, redirect, url_for
-from flask_restx_patched import Resource
 from flask_restx._http import HTTPStatus
 
-from app.extensions import db, is_extension_enabled
 import app.extensions.logging as AuditLog  # NOQA
-from app.extensions.api import abort, Namespace
-from app.modules.users.models import User
+import app.version
+from app.extensions import db, is_extension_enabled
+from app.extensions.api import Namespace, abort
 from app.modules.users import permissions
+from app.modules.users.models import User
 from app.modules.users.permissions.types import AccessOperation
 from app.utils import HoustonException
-import app.version
+from flask_restx_patched import Resource
 
-from . import schemas, parameters
+from . import parameters, schemas
 from .models import SiteSetting
-import json
-
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 api = Namespace(

--- a/app/modules/site_settings/schemas.py
+++ b/app/modules/site_settings/schemas.py
@@ -5,8 +5,8 @@ Serialization schemas for Site Settings resources RESTful API
 """
 from flask_marshmallow import base_fields
 
-from flask_restx_patched import ModelSchema
 from app.extensions import ExtraValidationSchema
+from flask_restx_patched import ModelSchema
 
 from .models import SiteSetting
 

--- a/app/modules/social_groups/__init__.py
+++ b/app/modules/social_groups/__init__.py
@@ -4,9 +4,8 @@ Social Groups module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('social_groups'):

--- a/app/modules/social_groups/models.py
+++ b/app/modules/social_groups/models.py
@@ -5,12 +5,11 @@ Social Groups database models
 """
 
 import logging
-
-from app.extensions import db, HoustonModel
-from app.utils import HoustonException
-import app.extensions.logging as AuditLog
-
 import uuid
+
+import app.extensions.logging as AuditLog
+from app.extensions import HoustonModel, db
+from app.utils import HoustonException
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/app/modules/social_groups/parameters.py
+++ b/app/modules/social_groups/parameters.py
@@ -4,9 +4,11 @@ Input arguments (Parameters) for Social Groups resources RESTful API
 -----------------------------------------------------------
 """
 import logging
+
 from flask_marshmallow import base_fields
-from flask_restx_patched import Parameters, PatchJSONParameters
+
 import app.extensions.logging as AuditLog
+from flask_restx_patched import Parameters, PatchJSONParameters
 
 from . import schemas
 

--- a/app/modules/social_groups/resources.py
+++ b/app/modules/social_groups/resources.py
@@ -10,14 +10,15 @@ import logging
 import uuid
 
 from flask import request
-from flask_restx_patched import Resource
 from flask_restx._http import HTTPStatus
-from app.utils import HoustonException
+
+import app.extensions.logging as AuditLog
 from app.extensions import db
-from app.extensions.api import abort, Namespace
+from app.extensions.api import Namespace, abort
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
-import app.extensions.logging as AuditLog
+from app.utils import HoustonException
+from flask_restx_patched import Resource
 
 from . import parameters, schemas
 from .models import SocialGroup
@@ -54,7 +55,7 @@ def validate_members(input_data):
             )
         # Use same validation for members (in create and patch) and member(in patch)
         # roles is the only valid key for members but guid is valid for member patch
-        if not data.keys() <= set(['roles']):
+        if not data.keys() <= {'roles'}:
             raise HoustonException(
                 log,
                 f'Social Group member {member_guid} fields not supported {set(data.keys())}',

--- a/app/modules/social_groups/schemas.py
+++ b/app/modules/social_groups/schemas.py
@@ -5,6 +5,7 @@ Serialization schemas for Social Groups resources RESTful API
 """
 
 from flask_marshmallow import base_fields
+
 from flask_restx_patched import ModelSchema
 
 from .models import SocialGroup, SocialGroupIndividualMembership

--- a/app/modules/swagger_ui.py
+++ b/app/modules/swagger_ui.py
@@ -12,7 +12,6 @@ from flask import Blueprint
 
 from .utils import fail_on_missing_static_folder
 
-
 blueprint = Blueprint(
     'customized_swagger_ui',
     __name__,

--- a/app/modules/users/__init__.py
+++ b/app/modules/users/__init__.py
@@ -4,9 +4,8 @@ Users module
 ============
 """
 
-from app.extensions.api import api_v1
 from app.extensions import register_elasticsearch_model
-
+from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
 if not is_module_enabled('users'):

--- a/app/modules/users/parameters.py
+++ b/app/modules/users/parameters.py
@@ -7,23 +7,23 @@ Input arguments (Parameters) for User resources RESTful API
 import logging
 from pathlib import Path
 
+import PIL
+
 # from flask import current_app
 from flask_login import current_user
 from flask_marshmallow import base_fields
+from marshmallow import validates_schema
+
+from app.extensions.api import abort
+from app.extensions.api.parameters import PaginationParameters
+from app.utils import HoustonException
 from flask_restx_patched import Parameters, PatchJSONParameters
 from flask_restx_patched._http import HTTPStatus
-from marshmallow import validates_schema
-import PIL
-
-from app.extensions.api.parameters import PaginationParameters
-from app.extensions.api import abort
-from app.utils import HoustonException
 
 from . import schemas
 
 # from . import permissions
-from .models import User, db, USER_ROLES
-
+from .models import USER_ROLES, User, db
 
 log = logging.getLogger(__name__)
 
@@ -202,11 +202,11 @@ class PatchUserDetailsParameters(PatchJSONParameters):
         Changing `is_admin` property requires current user to be Admin, and
         `current_password` of the current user should be provided..
         """
-        log.debug('Updating replace field %s' % (field,))
-        log.debug('sensitive %s' % (cls.SENSITIVE_FIELDS,))
-        log.debug('privileged %s' % (cls.PRIVILEGED_FIELDS,))
+        log.debug('Updating replace field {}'.format(field))
+        log.debug('sensitive {}'.format(cls.SENSITIVE_FIELDS))
+        log.debug('privileged {}'.format(cls.PRIVILEGED_FIELDS))
         if field in cls.SENSITIVE_FIELDS or field in cls.PRIVILEGED_FIELDS:
-            log.debug('Updating sensitive field %s' % (field,))
+            log.debug('Updating sensitive field {}'.format(field))
             if 'current_password' not in state:
                 abort(
                     code=HTTPStatus.FORBIDDEN,
@@ -224,7 +224,7 @@ class PatchUserDetailsParameters(PatchJSONParameters):
         #         pass
 
         if field in cls.PRIVILEGED_FIELDS:
-            log.debug('Updating administrator-only field %s' % (field,))
+            log.debug('Updating administrator-only field {}'.format(field))
             if not current_user.is_admin:
                 abort(
                     code=HTTPStatus.FORBIDDEN,

--- a/app/modules/users/permissions/__init__.py
+++ b/app/modules/users/permissions/__init__.py
@@ -6,11 +6,13 @@ RESTful API permissions
 """
 
 import logging
+
 from flask_sqlalchemy import BaseQuery
 from permission import Permission as BasePermission
 
-from . import rules
 from app.modules.users.permissions.types import AccessOperation
+
+from . import rules
 
 log = logging.getLogger(__name__)
 

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -5,14 +5,15 @@ RESTful API Rules
 -----------------------
 """
 import logging
+from typing import Any, Type
 
 from flask_login import current_user
-from flask_restx_patched._http import HTTPStatus
 from permission import Rule as BaseRule
-from typing import Type, Any
+
 from app.extensions.api import abort
-from app.modules import module_required, is_module_enabled
+from app.modules import is_module_enabled, module_required
 from app.modules.users.permissions.types import AccessOperation
+from flask_restx_patched._http import HTTPStatus
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/app/modules/users/schemas.py
+++ b/app/modules/users/schemas.py
@@ -6,8 +6,9 @@ User schemas
 """
 
 from flask_marshmallow import base_fields
-from flask_restx_patched import ModelSchema
+
 from app.modules import is_module_enabled
+from flask_restx_patched import ModelSchema
 
 from .models import User
 

--- a/app/modules/utils.py
+++ b/app/modules/utils.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
+import logging
 from pathlib import Path
 from typing import NoReturn, Optional, Union
-from app.extensions.api import abort
+from uuid import UUID
+
 from flask import Blueprint, Flask, current_app, request
 
-import logging
-
-from uuid import UUID
+from app.extensions.api import abort
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -44,6 +44,7 @@ humanize
 
 itsdangerous<2.1.0
 
+jinja2<3.1.0
 jsonschema==3.2.0
 
 MarkupSafe<2.1.0

--- a/app/utils.py
+++ b/app/utils.py
@@ -5,11 +5,12 @@ Houston Common utils
 --------------------------
 """
 
-from flask_login import current_user  # NOQA
-import app.extensions.logging as AuditLog  # NOQA
-
 import datetime
 import logging
+
+from flask_login import current_user  # NOQA
+
+import app.extensions.logging as AuditLog  # NOQA
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -66,8 +67,8 @@ def get_celery_tasks_scheduled(type=None):
 
 
 def get_celery_data(task_id):
-    from flask import current_app
     from celery.result import AsyncResult
+    from flask import current_app
 
     inspect = current_app.celery.control.inspect()
     workers = inspect.ping()
@@ -133,8 +134,9 @@ def get_stored_filename(input_filename):
 def nlp_parse_complex_date_time(
     text, reference_date=None, tz='UTC', time_specificity=None
 ):
-    from app.modules.complex_date_time.models import ComplexDateTime, Specificities
     from sutime import SUTime
+
+    from app.modules.complex_date_time.models import ComplexDateTime, Specificities
 
     # https://github.com/FraBle/python-sutime
     # will throw RuntimeError if jars are not there

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -13,8 +13,7 @@ import os
 from functools import lru_cache
 from pathlib import Path
 
-from .utils import import_class, export_dotenv
-
+from .utils import export_dotenv, import_class
 
 CONTEXT_ENVIRONMENT_VARIABLE = 'HOUSTON_APP_CONTEXT'
 CONFIG_CLS_MAPPER = {

--- a/config/base.py
+++ b/config/base.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import datetime
+import multiprocessing
 import os
 import random
 import string
 from pathlib import Path
-import multiprocessing
 
 import flask
 import pytz

--- a/config/codex.py
+++ b/config/codex.py
@@ -3,7 +3,7 @@
 import os
 
 from .base import (
-    SageConfig,
+    DATA_ROOT,
     AssetGroupConfig,
     BaseConfig,
     EDMConfig,
@@ -11,8 +11,8 @@ from .base import (
     EmailConfig,
     GoogleConfig,
     ReCaptchaConfig,
+    SageConfig,
     WildbookDatabaseConfig,
-    DATA_ROOT,
 )
 
 

--- a/config/mws.py
+++ b/config/mws.py
@@ -3,7 +3,7 @@
 import os
 
 from .base import (
-    SageConfig,
+    DATA_ROOT,
     AssetGroupConfig,
     BaseConfig,
     EDMConfig,
@@ -11,8 +11,8 @@ from .base import (
     EmailConfig,
     GoogleConfig,
     ReCaptchaConfig,
+    SageConfig,
     WildbookDatabaseConfig,
-    DATA_ROOT,
 )
 
 

--- a/config/utils.py
+++ b/config/utils.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-
 __all__ = (
     'export_dotenv',
     'import_class',

--- a/flask_restx_patched/__init__.py
+++ b/flask_restx_patched/__init__.py
@@ -1,25 +1,22 @@
 # -*- coding: utf-8 -*-
 from flask_restx import *  # NOQA
+
 from .api import Api  # NOQA
-from .model import Schema, DefaultHTTPErrorSchema  # NOQA
+from .model import DefaultHTTPErrorSchema, Schema  # NOQA
 
 try:
     from .model import ModelSchema  # NOQA
 except ImportError:  # pragma: no cover
     pass
 
-from .namespace import (  # NOQA
-    Namespace,  # NOQA
-    is_extension_enabled,  # NOQA
-    is_module_enabled,  # NOQA
-    extension_required,  # NOQA
-    module_required,  # NOQA
-)  # NOQA
+from .namespace import Namespace  # NOQA
+from .namespace import extension_required  # NOQA
+from .namespace import is_extension_enabled  # NOQA
+from .namespace import is_module_enabled  # NOQA
+from .namespace import module_required  # NOQA; NOQA
+from .parameters import PatchJSONParameters  # NOQA
+from .parameters import PatchJSONParametersWithPassword  # NOQA
+from .parameters import SetOperationsJSONParameters  # NOQA
 from .parameters import Parameters, PostFormParameters  # NOQA
-from .parameters import (  # NOQA
-    PatchJSONParameters,  # NOQA
-    PatchJSONParametersWithPassword,  # NOQA
-    SetOperationsJSONParameters,  # NOQA
-)  # NOQA
-from .swagger import Swagger  # NOQA
 from .resource import Resource  # NOQA
+from .swagger import Swagger  # NOQA

--- a/flask_restx_patched/api.py
+++ b/flask_restx_patched/api.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
+import logging
+
+import requests
 from flask import jsonify
+from flask import make_response as original_flask_make_response
 from flask_restx import Api as OriginalApi
 from flask_restx._http import HTTPStatus
-from flask import make_response as original_flask_make_response
 from werkzeug import cached_property
 
 from .namespace import Namespace
 from .swagger import Swagger
-
-import requests
-import logging
 
 log = logging.getLogger(__name__)
 

--- a/flask_restx_patched/model.py
+++ b/flask_restx_patched/model.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
-from apispec.ext.marshmallow.swagger import fields2jsonschema, field2property
 import flask_marshmallow
-from werkzeug import cached_property
-
+from apispec.ext.marshmallow.swagger import field2property, fields2jsonschema
 from flask_restx.model import Model as OriginalModel
+from werkzeug import cached_property
 
 
 class SchemaMixin(object):

--- a/flask_restx_patched/namespace.py
+++ b/flask_restx_patched/namespace.py
@@ -1,19 +1,20 @@
 # -*- coding: utf-8 -*-
+import os
 from functools import wraps
 
+import elasticsearch
 import flask
 import flask_marshmallow
 from flask_restx import Namespace as OriginalNamespace
-from flask_restx.utils import merge, unpack
 from flask_restx._http import HTTPStatus
+from flask_restx.utils import merge, unpack
 from webargs.flaskparser import parser as webargs_parser
 from werkzeug import cached_property  # NOQA
 from werkzeug import exceptions as http_exceptions
-import elasticsearch
-import os
 
-from .model import Model, DefaultHTTPErrorSchema
 from config import get_preliminary_config
+
+from .model import DefaultHTTPErrorSchema, Model
 
 
 def is_x_enabled(names, name_args, enabled_names):
@@ -628,7 +629,7 @@ class Namespace(OriginalNamespace):
             )
 
             return self.doc(
-                description='**REQUIRED EXTENSIONS: %s**\n\n' % (extensions,)
+                description='**REQUIRED EXTENSIONS: {}**\n\n'.format(extensions)
             )(
                 self.response(
                     code=HTTPStatus.NOT_IMPLEMENTED.value,
@@ -680,7 +681,7 @@ class Namespace(OriginalNamespace):
                 protected_func, _required_decorator
             )
 
-            return self.doc(description='**REQUIRED MODULES: %s**\n\n' % (modules,))(
+            return self.doc(description='**REQUIRED MODULES: {}**\n\n'.format(modules))(
                 self.response(
                     code=HTTPStatus.NOT_IMPLEMENTED.value,
                     description='Some required server-side modules are disabled',

--- a/flask_restx_patched/parameters.py
+++ b/flask_restx_patched/parameters.py
@@ -2,15 +2,13 @@
 # pylint: disable=missing-docstring
 import logging
 
-from six import itervalues
+import sqlalchemy as sa
 from flask import request
 from flask_login import current_user
-from flask_restx._http import HTTPStatus
 from flask_marshmallow import Schema, base_fields
-from marshmallow import validate, validates_schema, pre_load, ValidationError
-
-import sqlalchemy as sa
-
+from flask_restx._http import HTTPStatus
+from marshmallow import ValidationError, pre_load, validate, validates_schema
+from six import itervalues
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -490,7 +488,7 @@ class SetOperationsJSONParameters(Parameters):
         Performs all necessary operations by calling class methods with
         corresponding names.
         """
-        working_set = set([])
+        working_set = set()
 
         if starting_set is not None:
             for starting_obj in starting_set:

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -12,7 +12,6 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait
 
-
 TIMEOUT = int(os.getenv('TIMEOUT', 20))
 POLL_FREQUENCY = int(os.getenv('POLL_FREQUENCY', 1))
 CODEX_URL = os.getenv('CODEX_URL', 'http://localhost:84/')

--- a/integration_tests/test_social_groups.py
+++ b/integration_tests/test_social_groups.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-from . import utils
 import time
+
+from . import utils
 
 
 # Not a generic util as there has to be exactly one asset group sighting, no assets, one sighting, and three

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -146,13 +146,13 @@ def wait_for_progress(session, codex_url, response, progress_type='preparation')
 
     pprint.pprint(response.json())
 
-    progress_guid = response.json()['progress_%s' % (progress_type,)]['guid']
+    progress_guid = response.json()['progress_{}'.format(progress_type)]['guid']
 
     progress_url = codex_url(f'/api/v1/progress/{progress_guid}')
     wait_for(session.get, progress_url, lambda response: response.json()['complete'])
 
     asset_group_guid = response.json()['guid']
 
-    response = session.get(codex_url('/api/v1/asset_groups/%s/' % (asset_group_guid,)))
+    response = session.get(codex_url('/api/v1/asset_groups/{}/'.format(asset_group_guid)))
 
     return response

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-from __future__ import with_statement
+import logging
+from logging.config import fileConfig  # NOQA
+
 from alembic import context
 from sqlalchemy import engine_from_config, pool
-from logging.config import fileConfig  # NOQA
-import logging
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/migrations/versions/001eedbc2f9a_.py
+++ b/migrations/versions/001eedbc2f9a_.py
@@ -6,12 +6,11 @@ Revises: cd0bc2d4043a
 Create Date: 2021-10-04 16:42:16.522352
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '001eedbc2f9a'

--- a/migrations/versions/03cf788ac8f8_.py
+++ b/migrations/versions/03cf788ac8f8_.py
@@ -6,12 +6,11 @@ Revises: 634551347a44
 Create Date: 2022-03-15 15:24:12.242789
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '03cf788ac8f8'

--- a/migrations/versions/13241dd1fd5b_adding_social_group.py
+++ b/migrations/versions/13241dd1fd5b_adding_social_group.py
@@ -6,12 +6,11 @@ Revises: 922f78ec3698
 Create Date: 2021-10-26 15:15:10.855822
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '13241dd1fd5b'

--- a/migrations/versions/13e7f8e7bcf8_.py
+++ b/migrations/versions/13e7f8e7bcf8_.py
@@ -6,12 +6,11 @@ Revises: a6b1cfd945f2
 Create Date: 2021-05-14 23:00:10.459326
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '13e7f8e7bcf8'

--- a/migrations/versions/19dd4e2c1e63_.py
+++ b/migrations/versions/19dd4e2c1e63_.py
@@ -6,9 +6,8 @@ Revises: e9df5182903a
 Create Date: 2022-02-15 00:05:23.174018
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '19dd4e2c1e63'

--- a/migrations/versions/214ba937eadf_.py
+++ b/migrations/versions/214ba937eadf_.py
@@ -6,12 +6,11 @@ Revises: 13241dd1fd5b
 Create Date: 2021-11-17 21:11:24.715282
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '214ba937eadf'

--- a/migrations/versions/272bc58baeff_relationship_type_roles_guid.py
+++ b/migrations/versions/272bc58baeff_relationship_type_roles_guid.py
@@ -9,12 +9,11 @@ Create Date: 2022-04-12 15:51:41.958648
 import json
 import uuid
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '272bc58baeff'

--- a/migrations/versions/2a02d5f72c3b_.py
+++ b/migrations/versions/2a02d5f72c3b_.py
@@ -6,9 +6,8 @@ Revises: 628399bcec88
 Create Date: 2021-07-26 13:37:11.516001
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '2a02d5f72c3b'

--- a/migrations/versions/2d3ba401d0f0_.py
+++ b/migrations/versions/2d3ba401d0f0_.py
@@ -6,9 +6,8 @@ Revises: 4b2d7014d79e
 Create Date: 2021-08-20 13:09:29.168663
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '2d3ba401d0f0'

--- a/migrations/versions/2ef73ff71f0c_.py
+++ b/migrations/versions/2ef73ff71f0c_.py
@@ -6,12 +6,11 @@ Revises: 9ff1b7326151
 Create Date: 2021-12-17 02:10:05.796710
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '2ef73ff71f0c'

--- a/migrations/versions/32145d0959ae_audit_log.py
+++ b/migrations/versions/32145d0959ae_audit_log.py
@@ -6,12 +6,11 @@ Revises: 2d3ba401d0f0
 Create Date: 2021-09-01 14:41:25.158199
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '32145d0959ae'

--- a/migrations/versions/329c594dd8d7_.py
+++ b/migrations/versions/329c594dd8d7_.py
@@ -6,12 +6,11 @@ Revises: f5240055f6f0
 Create Date: 2021-09-29 10:08:35.246908
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '329c594dd8d7'

--- a/migrations/versions/3c74d2d3214a_initial_database.py
+++ b/migrations/versions/3c74d2d3214a_initial_database.py
@@ -6,13 +6,12 @@ Revises: None
 Create Date: 2021-04-27 12:38:21.490885
 
 """
-from alembic import op
 import sqlalchemy as sa
 import sqlalchemy_utils
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '3c74d2d3214a_initial_database'

--- a/migrations/versions/3fc0b28658aa_.py
+++ b/migrations/versions/3fc0b28658aa_.py
@@ -6,13 +6,12 @@ Revises: 804d984e9dd4
 Create Date: 2022-01-25 09:09:17.621655
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
 
 import app
 import app.extensions
-from sqlalchemy.dialects import postgresql
-
 
 # revision identifiers, used by Alembic.
 revision = '3fc0b28658aa'

--- a/migrations/versions/47a80ead3a90_.py
+++ b/migrations/versions/47a80ead3a90_.py
@@ -6,12 +6,11 @@ Revises: 4aa284fa3f72
 Create Date: 2022-01-11 23:41:19.450220
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '47a80ead3a90'

--- a/migrations/versions/49c704ff6fa9_sighting_name.py
+++ b/migrations/versions/49c704ff6fa9_sighting_name.py
@@ -6,9 +6,8 @@ Revises: 7d391a027bd4
 Create Date: 2021-07-20 13:46:26.545335
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '49c704ff6fa9'

--- a/migrations/versions/4aa284fa3f72_.py
+++ b/migrations/versions/4aa284fa3f72_.py
@@ -6,12 +6,11 @@ Revises: 973184c68d5e
 Create Date: 2021-12-28 17:14:56.872762
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '4aa284fa3f72'

--- a/migrations/versions/4b2d7014d79e_.py
+++ b/migrations/versions/4b2d7014d79e_.py
@@ -6,12 +6,11 @@ Revises: b011bd72aadd
 Create Date: 2021-08-16 19:26:54.317352
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '4b2d7014d79e'

--- a/migrations/versions/52af6deb082b_remove_annot_jobs.py
+++ b/migrations/versions/52af6deb082b_remove_annot_jobs.py
@@ -6,9 +6,8 @@ Revises: 47a80ead3a90
 Create Date: 2022-01-14 17:48:10.807644
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '52af6deb082b'

--- a/migrations/versions/58bf0e49cbf7_adding_sighting_stage.py
+++ b/migrations/versions/58bf0e49cbf7_adding_sighting_stage.py
@@ -6,9 +6,8 @@ Revises: adb5d1a314bc
 Create Date: 2021-06-07 19:52:25.795223
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '58bf0e49cbf7'

--- a/migrations/versions/5c2ffe7143c9_.py
+++ b/migrations/versions/5c2ffe7143c9_.py
@@ -6,12 +6,11 @@ Revises: 13e7f8e7bcf8
 Create Date: 2021-05-18 10:54:07.907512
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '5c2ffe7143c9'

--- a/migrations/versions/628399bcec88_linking_sightings_to_asset_group_.py
+++ b/migrations/versions/628399bcec88_linking_sightings_to_asset_group_.py
@@ -6,12 +6,11 @@ Revises: 49c704ff6fa9
 Create Date: 2021-07-21 14:35:34.087065
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '628399bcec88'

--- a/migrations/versions/634551347a44_remove_extension.py
+++ b/migrations/versions/634551347a44_remove_extension.py
@@ -6,9 +6,8 @@ Revises: ea69d76faa6b
 Create Date: 2022-03-11 10:17:08.567099
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '634551347a44'

--- a/migrations/versions/65f9621bd3dd_.py
+++ b/migrations/versions/65f9621bd3dd_.py
@@ -6,9 +6,8 @@ Revises: f788098878ac
 Create Date: 2022-05-13 10:30:15.136596
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '65f9621bd3dd'

--- a/migrations/versions/7d391a027bd4_.py
+++ b/migrations/versions/7d391a027bd4_.py
@@ -6,12 +6,11 @@ Revises: a7396fa56571
 Create Date: 2021-07-01 09:11:57.821816
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '7d391a027bd4'

--- a/migrations/versions/804d984e9dd4_.py
+++ b/migrations/versions/804d984e9dd4_.py
@@ -6,9 +6,8 @@ Revises: 52af6deb082b
 Create Date: 2022-01-19 00:38:15.978803
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '804d984e9dd4'

--- a/migrations/versions/88244eed06d0_.py
+++ b/migrations/versions/88244eed06d0_.py
@@ -6,12 +6,11 @@ Revises: 2ef73ff71f0c
 Create Date: 2021-12-20 20:08:32.545465
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '88244eed06d0'

--- a/migrations/versions/8bea1f7d2e44_.py
+++ b/migrations/versions/8bea1f7d2e44_.py
@@ -6,12 +6,11 @@ Revises: 5c2ffe7143c9
 Create Date: 2021-05-20 08:08:01.140046
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '8bea1f7d2e44'

--- a/migrations/versions/922f78ec3698_.py
+++ b/migrations/versions/922f78ec3698_.py
@@ -6,12 +6,11 @@ Revises: 001eedbc2f9a
 Create Date: 2021-10-21 20:53:12.360366
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '922f78ec3698'

--- a/migrations/versions/973184c68d5e_.py
+++ b/migrations/versions/973184c68d5e_.py
@@ -6,12 +6,11 @@ Revises: 88244eed06d0
 Create Date: 2022-01-04 20:51:52.814904
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '973184c68d5e'

--- a/migrations/versions/9a6d8b560a5a_remove_houston_config.py
+++ b/migrations/versions/9a6d8b560a5a_remove_houston_config.py
@@ -6,11 +6,10 @@ Revises: fd467d5e0812
 Create Date: 2022-03-18 20:47:33.020537
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '9a6d8b560a5a'

--- a/migrations/versions/9b2a1efceeec_.py
+++ b/migrations/versions/9b2a1efceeec_.py
@@ -6,12 +6,11 @@ Revises: 8bea1f7d2e44
 Create Date: 2021-05-20 15:46:22.561781
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = '9b2a1efceeec'

--- a/migrations/versions/9e71ecc2708a_.py
+++ b/migrations/versions/9e71ecc2708a_.py
@@ -11,7 +11,6 @@ from alembic import op
 import app
 import app.extensions
 
-
 # revision identifiers, used by Alembic.
 revision = '9e71ecc2708a'
 down_revision = '9b2a1efceeec'

--- a/migrations/versions/9ff1b7326151_.py
+++ b/migrations/versions/9ff1b7326151_.py
@@ -6,9 +6,8 @@ Revises: cccb5639bfd9
 Create Date: 2021-12-08 14:48:49.256743
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '9ff1b7326151'

--- a/migrations/versions/a6b1cfd945f2_addition_of_assetgroupsightings_tables.py
+++ b/migrations/versions/a6b1cfd945f2_addition_of_assetgroupsightings_tables.py
@@ -6,12 +6,11 @@ Revises: 3c74d2d3214a_initial_database
 Create Date: 2021-05-05 18:33:04.385872
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = 'a6b1cfd945f2'

--- a/migrations/versions/a7396fa56571_.py
+++ b/migrations/versions/a7396fa56571_.py
@@ -6,9 +6,8 @@ Revises: 58bf0e49cbf7
 Create Date: 2021-06-28 16:52:08.158630
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'a7396fa56571'

--- a/migrations/versions/adb5d1a314bc_.py
+++ b/migrations/versions/adb5d1a314bc_.py
@@ -6,9 +6,8 @@ Revises: fa952f537929
 Create Date: 2021-06-03 23:26:29.091559
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'adb5d1a314bc'

--- a/migrations/versions/afedda6596b9_.py
+++ b/migrations/versions/afedda6596b9_.py
@@ -6,12 +6,11 @@ Revises: cc1f915cde87
 Create Date: 2022-05-16 23:17:52.659466
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = 'afedda6596b9'

--- a/migrations/versions/b011bd72aadd_notification_preferences.py
+++ b/migrations/versions/b011bd72aadd_notification_preferences.py
@@ -6,12 +6,11 @@ Revises: d4b6b2afa11d
 Create Date: 2021-08-16 18:40:24.897375
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = 'b011bd72aadd'

--- a/migrations/versions/b58abf228d55_delete_creator_collaborationuserassociations.py
+++ b/migrations/versions/b58abf228d55_delete_creator_collaborationuserassociations.py
@@ -8,9 +8,8 @@ Create Date: 2022-04-29 08:21:34.416039
 """
 import uuid
 
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'b58abf228d55'

--- a/migrations/versions/b823ccfc2d9b_.py
+++ b/migrations/versions/b823ccfc2d9b_.py
@@ -6,9 +6,8 @@ Revises: 2a02d5f72c3b
 Create Date: 2021-08-10 05:37:19.652762
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'b823ccfc2d9b'

--- a/migrations/versions/c875a096ef76_.py
+++ b/migrations/versions/c875a096ef76_.py
@@ -6,9 +6,8 @@ Revises: ce5c26b34f15
 Create Date: 2022-05-05 07:04:48.266281
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'c875a096ef76'

--- a/migrations/versions/caf961b9ac34_.py
+++ b/migrations/versions/caf961b9ac34_.py
@@ -6,9 +6,8 @@ Revises: 32145d0959ae
 Create Date: 2021-09-09 14:51:16.383863
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'caf961b9ac34'

--- a/migrations/versions/cc1f915cde87_.py
+++ b/migrations/versions/cc1f915cde87_.py
@@ -6,12 +6,11 @@ Revises: ce5c26b34f15
 Create Date: 2022-05-05 19:33:23.318457
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = 'cc1f915cde87'
@@ -120,10 +119,8 @@ def downgrade():
         "CREATE TYPE assetgroupsightingstage AS ENUM('unknown', 'detection', 'curation', 'processed', 'failed')"
     )
     op.execute(
-        (
-            'ALTER TABLE asset_group_sighting ALTER COLUMN stage TYPE assetgroupsightingstage USING '
-            'stage::text::assetgroupsightingstage'
-        )
+        'ALTER TABLE asset_group_sighting ALTER COLUMN stage TYPE assetgroupsightingstage USING '
+        'stage::text::assetgroupsightingstage'
     )
     op.execute('DROP TYPE assetgroupsightingstage_old')
     # ### end Alembic commands ###

--- a/migrations/versions/cccb5639bfd9_.py
+++ b/migrations/versions/cccb5639bfd9_.py
@@ -6,12 +6,11 @@ Revises: 214ba937eadf
 Create Date: 2021-12-02 23:06:23.742054
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = 'cccb5639bfd9'

--- a/migrations/versions/cd0bc2d4043a_.py
+++ b/migrations/versions/cd0bc2d4043a_.py
@@ -6,12 +6,11 @@ Revises: 329c594dd8d7
 Create Date: 2021-09-27 18:38:39.616025
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = 'cd0bc2d4043a'

--- a/migrations/versions/ce5c26b34f15_.py
+++ b/migrations/versions/ce5c26b34f15_.py
@@ -6,13 +6,12 @@ Revises: b58abf228d55
 Create Date: 2022-04-29 17:33:52.397614
 
 """
-from alembic import op
 import sqlalchemy as sa
 import sqlalchemy_utils  # noqa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = 'ce5c26b34f15'

--- a/migrations/versions/d4b6b2afa11d_.py
+++ b/migrations/versions/d4b6b2afa11d_.py
@@ -6,12 +6,11 @@ Revises: b823ccfc2d9b
 Create Date: 2021-08-13 23:35:11.947441
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = 'd4b6b2afa11d'

--- a/migrations/versions/e492faa9e63a_.py
+++ b/migrations/versions/e492faa9e63a_.py
@@ -6,12 +6,11 @@ Revises: 3fc0b28658aa
 Create Date: 2022-02-08 10:05:57.487115
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = 'e492faa9e63a'

--- a/migrations/versions/e83e2897dd6c_.py
+++ b/migrations/versions/e83e2897dd6c_.py
@@ -6,9 +6,8 @@ Revises: caf961b9ac34
 Create Date: 2021-09-10 17:03:14.518622
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'e83e2897dd6c'

--- a/migrations/versions/e9df5182903a_.py
+++ b/migrations/versions/e9df5182903a_.py
@@ -6,9 +6,8 @@ Revises: e492faa9e63a
 Create Date: 2022-02-10 00:46:18.247165
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'e9df5182903a'

--- a/migrations/versions/ea69d76faa6b_.py
+++ b/migrations/versions/ea69d76faa6b_.py
@@ -6,12 +6,11 @@ Revises: e9df5182903a
 Create Date: 2022-02-15 18:06:43.928793
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = 'ea69d76faa6b'

--- a/migrations/versions/ed7b9eb99d21_.py
+++ b/migrations/versions/ed7b9eb99d21_.py
@@ -9,7 +9,6 @@ Create Date: 2022-04-26 09:54:19.649695
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-
 # revision identifiers, used by Alembic.
 revision = 'ed7b9eb99d21'
 down_revision = '272bc58baeff'

--- a/migrations/versions/f2d512a7ccdd_jobcontrol.py
+++ b/migrations/versions/f2d512a7ccdd_jobcontrol.py
@@ -6,12 +6,11 @@ Revises: 9e71ecc2708a
 Create Date: 2021-06-01 15:32:32.996776
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = 'f2d512a7ccdd'

--- a/migrations/versions/f5240055f6f0_.py
+++ b/migrations/versions/f5240055f6f0_.py
@@ -6,12 +6,11 @@ Revises: e83e2897dd6c
 Create Date: 2021-09-14 21:45:04.121837
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = 'f5240055f6f0'

--- a/migrations/versions/f788098878ac_.py
+++ b/migrations/versions/f788098878ac_.py
@@ -6,9 +6,8 @@ Revises: c875a096ef76
 Create Date: 2022-05-06 22:24:51.978020
 
 """
-from alembic import op
 import sqlalchemy as sa
-
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'f788098878ac'

--- a/migrations/versions/fa952f537929_.py
+++ b/migrations/versions/fa952f537929_.py
@@ -6,12 +6,11 @@ Revises: f2d512a7ccdd
 Create Date: 2021-06-02 16:00:18.342313
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = 'fa952f537929'

--- a/migrations/versions/fd467d5e0812_.py
+++ b/migrations/versions/fd467d5e0812_.py
@@ -6,12 +6,11 @@ Revises: 19dd4e2c1e63
 Create Date: 2022-04-06 10:25:46.398750
 
 """
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 import app
 import app.extensions
-
 
 # revision identifiers, used by Alembic.
 revision = 'fd467d5e0812'

--- a/scripts/docs/generate_models_graph.py
+++ b/scripts/docs/generate_models_graph.py
@@ -47,7 +47,7 @@ for model in get_models():
         pydot.Node(
             model.__name__.lower(),
             fontsize='10',
-            label='{%s|%s}' % (model.__name__, '\n'.join(column_names)),
+            label='{{{}|{}}}'.format(model.__name__, '\n'.join(column_names)),
             shape='record',
         )
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,15 @@ verbose = false
 skip-string-normalization = true
 single-quotes = true
 
+[tool:isort]
+profile = black
+line_length = 90
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+
 [tool:pytest]
 minversion = 5.4
 addopts = -v -p no:doctest --xdoctest --xdoctest-style=google --random-order --random-order-bucket=global --cov=./ --cov-report html -m "not separate" --durations=0 --durations-min=3.0 --color=yes --code-highlight=yes --show-capture=log -ra

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, print_function, division
-import subprocess
+from __future__ import absolute_import, division, print_function
+
 import os
+import subprocess
 
 from setuptools import setup
-
 
 PROJECT_ROOT = os.path.abspath(os.path.dirname(__file__))
 
@@ -69,7 +69,7 @@ REVISION = git_version()
 SUFFIX = REVISION[:8]
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 if SUFFIX:
-    VERSION = '%s.%s' % (VERSION, SUFFIX)
+    VERSION = '{}.{}'.format(VERSION, SUFFIX)
 PACKAGES = ['.']
 
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -11,8 +11,8 @@ import platform
 try:
     import rich
     from rich.logging import RichHandler
-    from rich.theme import Theme
     from rich.style import Style
+    from rich.theme import Theme
 
     console_kwargs = {
         'theme': Theme(

--- a/tasks/app/__init__.py
+++ b/tasks/app/__init__.py
@@ -6,9 +6,9 @@ Application related tasks for Invoke.
 from invoke import Collection
 
 from config import get_preliminary_config
-
 from tasks.app import (
     assets,
+    audit_logs,
     boilerplates,
     config,
     db,
@@ -18,7 +18,6 @@ from tasks.app import (
     fileuploads,
     initial_development_data,
     job_control,
-    audit_logs,
     run,
     shell,
     site_settings,
@@ -26,7 +25,6 @@ from tasks.app import (
     tus,
     users,
 )
-
 
 namespace = Collection(
     assets,

--- a/tasks/app/audit_logs.py
+++ b/tasks/app/audit_logs.py
@@ -29,9 +29,10 @@ def all(context):
 @app_context_task()
 def all_faults(context):
     """Print out all of the audit log faults"""
-    from app.modules.audit_logs.models import AuditLog
-    import app.extensions.logging as AuditLogExtension  # NOQA
     from sqlalchemy import desc
+
+    import app.extensions.logging as AuditLogExtension  # NOQA
+    from app.modules.audit_logs.models import AuditLog
 
     faults = (
         AuditLog.query.filter(

--- a/tasks/app/boilerplates.py
+++ b/tasks/app/boilerplates.py
@@ -78,7 +78,7 @@ def crud_module(context, module_name='', module_name_singular=''):
             module_title=module_title,
             module_namespace=module_name.replace('_', '-'),
             model_name=model_name,
-        ).dump('%s/%s.py' % (module_path, template_file))
+        ).dump('{}/{}.py'.format(module_path, template_file))
 
     log.info('Module `%s` has been created.', module_name)
     print(

--- a/tasks/app/config.py
+++ b/tasks/app/config.py
@@ -11,8 +11,9 @@ def show(context):
     """
     Show application configuration data
     """
-    from flask import current_app
     from functools import reduce
+
+    from flask import current_app
 
     config = current_app.config
     max_key_len = reduce(

--- a/tasks/app/db.py
+++ b/tasks/app/db.py
@@ -12,18 +12,17 @@ import shutil
 
 from tasks.utils import app_context_task
 
-
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 try:
     from alembic import __version__ as __alembic_version__
-    from alembic.config import Config as AlembicConfig
     from alembic import command
+    from alembic.config import Config as AlembicConfig
 except ImportError:  # pragma: no cover
     log.warning("Alembic cannot be imported, so some app.db.* tasks won't be available!")
 else:
 
-    alembic_version = tuple([int(v) for v in __alembic_version__.split('.')[0:3]])
+    alembic_version = tuple(int(v) for v in __alembic_version__.split('.')[0:3])
 
     class Config(AlembicConfig):
         """
@@ -454,6 +453,7 @@ def _reset(context):
     Delete the filesystem database and re-initialize
     """
     from flask import current_app
+
     from tasks.app.run import warmup
 
     delete_path_configs = [

--- a/tasks/app/db_templates/flask/env.py
+++ b/tasks/app/db_templates/flask/env.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-from __future__ import with_statement
+import logging
+from logging.config import fileConfig  # NOQA
+
 from alembic import context
 from sqlalchemy import engine_from_config, pool
-from logging.config import fileConfig  # NOQA
-import logging
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.

--- a/tasks/app/elasticsearch.py
+++ b/tasks/app/elasticsearch.py
@@ -21,7 +21,7 @@ def _get_available_model_mappings():
             available[name] = registered_model
         else:
             for registered_model in registered_models:
-                unique_name = '%s.%s' % (
+                unique_name = '{}.{}'.format(
                     registered_model.__module__,
                     registered_model.__name__,
                 )
@@ -44,7 +44,7 @@ def _index_worker(model=None, **kwargs):
             model_cls = available.get(model, None)
 
             if model_cls is None:
-                print('Model must be one of %r' % (set(available.keys()),))
+                print('Model must be one of {!r}'.format(set(available.keys())))
             else:
                 model_cls.index_all()
 
@@ -62,7 +62,7 @@ def _prune_worker(model=None):
             model_cls = available.get(model, None)
 
             if model_cls is None:
-                print('Model must be one of %r' % (set(available.keys()),))
+                print('Model must be one of {!r}'.format(set(available.keys())))
             else:
                 model_cls.prune_all()
 
@@ -79,7 +79,7 @@ def _invalidate_worker(model=None):
         model_cls = available.get(model, None)
 
         if model_cls is None:
-            print('Model must be one of %r' % (set(available.keys()),))
+            print('Model must be one of {!r}'.format(set(available.keys())))
         else:
             model_cls.invalidate_all()
 
@@ -93,8 +93,9 @@ def status(context, model=None):
     """
     Get the status from Elasticsearch
     """
-    from app.extensions import elasticsearch as es
     import utool as ut
+
+    from app.extensions import elasticsearch as es
 
     status = es.es_status(missing=True)
     print(ut.repr3(status))
@@ -182,11 +183,11 @@ def delete_index(context, model=None):
         model_cls = available.get(model, None)
 
         if model_cls is None:
-            print('Model must be one of %r' % (set(available.keys()),))
+            print('Model must be one of {!r}'.format(set(available.keys())))
         else:
             indices.append(model_cls._index())
 
     if len(indices) > 0:
         for index in indices:
-            print('Deleting ES index %r' % (index,))
+            print('Deleting ES index {!r}'.format(index))
             es.es_delete_index(index)

--- a/tasks/app/email.py
+++ b/tasks/app/email.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from tasks.utils import app_context_task
-from app.modules.emails.models import EmailTypes
 from app.extensions.email import Email
+from app.modules.emails.models import EmailTypes
 from app.modules.site_settings.models import SiteSetting
+from tasks.utils import app_context_task
 
 
 @app_context_task(

--- a/tasks/app/initial_development_data.py
+++ b/tasks/app/initial_development_data.py
@@ -5,10 +5,9 @@ This file contains initialization data for development usage only.
 
 You can execute this code via ``invoke app.db.init_development_data``
 """
-from app.extensions import db, api
-
 import uuid
 
+from app.extensions import api, db
 
 DOCUMENTATION_CLIENT_GUID = uuid.UUID('00000000-0000-0000-0000-000000000000')
 DOCUMENTATION_CLIENT_SECRET = 'SECRET'
@@ -74,8 +73,8 @@ def init_auth(docs_user):
 
 
 def init():
-    from app.modules.users.models import User
     from app.modules.auth.models import OAuth2Client
+    from app.modules.users.models import User
 
     # Automatically update `default_scopes` for `documentation` OAuth2 Client,
     # as it is nice to have an ability to evaluate all available API calls.

--- a/tasks/app/job_control.py
+++ b/tasks/app/job_control.py
@@ -3,9 +3,10 @@
 Application Job_control related tasks for Invoke.
 """
 
-from tasks.utils import app_context_task
-from app.utils import HoustonException
 import pprint
+
+from app.utils import HoustonException
+from tasks.utils import app_context_task
 
 
 @app_context_task()

--- a/tasks/app/run.py
+++ b/tasks/app/run.py
@@ -8,14 +8,12 @@ try:
     from importlib import reload
 except ImportError:  # pragma: no cover
     pass  # Python 2 has built-in reload() function
+import logging
 import os
 import platform
-import logging
+
 from flask_restx_patched import is_extension_enabled
-
-
 from tasks.utils import app_context_task
-
 
 log = logging.getLogger(__name__)
 
@@ -25,8 +23,9 @@ DEFAULT_HOST = '0.0.0.0'
 
 def hide_noisy_endpoint_logs():
     """Disable logs for requests to specific endpoints."""
-    from werkzeug import serving
     import re
+
+    from werkzeug import serving
 
     disabled_endpoints = (
         '/api/v1/site-settings/heartbeat',
@@ -76,7 +75,7 @@ def warmup(
     if print_routes or app.debug:
         log.info('Using route rules:')
         for rule in app.url_map.iter_rules():
-            log.info('\t%r' % (rule,))
+            log.info('\t{!r}'.format(rule))
 
     return app
 

--- a/tasks/app/shell.py
+++ b/tasks/app/shell.py
@@ -3,7 +3,6 @@ import logging
 
 from invoke import task
 
-
 log = logging.getLogger(__name__)
 
 
@@ -11,6 +10,7 @@ log = logging.getLogger(__name__)
 def shell(context):
     """Enter into IPython Shell with an initialized app"""
     import IPython
+
     from app import create_app
 
     app = create_app()

--- a/tasks/app/site_settings.py
+++ b/tasks/app/site_settings.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from app.extensions import db
-
-from tasks.utils import app_context_task
 from app.modules.fileuploads.models import FileUpload  # NOQA
 from app.modules.site_settings.models import SiteSetting  # NOQA
+from tasks.utils import app_context_task
 
 
 @app_context_task(

--- a/tasks/app/tus.py
+++ b/tasks/app/tus.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-from tasks.utils import app_context_task
-from app.utils import sizeof
 import logging
+
+from app.utils import sizeof
+from tasks.utils import app_context_task
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -11,15 +12,16 @@ def cache_info(context, model=None):
     """
     Get the status of the Tus cache folder
     """
-    from app.modules.users.models import User
-    from app.extensions import tus
-    from flask import current_app
-    import humanize
     import datetime
     import json
     import os
-
     import time
+
+    import humanize
+    from flask import current_app
+
+    from app.extensions import tus
+    from app.modules.users.models import User
 
     tus_directory = tus.tus_upload_dir(current_app)
 

--- a/tasks/app/users.py
+++ b/tasks/app/users.py
@@ -37,8 +37,8 @@ def add_role(context, email, role):
     """
     Update a given user (email) to have a role (Admin, Staff, Internal, Researcher, Contributor, Exporter)
     """
-    from app.modules.users.models import User
     from app.extensions import db
+    from app.modules.users.models import User
 
     user = User.find(email=email)
 
@@ -50,7 +50,7 @@ def add_role(context, email, role):
     role = role.lower()
 
     if role in ['admin', 'administrator']:
-        print('Found user:\n\t%r' % (user,))
+        print('Found user:\n\t{!r}'.format(user))
         answer = input(
             'Are you sure you want to promote the above found user to a site administrator? [Y / N]: '
         )
@@ -87,8 +87,8 @@ def remove_role(context, email, role):
     """
     Update a given user (email) to not have a role (Admin, Staff, Internal, Researcher, Contributor, Exporter)
     """
-    from app.modules.users.models import User
     from app.extensions import db
+    from app.modules.users.models import User
 
     user = User.find(email=email)
 
@@ -126,8 +126,8 @@ def create_oauth2_client(context, email, guid, secret, default_scopes=None):
     """
     Create a new OAuth2 Client associated with a given user (email).
     """
-    from app.modules.users.models import User
     from app.modules.auth.models import OAuth2Client
+    from app.modules.users.models import User
 
     user = User.find(email=email)
 

--- a/tasks/codex/__init__.py
+++ b/tasks/codex/__init__.py
@@ -6,7 +6,6 @@ Application related tasks for Invoke.
 from invoke import Collection
 
 from config import get_preliminary_config
-
 from tasks.app import run
 from tasks.codex import (
     asset_groups,
@@ -17,13 +16,12 @@ from tasks.codex import (
     initialize,
     integrations,
     integrity,
-    organizations,
     job_control,
+    organizations,
     progress,
     projects,
     sightings,
 )
-
 
 namespace = Collection(
     asset_groups,

--- a/tasks/codex/consistency.py
+++ b/tasks/codex/consistency.py
@@ -6,11 +6,11 @@ This file contains initialization data for development usage only.
 You can execute this code via ``invoke codex.consistency``
 """
 import logging
-import tqdm
 
-from app.extensions import db
+import tqdm
 from flask import current_app
 
+from app.extensions import db
 from tasks.utils import app_context_task
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
@@ -69,8 +69,9 @@ def user_staff_permissions(context):
 
 @app_context_task
 def cleanup_gitlab(context, dryrun=False, clean=False):
-    import gitlab
     import datetime
+
+    import gitlab
     import pytz
 
     TEST_GROUP_NAMES = ['TEST']
@@ -89,7 +90,7 @@ def cleanup_gitlab(context, dryrun=False, clean=False):
 
     gl = gitlab.Gitlab(remote_uri, private_token=remote_personal_access_token)
     gl.auth()
-    log.info('Logged in: %r' % (gl,))
+    log.info('Logged in: {!r}'.format(gl))
 
     projects = []
     groups = gl.groups.list()

--- a/tasks/codex/elasticsearch.py
+++ b/tasks/codex/elasticsearch.py
@@ -3,8 +3,9 @@
 Application Users management related tasks for Invoke.
 """
 
-from tasks.utils import app_context_task
 import datetime
+
+from tasks.utils import app_context_task
 
 
 @app_context_task(

--- a/tasks/codex/integrations.py
+++ b/tasks/codex/integrations.py
@@ -5,7 +5,6 @@ import sys
 
 from tasks.utils import app_context_task
 
-
 log = logging.getLogger(__name__)
 
 

--- a/tasks/codex/integrity.py
+++ b/tasks/codex/integrity.py
@@ -3,9 +3,10 @@
 Application AssetGroup management related tasks for Invoke.
 """
 
-from tasks.utils import app_context_task
-from app.extensions import db
 import pprint
+
+from app.extensions import db
+from tasks.utils import app_context_task
 
 
 def print_result(result):

--- a/tasks/codex/job_control.py
+++ b/tasks/codex/job_control.py
@@ -3,8 +3,9 @@
 Application Codex Job_control related tasks for Invoke.
 """
 
-from tasks.utils import app_context_task
 import pprint
+
+from tasks.utils import app_context_task
 
 
 def _get_jobs(model, stage, guid=None):

--- a/tasks/codex/sightings.py
+++ b/tasks/codex/sightings.py
@@ -3,8 +3,9 @@
 Application AssetGroup management related tasks for Invoke.
 """
 
-from tasks.utils import app_context_task
 import pprint
+
+from tasks.utils import app_context_task
 
 
 @app_context_task

--- a/tasks/dependencies.py
+++ b/tasks/dependencies.py
@@ -6,7 +6,6 @@ import logging
 
 from invoke import task
 
-
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 
@@ -33,7 +32,7 @@ def install_frontend_ui(context, on_error='raise'):
     except Exception as ex:
         if on_error in ['raise']:
             raise ex
-        log.warning('Front-end UI failed to install. (on_error = %r)' % (on_error,))
+        log.warning('Front-end UI failed to install. (on_error = {!r})'.format(on_error))
 
 
 @task
@@ -49,7 +48,7 @@ def install_swagger_ui(context, on_error='raise'):
     except Exception as ex:
         if on_error in ['raise']:
             raise ex
-        log.warning('Swagger UI failed to install. (on_error = %r)' % (on_error,))
+        log.warning('Swagger UI failed to install. (on_error = {!r})'.format(on_error))
 
 
 @task

--- a/tasks/docker_compose.py
+++ b/tasks/docker_compose.py
@@ -4,10 +4,9 @@ docker-compose tasks for invoke
 """
 import logging
 
+import yaml
 from invoke import task
 from invoke.exceptions import Exit
-import yaml
-
 
 logger = logging.getLogger(__name__)
 

--- a/tasks/edm.py
+++ b/tasks/edm.py
@@ -3,8 +3,9 @@
 Application EDM related tasks for Invoke.
 """
 
-from tasks.utils import app_context_task
 from flask import current_app as app
+
+from tasks.utils import app_context_task
 
 
 @app_context_task()

--- a/tasks/mws/__init__.py
+++ b/tasks/mws/__init__.py
@@ -6,14 +6,8 @@ Application related tasks for Invoke.
 from invoke import Collection
 
 from config import get_preliminary_config
-
 from tasks.app import run
-from tasks.mws import (
-    consistency,
-    initialize,
-    integrations,
-)
-
+from tasks.mws import consistency, initialize, integrations
 
 namespace = Collection(
     consistency,

--- a/tasks/mws/consistency.py
+++ b/tasks/mws/consistency.py
@@ -6,6 +6,7 @@ This file contains initialization data for development usage only.
 You can execute this code via ``invoke mws.consistency``
 """
 import logging
+
 from tasks.utils import app_context_task
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name

--- a/tasks/mws/integrations.py
+++ b/tasks/mws/integrations.py
@@ -4,7 +4,6 @@ import sys
 
 from tasks.utils import app_context_task
 
-
 log = logging.getLogger(__name__)
 
 

--- a/tasks/sage.py
+++ b/tasks/sage.py
@@ -3,10 +3,12 @@
 Application Sage related tasks for Invoke.
 """
 
-from tasks.utils import app_context_task
-from flask import current_app
-import app
 import logging
+
+from flask import current_app
+
+import app
+from tasks.utils import app_context_task
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -33,7 +35,7 @@ def _sync_worker(model=None, **kwargs):
         model_cls = available.get(model, None)
 
         if model_cls is None:
-            print('Model must be one of %r' % (set(available.keys()),))
+            print('Model must be one of {!r}'.format(set(available.keys())))
         else:
             model_cls.sync_all_with_sage(**kwargs)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -6,6 +6,5 @@ The Application tests collection
 # Get all of the nice log formatting with Rich
 import tasks  # NOQA
 
-
 TEST_ASSET_GROUP_UUID = '00000000-0000-0000-0000-000000000003'
 TEST_EMPTY_ASSET_GROUP_UUID = '00000000-0000-0000-0000-000000000001'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,28 +1,23 @@
 # -*- coding: utf-8 -*-
-from importlib import import_module
+import logging
 import os
 import pathlib
 import tempfile
-import uuid
 import time
+import uuid
+import warnings
+from importlib import import_module
 from unittest import mock
 
-import logging
-import warnings
-import sqlalchemy
 import pytest
+import sqlalchemy
 from flask_login import current_user, login_user, logout_user
-from flask_restx_patched import is_module_enabled, is_extension_enabled
 
 from app import create_app
 from config import CONTEXT_ENVIRONMENT_VARIABLE, VALID_CONTEXTS
+from flask_restx_patched import is_extension_enabled, is_module_enabled
 
-from . import (
-    utils,
-    TEST_ASSET_GROUP_UUID,
-    TEST_EMPTY_ASSET_GROUP_UUID,
-)
-
+from . import TEST_ASSET_GROUP_UUID, TEST_EMPTY_ASSET_GROUP_UUID, utils
 
 log = logging.getLogger('pytest.conftest')  # pylint: disable=invalid-name
 
@@ -336,7 +331,7 @@ def flask_app(gitlab_remote_login_pat, disable_elasticsearch):
                 indices = es.es_all_indices()
                 for index in indices:
                     if index.startswith(es.TESTING_PREFIX):
-                        log.debug('Cleaning up test index %r' % (index,))
+                        log.debug('Cleaning up test index {!r}'.format(index))
                         es.es_delete_index(index, app=app)
 
             # Drop all tables
@@ -566,8 +561,8 @@ def ensure_asset_group_repo(flask_app, db, asset_group, file_data=[]):
         print('Gitlab unavailable, skip git_push')
         return
 
+    from app.extensions.git_store.tasks import ensure_remote, git_push
     from app.extensions.gitlab import GitlabInitializationError
-    from app.extensions.git_store.tasks import git_push, ensure_remote
 
     asset_group.ensure_repository()
     # Call ensure_remote without .delay in tests to do it in the foreground
@@ -629,9 +624,9 @@ def test_asset_group_uuid(flask_app, db, researcher_1, test_asset_group_file_dat
         print('Gitlab unavailable, skip ensure_asset_group_repo')
         return
 
+    from app.extensions.git_store import GitStoreMajorType as AssetGroupMajorType
     from app.extensions.gitlab import GitlabInitializationError
     from app.modules.asset_groups.models import AssetGroup
-    from app.extensions.git_store import GitStoreMajorType as AssetGroupMajorType
 
     guid = TEST_ASSET_GROUP_UUID
     asset_group = AssetGroup.query.get(guid)
@@ -660,8 +655,8 @@ def test_asset_group_uuid(flask_app, db, researcher_1, test_asset_group_file_dat
 
 @pytest.fixture
 def test_empty_asset_group_uuid(flask_app, db, researcher_1):
-    from app.modules.asset_groups.models import AssetGroup
     from app.extensions.git_store import GitStoreMajorType as AssetGroupMajorType
+    from app.modules.asset_groups.models import AssetGroup
 
     guid = TEST_EMPTY_ASSET_GROUP_UUID
     asset_group = AssetGroup.query.get(guid)
@@ -773,8 +768,8 @@ def contributor_1_login(flask_app, contributor_1):
 
 @pytest.fixture()
 def public_encounter():
-    from app.modules.users.models import User
     import tests.utils as test_utils
+    from app.modules.users.models import User
 
     return test_utils.generate_owned_encounter(User.get_public_user())
 

--- a/tests/extensions/edm/test_edm.py
+++ b/tests/extensions/edm/test_edm.py
@@ -2,8 +2,9 @@
 # pylint: disable=invalid-name,missing-docstring
 
 import uuid
-import pytest
 from unittest import mock
+
+import pytest
 
 from tests.utils import extension_unavailable
 

--- a/tests/extensions/intelligent_agent/test_agents.py
+++ b/tests/extensions/intelligent_agent/test_agents.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name,missing-docstring
 
-import pytest
-
-from unittest.mock import patch
-from tests.utils import extension_unavailable
-import tweepy
 import time
+from unittest.mock import patch
+
+import pytest
+import tweepy
 
 from app.modules.site_settings.models import SiteSetting
+from tests.utils import extension_unavailable
 
 
 # manipulate into whatever fake twitter response we want
@@ -186,8 +186,8 @@ def test_twitter_tweet_io(flask_app_client):
 )
 def test_linked_tweet_and_misc(researcher_1, flask_app_client, admin_user):
     from app.extensions.intelligent_agent.models import TwitterBot, TwitterTweet
-    from tests.modules.site_settings.resources import utils as setting_utils
     from app.modules.users.models import User
+    from tests.modules.site_settings.resources import utils as setting_utils
 
     author_id = 'TEST123'
     tweet = get_fake_tweet()
@@ -306,8 +306,9 @@ def test_nlp_date():
     reason='Intelligent Agent extension disabled',
 )
 def test_duplicate_tweet(db):
-    from app.extensions.intelligent_agent.models import TwitterTweet
     import sqlalchemy
+
+    from app.extensions.intelligent_agent.models import TwitterTweet
 
     tweet = get_fake_tweet()
     tweet.id = 123456789

--- a/tests/extensions/intelligent_agent/test_misc.py
+++ b/tests/extensions/intelligent_agent/test_misc.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name,missing-docstring
 
-import pytest
 import uuid
+
+import pytest
 
 from tests import utils
 
@@ -12,7 +13,7 @@ from tests import utils
 # technically this has nothing to do with IntelligentAgent but these utils just came in via this work
 #  and i am not really sure where to put tests for utils.py ??
 def test_peristent_value(flask_app):
-    from app.utils import get_redis_connection, set_persisted_value, get_persisted_value
+    from app.utils import get_persisted_value, get_redis_connection, set_persisted_value
 
     if utils.redis_unavailable():
         pytest.skip('redis unavailable')

--- a/tests/extensions/test_elasticsearch.py
+++ b/tests/extensions/test_elasticsearch.py
@@ -1,14 +1,15 @@
 # -*- coding: utf-8 -*-
-import pytest
-import time
 import datetime
+import time
+
+import pytest
 import tqdm
 
 from tests.utils import (
+    elasticsearch,
     extension_unavailable,
     module_unavailable,
     wait_for_elasticsearch_status,
-    elasticsearch,
 )
 
 
@@ -17,8 +18,8 @@ from tests.utils import (
 )
 def test_indexing_with_elasticsearch():
     from app.extensions import elasticsearch as es
-    from app.modules.users.models import User
     from app.modules.assets.models import AssetTags
+    from app.modules.users.models import User
 
     assert User in es.REGISTERED_MODELS
     assert AssetTags not in es.REGISTERED_MODELS
@@ -68,15 +69,15 @@ def test_elasticsearch_utilities(
     request,
     test_root,
 ):
-    from app.extensions.elasticsearch import tasks as es_tasks
+    import tests.modules.asset_groups.resources.utils as asset_group_utils
     from app.extensions import elasticsearch as es
+    from app.extensions.elasticsearch import tasks as es_tasks
+    from app.modules.assets.models import Asset
     from app.modules.complex_date_time.models import ComplexDateTime, Specificities
     from app.modules.users.models import User
     from app.modules.users.schemas import UserListSchema
-    from app.modules.assets.models import Asset
-    from tests.modules.users.resources.utils import read_all_users_pagination
     from tests.modules.assets.resources.utils import read_all_assets_pagination
-    import tests.modules.asset_groups.resources.utils as asset_group_utils
+    from tests.modules.users.resources.utils import read_all_users_pagination
 
     if es.is_disabled():
         return

--- a/tests/extensions/test_gitlab.py
+++ b/tests/extensions/test_gitlab.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import tempfile
-from unittest import mock
 import uuid
+from unittest import mock
 
 import gitlab.exceptions
 import pytest

--- a/tests/extensions/tus/utils.py
+++ b/tests/extensions/tus/utils.py
@@ -4,12 +4,14 @@ tus test utils
 -------------
 """
 
-from flask import current_app
 import os
 import shutil
-import tqdm
-from PIL import Image
+
 import numpy as np
+import tqdm
+from flask import current_app
+from PIL import Image
+
 from app.extensions.tus import tus_upload_dir, tus_write_file_metadata
 from app.utils import get_stored_filename
 from tests.utils import random_nonce
@@ -50,7 +52,7 @@ def prep_randomized_tus_dir(total=100, transaction_id=None):
         os.mkdir(upload_dir)
 
     for iteration in tqdm.tqdm(list(range(total)), desc='Random Tus Images'):
-        filename = '%s.jpg' % (random_nonce(32),)
+        filename = '{}.jpg'.format(random_nonce(32))
         image_file = os.path.join(upload_dir, filename)
         numpy_image = np.around(np.random.rand(128, 128, 3) * 255.0).astype(np.uint8)
         Image.fromarray(numpy_image, 'RGB').save(image_file)

--- a/tests/modules/annotations/resources/test_annotation_identification.py
+++ b/tests/modules/annotations/resources/test_annotation_identification.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
 import uuid
 
+import pytest
+
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.modules.sightings.resources.utils as sighting_utils
 import tests.utils as test_utils
-
-import pytest
-
 from tests.utils import (
-    module_unavailable,
     extension_unavailable,
+    module_unavailable,
     wait_for_elasticsearch_status,
 )
 
@@ -32,9 +31,9 @@ def test_annotation_identification(
     request,
 ):
     # pylint: disable=invalid-name
-    from app.modules.sightings.models import Sighting, SightingStage
-    from app.modules.annotations.models import Annotation
     from app.extensions import elasticsearch as es
+    from app.modules.annotations.models import Annotation
+    from app.modules.sightings.models import Sighting, SightingStage
 
     if es.is_disabled():
         pytest.skip('Elasticsearch disabled (via command-line)')

--- a/tests/modules/annotations/resources/test_annotation_keywords.py
+++ b/tests/modules/annotations/resources/test_annotation_keywords.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
+import logging
+
+import pytest
+
 from tests import utils
 from tests.modules.annotations.resources import utils as annot_utils
 from tests.modules.asset_groups.resources import utils as ag_utils
 from tests.modules.keywords.resources import utils as keyword_utils
-import pytest
-import logging
-
 from tests.utils import module_unavailable
 
 log = logging.getLogger(__name__)

--- a/tests/modules/annotations/resources/test_create_annotation.py
+++ b/tests/modules/annotations/resources/test_create_annotation.py
@@ -2,12 +2,12 @@
 # pylint: disable=missing-docstring
 import uuid
 
-from tests.modules.annotations.resources import utils as annot_utils
-from tests.modules.asset_groups.resources import utils as ag_utils
-from tests.modules.encounters.resources import utils as enc_utils
-from tests.modules.assets.resources import utils as asset_utils
 import pytest
 
+from tests.modules.annotations.resources import utils as annot_utils
+from tests.modules.asset_groups.resources import utils as ag_utils
+from tests.modules.assets.resources import utils as asset_utils
+from tests.modules.encounters.resources import utils as enc_utils
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/annotations/resources/test_matching_set.py
+++ b/tests/modules/annotations/resources/test_matching_set.py
@@ -2,17 +2,17 @@
 # pylint: disable=missing-docstring
 import uuid
 
+import pytest
+
+from tests import utils
 from tests.modules.annotations.resources import utils as annot_utils
 from tests.modules.encounters.resources import utils as enc_utils
 from tests.modules.site_settings.resources import utils as setting_utils
-import pytest
-
 from tests.utils import (
-    module_unavailable,
     extension_unavailable,
+    module_unavailable,
     wait_for_elasticsearch_status,
 )
-from tests import utils
 
 
 @pytest.mark.skipif(
@@ -31,8 +31,8 @@ def test_annotation_matching_set(
     test_root,
 ):
     # pylint: disable=invalid-name
-    from app.modules.annotations.models import Annotation
     from app.extensions import elasticsearch as es
+    from app.modules.annotations.models import Annotation
 
     if es.is_disabled():
         pytest.skip('Elasticsearch disabled (via command-line)')

--- a/tests/modules/annotations/resources/test_patch_annotation.py
+++ b/tests/modules/annotations/resources/test_patch_annotation.py
@@ -2,11 +2,11 @@
 # pylint: disable=missing-docstring
 import uuid
 
+import pytest
+
 from tests import utils as test_utils
 from tests.modules.annotations.resources import utils as annot_utils
 from tests.modules.sightings.resources import utils as sighting_utils
-import pytest
-
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/annotations/resources/utils.py
+++ b/tests/modules/annotations/resources/utils.py
@@ -4,6 +4,7 @@ Annotation resources utils
 -------------
 """
 import json
+
 from tests import utils as test_utils
 
 PATH = '/api/v1/annotations/'
@@ -84,7 +85,7 @@ def patch_annotation(
 ):
     with flask_app_client.login(user, auth_scopes=('annotations:write',)):
         response = flask_app_client.patch(
-            '%s%s' % (PATH, annotation_guid),
+            '{}{}'.format(PATH, annotation_guid),
             content_type='application/json',
             data=json.dumps(data),
         )
@@ -100,7 +101,7 @@ def patch_annotation(
 
 def read_annotation(flask_app_client, user, annotation_guid, expected_status_code=200):
     with flask_app_client.login(user, auth_scopes=('annotations:read',)):
-        response = flask_app_client.get('%s%s' % (PATH, annotation_guid))
+        response = flask_app_client.get('{}{}'.format(PATH, annotation_guid))
 
     if expected_status_code == 200:
         test_utils.validate_dict_response(response, 200, EXPECTED_KEYS)
@@ -133,7 +134,7 @@ def read_all_annotations(flask_app_client, user, expected_status_code=200):
 
 def delete_annotation(flask_app_client, user, annotation_guid, expected_status_code=204):
     with flask_app_client.login(user, auth_scopes=('annotations:write',)):
-        response = flask_app_client.delete('%s%s' % (PATH, annotation_guid))
+        response = flask_app_client.delete('{}{}'.format(PATH, annotation_guid))
 
     if expected_status_code == 204:
         assert response.status_code == 204

--- a/tests/modules/asset_groups/resources/test_commit_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_commit_asset_group.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import tests.modules.asset_groups.resources.utils as asset_group_utils
-from tests import utils as test_utils
 import pytest
 
+import tests.modules.asset_groups.resources.utils as asset_group_utils
+from tests import utils as test_utils
 from tests.utils import module_unavailable
 
 
@@ -96,7 +96,7 @@ def test_commit_owner_asset_group(
         assert sighting.stage == SightingStage.un_reviewed
         # It seems encounters may not be returned in order so we can't assert
         # encounters[0].owner == regular_user
-        assert sorted([e.owner.email for e in encounters]) == [
+        assert sorted(e.owner.email for e in encounters) == [
             researcher_1.email,
             regular_user.email,
         ]
@@ -166,8 +166,8 @@ def test_commit_individual_asset_group(
     request,
 ):
     # pylint: disable=invalid-name
-    from app.modules.sightings.models import Sighting, SightingStage
     from app.modules.asset_groups.models import AssetGroupSighting
+    from app.modules.sightings.models import Sighting, SightingStage
 
     asset_group_uuid = None
     try:
@@ -229,10 +229,10 @@ def test_commit_anonymous_asset_group(
 ):
     # pylint: disable=invalid-name
     import tests.extensions.tus.utils as tus_utils
-    import tests.modules.assets.resources.utils as asset_utils
-    import tests.modules.sightings.resources.utils as sighting_utils
-    import tests.modules.encounters.resources.utils as encounter_utils
     import tests.modules.annotations.resources.utils as annot_utils
+    import tests.modules.assets.resources.utils as asset_utils
+    import tests.modules.encounters.resources.utils as encounter_utils
+    import tests.modules.sightings.resources.utils as sighting_utils
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     data = asset_group_utils.AssetGroupCreationData(transaction_id, test_filename)

--- a/tests/modules/asset_groups/resources/test_create_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_create_asset_group.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import tests.modules.asset_groups.resources.utils as asset_group_utils
-import tests.modules.users.resources.utils as user_utils
-import tests.extensions.tus.utils as tus_utils
-import tests.utils as test_utils
-import pytest
 import json
 
+import pytest
+
+import tests.extensions.tus.utils as tus_utils
+import tests.modules.asset_groups.resources.utils as asset_group_utils
+import tests.modules.users.resources.utils as user_utils
+import tests.utils as test_utils
 from tests.utils import module_unavailable
 
 
@@ -120,8 +121,9 @@ def test_create_asset_group(flask_app_client, researcher_1, readonly_user, test_
 
         asset_group_uuid = resp.json['guid']
         # Read the metadata file and make sure that the frontend sightings are exactly what we sent
-        from app.modules.asset_groups.models import AssetGroup
         import os
+
+        from app.modules.asset_groups.models import AssetGroup
 
         asset_group = AssetGroup.query.get(resp.json['guid'])
         asset_group_path = asset_group.get_absolute_path()
@@ -408,8 +410,9 @@ def test_create_asset_group_anonymous(
         data.set_field('submitterEmail', 'joe@blogs.com')
         resp = asset_group_utils.create_asset_group(flask_app_client, None, data.get())
         asset_group_uuid = resp.json['guid']
-        from app.modules.users.models import User
         import uuid
+
+        from app.modules.users.models import User
 
         assert uuid.UUID(resp.json['owner_guid']) == User.get_public_user().guid
 
@@ -428,8 +431,9 @@ def no_test_create_asset_group_detection(
     flask_app, flask_app_client, researcher_1, staff_user, test_root, db, request
 ):
     # pylint: disable=invalid-name
-    from tests.modules.asset_groups.resources.utils import AssetGroupCreationData
     from time import sleep
+
+    from tests.modules.asset_groups.resources.utils import AssetGroupCreationData
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
 
@@ -689,8 +693,9 @@ def test_create_asset_group_individual(
     empty_individual,
 ):
     # pylint: disable=invalid-name
-    from tests.modules.asset_groups.resources.utils import AssetGroupCreationData
     import uuid
+
+    from tests.modules.asset_groups.resources.utils import AssetGroupCreationData
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     asset_group_uuid = None
@@ -755,8 +760,9 @@ def test_create_asset_group_international(
     empty_individual,
 ):
     # pylint: disable=invalid-name
-    from tests.modules.asset_groups.resources.utils import AssetGroupCreationData
     import uuid
+
+    from tests.modules.asset_groups.resources.utils import AssetGroupCreationData
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     second_filename = 'zebra_?_.jpg'

--- a/tests/modules/asset_groups/resources/test_detection.py
+++ b/tests/modules/asset_groups/resources/test_detection.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import tests.modules.asset_groups.resources.utils as asset_group_utils
 import logging
 
+import tests.modules.asset_groups.resources.utils as asset_group_utils
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -23,10 +23,10 @@ def disabled_test_create_bulk_asset_group_and_detection(
         asset_group = AssetGroup.query.get(asset_group_uuid)
 
         for sighting in asset_group.asset_group_sightings:
-            log.info('sighting = %r' % (sighting,))
-            log.info('sighting.config = %r' % (sighting.config,))
-            log.info('sighting.stage = %r' % (sighting.stage,))
-            log.info('sighting.jobs = %r' % (sighting.jobs,))
+            log.info('sighting = {!r}'.format(sighting))
+            log.info('sighting.config = {!r}'.format(sighting.config))
+            log.info('sighting.stage = {!r}'.format(sighting.stage))
+            log.info('sighting.jobs = {!r}'.format(sighting.jobs))
             assert len(sighting.jobs) > 0
     finally:
         if asset_group_uuid:

--- a/tests/modules/asset_groups/resources/test_ensure_submission.py
+++ b/tests/modules/asset_groups/resources/test_ensure_submission.py
@@ -2,9 +2,9 @@
 # pylint: disable=missing-docstring
 import uuid
 
-from tests.modules.asset_groups.resources import utils
 import pytest
 
+from tests.modules.asset_groups.resources import utils
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/asset_groups/resources/test_patch_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_patch_asset_group.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import uuid
 import copy
+import uuid
 
-import tests.modules.asset_groups.resources.utils as asset_group_utils
-import tests.modules.annotations.resources.utils as annot_utils
-from tests import utils
 import pytest
 
+import tests.modules.annotations.resources.utils as annot_utils
+import tests.modules.asset_groups.resources.utils as asset_group_utils
+from tests import utils
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/asset_groups/resources/test_permissions.py
+++ b/tests/modules/asset_groups/resources/test_permissions.py
@@ -2,11 +2,11 @@
 # pylint: disable=missing-docstring
 import uuid
 
+import pytest
+
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.modules.assets.resources.utils as asset_utils
 from tests import utils as test_utils
-import pytest
-
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/asset_groups/resources/test_upload_file.py
+++ b/tests/modules/asset_groups/resources/test_upload_file.py
@@ -2,10 +2,10 @@
 # pylint: disable=missing-docstring
 from os.path import basename
 
-import tests.modules.asset_groups.resources.utils as asset_group_utils
-import tests.extensions.tus.utils as tus_utils
 import pytest
 
+import tests.extensions.tus.utils as tus_utils
+import tests.modules.asset_groups.resources.utils as asset_group_utils
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -8,11 +8,9 @@ import os
 import shutil
 from unittest import mock
 
-from config import get_preliminary_config
-
 import tests.extensions.tus.utils as tus_utils
+from config import get_preliminary_config
 from tests import utils as test_utils
-
 
 PATH = '/api/v1/asset_groups/'
 EXPECTED_ASSET_GROUP_SIGHTING_FIELDS = {
@@ -140,9 +138,10 @@ def patch_in_dummy_annotation(
     encounter_num=0,
     padding=0,
 ):
-    from app.modules.assets.models import Asset
-    from app.modules.annotations.models import Annotation
     import uuid
+
+    from app.modules.annotations.models import Annotation
+    from app.modules.assets.models import Asset
 
     asset = Asset.find(asset_uuid)
     assert asset
@@ -251,8 +250,8 @@ def read_all_asset_groups(flask_app_client, user, expected_status_code=200):
 def delete_asset_group(
     flask_app_client, user, asset_group_guid, expected_status_code=204
 ):
-    from app.modules.asset_groups.models import AssetGroup
     from app.extensions.git_store.tasks import delete_remote
+    from app.modules.asset_groups.models import AssetGroup
 
     with mock.patch('app.extensions.git_store.tasks') as tasks:
         # Do delete_remote in the foreground immediately instead of using a
@@ -261,7 +260,7 @@ def delete_asset_group(
             *args, **kwargs
         )
         with flask_app_client.login(user, auth_scopes=('asset_groups:write',)):
-            response = flask_app_client.delete('%s%s' % (PATH, asset_group_guid))
+            response = flask_app_client.delete('{}{}'.format(PATH, asset_group_guid))
 
     if expected_status_code == 204:
         assert response.status_code == 204, response.status_code
@@ -642,9 +641,10 @@ def get_bulk_creation_data(test_root, request, species_detection_model=None):
 
 def validate_file_data(test_root, data, filename):
     import hashlib
+    import io
 
     from PIL import Image
-    import io
+
     from app.modules.assets.models import Asset
 
     full_path = f'{test_root}/{filename}'
@@ -670,8 +670,8 @@ def commit_asset_group_sighting_sage_identification(
     asset_group_sighting_guid,
     expected_status_code=200,
 ):
-    from app.modules.annotations.models import Annotation
     from app.extensions import elasticsearch as es
+    from app.modules.annotations.models import Annotation
 
     # Start ID simulating success response from Sage
     with es.session.begin(blocking=True, forced=True):

--- a/tests/modules/asset_groups/test_models.py
+++ b/tests/modules/asset_groups/test_models.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 import uuid
+
+import pytest
+
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.utils as test_utils
-import pytest
 from app.utils import HoustonException
-
-from tests.utils import module_unavailable, extension_unavailable
+from tests.utils import extension_unavailable, module_unavailable
 
 
 @pytest.mark.skipif(
@@ -143,7 +144,7 @@ def test_asset_group_sightings_bulk(
 
 @pytest.mark.skipif(extension_unavailable('edm'), reason='EDM extension disabled')
 def test_asset_group_sighting_config_field_getter(researcher_1, request):
-    from app.modules.asset_groups.models import AssetGroupSighting, AssetGroup
+    from app.modules.asset_groups.models import AssetGroup, AssetGroupSighting
 
     asset_group = AssetGroup(owner=researcher_1)
     request.addfinalizer(asset_group.delete)

--- a/tests/modules/asset_groups/test_tus_creation.py
+++ b/tests/modules/asset_groups/test_tus_creation.py
@@ -2,19 +2,20 @@
 # pylint: disable=invalid-name,missing-docstring
 import os
 import pathlib
-import pytest
 import shutil
 
-from tests.utils import module_unavailable
+import pytest
+
 from tests.extensions.tus import utils as tus_utils
+from tests.utils import module_unavailable
 
 
 @pytest.mark.skipif(
     module_unavailable('asset_groups'), reason='AssetGroups module disabled'
 )
 def test_create_asset_group_from_tus(flask_app, db, researcher_1, test_root):
-    from app.utils import HoustonException
     from app.modules.asset_groups.models import AssetGroup
+    from app.utils import HoustonException
 
     tid = tus_utils.get_transaction_id()  # '11111111-1111-1111-1111-111111111111'
 

--- a/tests/modules/assets/resources/test_asset_tags.py
+++ b/tests/modules/assets/resources/test_asset_tags.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-from tests import utils
-import tests.modules.asset_groups.resources.utils as asset_group_utils
-import tests.modules.assets.resources.utils as asset_utils
-from tests.modules.keywords.resources import utils as tag_utils
 import pytest
 
+import tests.modules.asset_groups.resources.utils as asset_group_utils
+import tests.modules.assets.resources.utils as asset_utils
+from tests import utils
+from tests.modules.keywords.resources import utils as tag_utils
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/assets/resources/test_assets.py
+++ b/tests/modules/assets/resources/test_assets.py
@@ -2,13 +2,12 @@
 # pylint: disable=missing-docstring
 import hashlib
 
+import pytest
+
 import tests.extensions.tus.utils as tus_utils
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.modules.assets.resources.utils as asset_utils
-import pytest
-
 from tests.utils import module_unavailable
-
 
 # md5sum values of the initial and derived files
 initial_md5sum_values = [
@@ -179,8 +178,8 @@ def test_find_raw_asset(
     ).close()
 
     from app.modules.asset_groups.models import (
-        AssetGroupSightingStage,
         AssetGroupSighting,
+        AssetGroupSightingStage,
     )
 
     new_sighting = AssetGroupSighting.query.get(uuids['asset_group_sighting'])

--- a/tests/modules/assets/resources/utils.py
+++ b/tests/modules/assets/resources/utils.py
@@ -4,6 +4,7 @@ Assets resources utils
 -------------
 """
 import json
+
 from tests import utils as test_utils
 
 PATH = '/api/v1/assets/'
@@ -129,7 +130,7 @@ def read_all_assets_pagination(
 
 def delete_asset(flask_app_client, user, asset_guid, expected_status_code=204):
     with flask_app_client.login(user, auth_scopes=('assets:write',)):
-        response = flask_app_client.delete('%s%s' % (PATH, asset_guid))
+        response = flask_app_client.delete('{}{}'.format(PATH, asset_guid))
 
     if expected_status_code == 204:
         assert response.status_code == 204

--- a/tests/modules/assets/test_abox.py
+++ b/tests/modules/assets/test_abox.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from PIL import Image
 import pytest
+from PIL import Image
 
 # import tests.utils as test_utils
 from tests.utils import module_unavailable
@@ -11,8 +11,8 @@ from tests.utils import module_unavailable
     module_unavailable('asset_groups'), reason='AssetGroups module disabled'
 )
 def test_abox_format():
-    from app.modules.assets.models import Asset
     from app.modules.annotations.models import Annotation
+    from app.modules.assets.models import Asset
 
     asset = Asset()
     image = Image.new('RGB', (1000, 800))

--- a/tests/modules/assets/test_models.py
+++ b/tests/modules/assets/test_models.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import pathlib
-from unittest import mock
 import uuid
+from unittest import mock
 
-from PIL import Image
 import pytest
+from PIL import Image
 
 import tests.utils as test_utils
 from tests.utils import module_unavailable
@@ -15,12 +15,11 @@ from tests.utils import module_unavailable
 )
 def set_up_assets(flask_app, db, test_root, admin_user, request):
     from app.modules.annotations.models import Annotation
-    from app.modules.asset_groups.models import AssetGroup
     from app.modules.asset_groups.metadata import AssetGroupMetadata
+    from app.modules.asset_groups.models import AssetGroup
     from app.modules.sightings.models import Sighting, SightingAssets, SightingStage
-
     from tests.modules.asset_groups.resources.utils import AssetGroupCreationData
-    from tests.utils import create_transaction_dir, copy_uploaded_file, cleanup
+    from tests.utils import cleanup, copy_uploaded_file, create_transaction_dir
 
     # Add jpg files to tus transaction dir
     transaction_id = str(uuid.uuid4())
@@ -69,8 +68,8 @@ def set_up_assets(flask_app, db, test_root, admin_user, request):
 )
 def test_asset_meta_and_delete(flask_app, db, test_root, admin_user, request):
     from app.modules.annotations.models import Annotation
-    from app.modules.assets.models import Asset
     from app.modules.asset_groups.models import AssetGroup
+    from app.modules.assets.models import Asset
     from app.modules.sightings.models import Sighting, SightingAssets
 
     asset_group = set_up_assets(flask_app, db, test_root, admin_user, request)

--- a/tests/modules/audit_logs/resources/test_audit_log.py
+++ b/tests/modules/audit_logs/resources/test_audit_log.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import tests.modules.asset_groups.resources.utils as asset_group_utils
-import tests.modules.users.resources.utils as user_utils
-import tests.modules.audit_logs.resources.utils as audit_utils
 import pytest
 
+import tests.modules.asset_groups.resources.utils as asset_group_utils
+import tests.modules.audit_logs.resources.utils as audit_utils
+import tests.modules.users.resources.utils as user_utils
 from tests.utils import module_unavailable
 
 
@@ -172,8 +172,8 @@ def test_most_ia_pipeline_audit_log(
 def test_audit_log_faults(
     flask_app_client, researcher_1, readonly_user, admin_user, test_root, db
 ):
-    from app.modules.audit_logs.models import AuditLog
     import app.extensions.logging as AuditLogExtension
+    from app.modules.audit_logs.models import AuditLog
 
     # Reuse a different test that generates a truckload of faults
     from tests.modules.asset_groups.resources.test_create_asset_group import (

--- a/tests/modules/audit_logs/test_audit_log_extension.py
+++ b/tests/modules/audit_logs/test_audit_log_extension.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 def test_raising_faults():
-    from app.modules.audit_logs.models import AuditLog
     import app.extensions.logging as AuditLogExtension  # NOQA
+    from app.modules.audit_logs.models import AuditLog
 
     houston_fault_msg = (
         'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'

--- a/tests/modules/auth/conftest.py
+++ b/tests/modules/auth/conftest.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import datetime
+
 import pytest
 import pytz
 

--- a/tests/modules/auth/resources/test_creating_oauth2client.py
+++ b/tests/modules/auth/resources/test_creating_oauth2client.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-import pytest
 import uuid
+
+import pytest
 import six
 
 

--- a/tests/modules/auth/resources/test_getting_oauth2clients_info.py
+++ b/tests/modules/auth/resources/test_getting_oauth2clients_info.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import pytest
 import uuid
+
+import pytest
 
 
 @pytest.mark.parametrize(

--- a/tests/modules/auth/resources/test_token.py
+++ b/tests/modules/auth/resources/test_token.py
@@ -174,7 +174,7 @@ def test_regular_user_can_revoke_token(
         '/api/v1/auth/revoke',
         content_type='application/x-www-form-urlencoded',
         headers={
-            'Authorization': 'Bearer %s' % (regular_user_oauth2_token.access_token,)
+            'Authorization': 'Bearer {}'.format(regular_user_oauth2_token.access_token)
         },
         data=data,
     )

--- a/tests/modules/auth/test_login_manager_integration.py
+++ b/tests/modules/auth/test_login_manager_integration.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 import datetime
 
-from mock import Mock
-
 from flask import request
+from mock import Mock
 
 from app.modules import auth
 

--- a/tests/modules/auth/test_models.py
+++ b/tests/modules/auth/test_models.py
@@ -3,7 +3,7 @@ import datetime
 
 import pytz
 
-from app.modules.auth.models import Code, CodeTypes, CodeDecisions
+from app.modules.auth.models import Code, CodeDecisions, CodeTypes
 
 
 def test_Code(db, researcher_1):

--- a/tests/modules/collaborations/resources/test_collaboration_create.py
+++ b/tests/modules/collaborations/resources/test_collaboration_create.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
+import uuid
+
+import pytest
+
 import tests.modules.collaborations.resources.utils as collab_utils
 import tests.modules.users.resources.utils as user_utils
 import tests.utils as test_utils
-
-import uuid
-import pytest
-
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/collaborations/resources/test_collaboration_notification.py
+++ b/tests/modules/collaborations/resources/test_collaboration_notification.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
+import pytest
+
 import tests.modules.collaborations.resources.utils as collab_utils
 import tests.modules.notifications.resources.utils as notif_utils
 import tests.utils as utils
-import pytest
-
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/collaborations/resources/test_collaboration_patch.py
+++ b/tests/modules/collaborations/resources/test_collaboration_patch.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import tests.modules.collaborations.resources.utils as collab_utils
-from tests import utils
-import pytest
 import uuid
 
+import pytest
+
+import tests.modules.collaborations.resources.utils as collab_utils
+from tests import utils
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/collaborations/resources/test_collaboration_usage.py
+++ b/tests/modules/collaborations/resources/test_collaboration_usage.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import tests.modules.collaborations.resources.utils as collab_utils
-import tests.modules.asset_groups.resources.utils as asset_group_utils
 import pytest
 
+import tests.modules.asset_groups.resources.utils as asset_group_utils
+import tests.modules.collaborations.resources.utils as collab_utils
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/collaborations/resources/utils.py
+++ b/tests/modules/collaborations/resources/utils.py
@@ -4,6 +4,7 @@ Collaboration resources utils
 -------------
 """
 import json
+
 from tests import utils as test_utils
 
 PATH = '/api/v1/collaborations/'

--- a/tests/modules/collaborations/test_models.py
+++ b/tests/modules/collaborations/test_models.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name,missing-docstring
 
-import pytest
-
 import logging
-
 from unittest import mock
+
+import pytest
 
 from tests.utils import module_unavailable
 
@@ -52,8 +51,7 @@ def test_collaboration_create_with_members(
     module_unavailable('collaborations'), reason='Collaborations module disabled'
 )
 def test_collaboration_read_state_changes(db, collab_user_a, collab_user_b, request):
-    from app.modules.collaborations.models import Collaboration
-    from app.modules.collaborations.models import CollaborationUserState
+    from app.modules.collaborations.models import Collaboration, CollaborationUserState
 
     collab = Collaboration([collab_user_a, collab_user_b], collab_user_a)
     with db.session.begin():
@@ -99,8 +97,7 @@ def test_collaboration_read_state_changes(db, collab_user_a, collab_user_b, requ
     module_unavailable('collaborations'), reason='Collaborations module disabled'
 )
 def test_collaboration_edit_state_changes(db, collab_user_a, collab_user_b, request):
-    from app.modules.collaborations.models import Collaboration
-    from app.modules.collaborations.models import CollaborationUserState
+    from app.modules.collaborations.models import Collaboration, CollaborationUserState
 
     collab = Collaboration([collab_user_a, collab_user_b], collab_user_a)
     with db.session.begin():

--- a/tests/modules/complex_date_time/test_basics.py
+++ b/tests/modules/complex_date_time/test_basics.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name,missing-docstring
 
+import datetime
+
 import pytest
-from tests.utils import module_unavailable
+
 from app.utils import (
-    iso8601_to_datetime_with_timezone,
     datetime_as_timezone,
+    iso8601_to_datetime_with_timezone,
     normalized_timezone_string,
 )
-import datetime
+from tests.utils import module_unavailable
 
 
 @pytest.mark.skipif(
@@ -42,8 +44,9 @@ def test_utils():
     module_unavailable('complex_date_time'), reason='ComplexDateTime module disabled'
 )
 def test_models(db, request):
-    from app.modules.complex_date_time.models import ComplexDateTime, Specificities
     from dateutil import tz
+
+    from app.modules.complex_date_time.models import ComplexDateTime, Specificities
 
     try:
         cdt = ComplexDateTime('test', 'test', 'test')
@@ -220,8 +223,8 @@ def test_models(db, request):
     module_unavailable('complex_date_time'), reason='ComplexDateTime module disabled'
 )
 def test_nlp_time():
-    from app.utils import nlp_parse_complex_date_time
     from app.modules.complex_date_time.models import Specificities
+    from app.utils import nlp_parse_complex_date_time
 
     refdate = '2019-08-15'
     text = 'a week ago at 3:30'
@@ -260,9 +263,11 @@ def test_nlp_time():
     module_unavailable('complex_date_time'), reason='ComplexDateTime module disabled'
 )
 def test_nlp_time_mocked():
-    from app.utils import nlp_parse_complex_date_time
-    import sutime
     from unittest.mock import patch
+
+    import sutime
+
+    from app.utils import nlp_parse_complex_date_time
 
     class mock_SUTime(object):
         def parse(self, val, reference_date=None):

--- a/tests/modules/emails/test_email.py
+++ b/tests/modules/emails/test_email.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-from pathlib import Path
 import uuid
+from pathlib import Path
 
-from app.modules.emails.models import RecordedEmail, EmailTypes, EmailRecord
-from app.modules.site_settings.models import SiteSetting
-from app.extensions.email import Email
 import pytest
 
+from app.extensions.email import Email
+from app.modules.emails.models import EmailRecord, EmailTypes, RecordedEmail
+from app.modules.site_settings.models import SiteSetting
 
 test_recipient = str(uuid.uuid4()) + '-test@example.com'
 

--- a/tests/modules/encounters/resources/test_delete_encounter.py
+++ b/tests/modules/encounters/resources/test_delete_encounter.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
-from tests.modules.sightings.resources import utils as sighting_utils
-from tests.modules.encounters.resources import utils as enc_utils
-from tests.modules.individuals.resources import utils as indiv_utils
-from tests import utils as test_utils
 import pytest
 
+from tests import utils as test_utils
+from tests.modules.encounters.resources import utils as enc_utils
+from tests.modules.individuals.resources import utils as indiv_utils
+from tests.modules.sightings.resources import utils as sighting_utils
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/encounters/resources/test_modify_encounter.py
+++ b/tests/modules/encounters/resources/test_modify_encounter.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import uuid
-from unittest import mock
 import datetime
 import time
+import uuid
+from unittest import mock
+
+import pytest
 
 from tests import utils
 from tests.modules.annotations.resources import utils as annot_utils
 from tests.modules.encounters.resources import utils as enc_utils
 from tests.modules.sightings.resources import utils as sighting_utils
 from tests.modules.site_settings.resources import utils as setting_utils
-import pytest
-
 from tests.utils import module_unavailable
 
 
@@ -28,8 +28,8 @@ def test_modify_encounter(
     test_root,
 ):
     # pylint: disable=invalid-name
-    from app.modules.encounters.models import Encounter
     from app.modules.complex_date_time.models import ComplexDateTime, Specificities
+    from app.modules.encounters.models import Encounter
 
     data_in = {
         'time': datetime.datetime.now().isoformat() + '+00:00',
@@ -218,10 +218,8 @@ def test_modify_encounter(
     expected_order = [
         value[1]
         for value in sorted(
-            [
-                (encounter.time.datetime, encounter.guid)
-                for encounter in [new_encounter_1, new_encounter_2]
-            ]
+            (encounter.time.datetime, encounter.guid)
+            for encounter in [new_encounter_1, new_encounter_2]
         )
     ]
     assert actual_order == expected_order
@@ -239,10 +237,8 @@ def test_modify_encounter(
     expected_order = [
         value[1]
         for value in sorted(
-            [
-                (encounter.time.datetime, encounter.guid)
-                for encounter in [new_encounter_1, new_encounter_2]
-            ]
+            (encounter.time.datetime, encounter.guid)
+            for encounter in [new_encounter_1, new_encounter_2]
         )
     ]
     assert actual_order[::-1] == expected_order
@@ -416,9 +412,9 @@ def test_modify_encounter_error(
 def test_create_encounter_time_test(
     flask_app, flask_app_client, researcher_1, request, test_root
 ):
-    from tests.modules.sightings.resources import utils as sighting_utils
-    from app.modules.encounters.models import Encounter
     from app.modules.complex_date_time.models import Specificities
+    from app.modules.encounters.models import Encounter
+    from tests.modules.sightings.resources import utils as sighting_utils
 
     # test with invalid time
     sighting_data = {

--- a/tests/modules/encounters/resources/test_read_encounters.py
+++ b/tests/modules/encounters/resources/test_read_encounters.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-from tests import utils
 import pytest
 
+from tests import utils
 from tests.utils import module_unavailable
 
 PATH = '/api/v1/encounters/'

--- a/tests/modules/encounters/resources/utils.py
+++ b/tests/modules/encounters/resources/utils.py
@@ -113,7 +113,7 @@ def delete_encounter(
     flask_app_client, user, enc_guid, expected_status_code=204, headers=None
 ):
     with flask_app_client.login(user, auth_scopes=('encounter:write',)):
-        response = flask_app_client.delete('%s%s' % (PATH, enc_guid), headers=headers)
+        response = flask_app_client.delete('{}{}'.format(PATH, enc_guid), headers=headers)
 
     if expected_status_code == 204:
         assert response.status_code == 204

--- a/tests/modules/encounters/test_models.py
+++ b/tests/modules/encounters/test_models.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name,missing-docstring
 
-import tests.utils as test_utils
-import logging
 import datetime
+import logging
+
 import pytest
 
+import tests.utils as test_utils
 from tests.utils import module_unavailable
-
 
 log = logging.getLogger(__name__)
 
@@ -80,9 +80,9 @@ def test_owned_encounters_ordering(db, request):
 
 @pytest.mark.skipif(module_unavailable('encounters'), reason='Encounters module disabled')
 def test_encounter_time(db, request):
-    from app.modules.users.models import User
     from app.modules.complex_date_time.models import ComplexDateTime, Specificities
     from app.modules.encounters.models import Encounter
+    from app.modules.users.models import User
 
     public_owner = User.get_public_user()
     test_encounter = test_utils.generate_owned_encounter(public_owner)

--- a/tests/modules/fileuploads/test_models.py
+++ b/tests/modules/fileuploads/test_models.py
@@ -6,14 +6,14 @@ import pathlib
 import shutil
 import uuid
 
-from app.modules.fileuploads.models import FileUpload, modify_image
-from PIL import Image
 import pytest
+from PIL import Image
 
+from app.modules.fileuploads.models import FileUpload, modify_image
 from tests.utils import (
     TemporaryDirectoryUUID,
-    create_transaction_dir,
     copy_uploaded_file,
+    create_transaction_dir,
     write_uploaded_file,
 )
 

--- a/tests/modules/individuals/resources/test_elasticsearch.py
+++ b/tests/modules/individuals/resources/test_elasticsearch.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
+import pytest
+
+from app.extensions import elasticsearch as es
 from tests import utils as test_utils
 from tests.extensions.elasticsearch.resources import utils as es_utils
 from tests.modules.individuals.resources import utils as individual_utils
-from tests.utils import module_unavailable, extension_unavailable
-from app.extensions import elasticsearch as es
-
-import pytest
+from tests.utils import extension_unavailable, module_unavailable
 
 
 @pytest.mark.skipif(
@@ -69,9 +69,10 @@ def test_individual_elasticsearch_mappings(
     reason='Elasticsearch extension disabled',
 )
 def test_returned_schema(flask_app_client, researcher_1, admin_user, request, test_root):
+    import datetime
+
     from app.modules.individuals.models import Individual
     from tests.modules.site_settings.resources import utils as setting_utils
-    import datetime
 
     # make a taxonomy to use
     response = setting_utils.read_main_settings(

--- a/tests/modules/individuals/resources/test_individual_crud.py
+++ b/tests/modules/individuals/resources/test_individual_crud.py
@@ -1,20 +1,17 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import logging
-
-import uuid
 import datetime
+import logging
+import uuid
 
-from tests.modules.individuals.resources import utils as individual_utils
-from tests.modules.annotations.resources import utils as annot_utils
-from tests.modules.sightings.resources import utils as sighting_utils
-from tests.modules.site_settings.resources import utils as setting_utils
-
-from tests import utils
 import pytest
 
+from tests import utils
+from tests.modules.annotations.resources import utils as annot_utils
+from tests.modules.individuals.resources import utils as individual_utils
+from tests.modules.sightings.resources import utils as sighting_utils
+from tests.modules.site_settings.resources import utils as setting_utils
 from tests.utils import module_unavailable
-
 
 log = logging.getLogger(__name__)
 
@@ -115,10 +112,10 @@ def test_read_encounter_from_edm(db, flask_app_client):
     module_unavailable('individuals'), reason='Individuals module disabled'
 )
 def test_add_remove_encounters(db, flask_app_client, researcher_1, request, test_root):
-    from app.modules.individuals.models import Individual
-    from app.modules.encounters.models import Encounter
-    from app.modules.sightings.models import Sighting
     from app.modules.complex_date_time.models import Specificities
+    from app.modules.encounters.models import Encounter
+    from app.modules.individuals.models import Individual
+    from app.modules.sightings.models import Sighting
 
     test_time = datetime.datetime.now().isoformat() + '+00:00'
     data_in = {
@@ -263,9 +260,9 @@ def test_individual_has_detailed_encounter_from_edm(
     test_root,
     test_asset_group_uuid,
 ):
+    from app.modules.asset_groups.models import AssetGroup
     from app.modules.encounters.models import Encounter
     from app.modules.sightings.models import Sighting
-    from app.modules.asset_groups.models import AssetGroup
 
     data_in = {
         'encounters': [

--- a/tests/modules/individuals/resources/test_individual_delete_empty.py
+++ b/tests/modules/individuals/resources/test_individual_delete_empty.py
@@ -2,12 +2,10 @@
 # pylint: disable=missing-docstring
 import logging
 
+import pytest
 
 from tests import utils as test_utils
-
-import pytest
 from tests.utils import module_unavailable
-
 
 log = logging.getLogger(__name__)
 

--- a/tests/modules/individuals/resources/test_individual_featured_asset_guid.py
+++ b/tests/modules/individuals/resources/test_individual_featured_asset_guid.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-from tests.modules.sightings.resources import utils as sighting_utils
-from tests.modules.asset_groups.resources import utils as asset_group_utils
-from tests.modules.individuals.resources import utils as individual_utils
-from tests.modules.annotations.resources import utils as annot_utils
-from tests import utils
 import pytest
 
+from tests import utils
+from tests.modules.annotations.resources import utils as annot_utils
+from tests.modules.asset_groups.resources import utils as asset_group_utils
+from tests.modules.individuals.resources import utils as individual_utils
+from tests.modules.sightings.resources import utils as sighting_utils
 from tests.utils import module_unavailable
 
 
@@ -140,8 +140,8 @@ def test_patch_featured_asset_guid_on_individual(
 )
 def test_featured_individual_read(db, flask_app_client, researcher_1, test_root, request):
     from app.modules.annotations.models import Annotation
-    from app.modules.individuals.models import Individual
     from app.modules.assets.models import Asset
+    from app.modules.individuals.models import Individual
 
     # Specifically use the large one as we want multiple assets
     uuids = individual_utils.create_individual_and_sighting(

--- a/tests/modules/individuals/resources/test_individual_names.py
+++ b/tests/modules/individuals/resources/test_individual_names.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
+import pytest
+
 from tests import utils
 from tests.modules.individuals.resources import utils as individual_utils
 from tests.modules.sightings.resources import utils as sighting_utils
-
-import pytest
-
 from tests.utils import module_unavailable
 
 
@@ -371,8 +370,8 @@ def test_get_set_individual_names(
     module_unavailable('individuals'), reason='Individuals module disabled'
 )
 def test_get_by_name(db, flask_app_client, researcher_1, request, test_root):
-    from app.modules.names.models import DEFAULT_NAME_CONTEXT
     from app.modules.individuals.models import Individual
+    from app.modules.names.models import DEFAULT_NAME_CONTEXT
     from app.utils import HoustonException
 
     individual_1_id = individual_utils.create_individual_and_sighting(

--- a/tests/modules/individuals/resources/test_merge.py
+++ b/tests/modules/individuals/resources/test_merge.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
-from tests.modules.individuals.resources import utils as individual_utils
-import pytest
-from tests import utils as test_utils
 import logging
+
+import pytest
+
+from tests import utils as test_utils
+from tests.modules.individuals.resources import utils as individual_utils
 
 log = logging.getLogger(__name__)
 
@@ -355,7 +357,7 @@ def test_get_data_and_voting(
     assert response.json.get('vote') == 'allow'
     voters = IndividualMergeRequestVote.get_voters(request_id)
     assert len(voters) == 2
-    assert set(voters) == set([researcher_1, researcher_2])
+    assert set(voters) == {researcher_1, researcher_2}
 
     # test the is_resolved field on merge notifications
     res1_notifs = notif_utils.read_all_notifications(flask_app_client, researcher_1)
@@ -504,7 +506,7 @@ def test_decline_voting(
     assert response.json.get('vote') == 'block'
     voters = IndividualMergeRequestVote.get_voters(request_id)
     assert len(voters) == 2
-    assert set(voters) == set([researcher_1, researcher_2])
+    assert set(voters) == {researcher_1, researcher_2}
 
     # test the is_resolved field on merge notifications
     res1_notifs = notif_utils.read_all_notifications(flask_app_client, researcher_1)

--- a/tests/modules/individuals/resources/test_merge_conflicts.py
+++ b/tests/modules/individuals/resources/test_merge_conflicts.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import pytest
-from tests import utils as test_utils
 import logging
+
+import pytest
+
+from tests import utils as test_utils
 
 log = logging.getLogger(__name__)
 

--- a/tests/modules/individuals/resources/test_modify_individual.py
+++ b/tests/modules/individuals/resources/test_modify_individual.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
+import pytest
+
 from tests import utils
 from tests.modules.individuals.resources import utils as individual_utils
 from tests.modules.sightings.resources import utils as sighting_utils
 from tests.modules.site_settings.resources import utils as setting_utils
-import pytest
-
 from tests.utils import module_unavailable
 
 
@@ -19,8 +19,8 @@ def test_modify_individual_edm_fields(
 ):
 
     from app.modules.encounters.models import Encounter
-    from app.modules.sightings.models import Sighting
     from app.modules.individuals.models import Individual
+    from app.modules.sightings.models import Sighting
 
     individual_json = None
     tx = setting_utils.get_some_taxonomy_dict(flask_app_client, staff_user)

--- a/tests/modules/individuals/resources/utils.py
+++ b/tests/modules/individuals/resources/utils.py
@@ -3,8 +3,9 @@
 Individual resources utils
 -------------
 """
-import logging
 import json
+import logging
+
 from tests import utils as test_utils
 from tests.modules.sightings.resources import utils as sighting_utils
 
@@ -97,7 +98,7 @@ def read_individual(
     flask_app_client, regular_user, individual_guid, expected_status_code=200
 ):
     with flask_app_client.login(regular_user, auth_scopes=('individuals:read',)):
-        response = flask_app_client.get('%s%s' % (PATH, individual_guid))
+        response = flask_app_client.get('{}{}'.format(PATH, individual_guid))
 
     assert response.status_code == expected_status_code
     if response.status_code == 200:
@@ -117,7 +118,7 @@ def read_individual_path(
 
 def delete_individual(flask_app_client, user, guid, expected_status_code=204):
     with flask_app_client.login(user, auth_scopes=('individuals:write',)):
-        response = flask_app_client.delete('%s%s' % (PATH, guid))
+        response = flask_app_client.delete('{}{}'.format(PATH, guid))
 
     if expected_status_code == 204:
         # we allow 404 here in the event that it is being called as a finalizer on an
@@ -141,7 +142,7 @@ def patch_individual(
 ):
     with flask_app_client.login(user, auth_scopes=('individuals:write',)):
         response = flask_app_client.patch(
-            '%s%s' % (PATH, individual_guid),
+            '{}{}'.format(PATH, individual_guid),
             data=json.dumps(patch_data),
             content_type='application/json',
             headers=headers,

--- a/tests/modules/individuals/test_cooccurrence.py
+++ b/tests/modules/individuals/test_cooccurrence.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name,missing-docstring
 
-from app.modules.users.models import User
-import tests.utils as test_utils
 import pytest
 
+import tests.utils as test_utils
+from app.modules.users.models import User
 from tests.utils import module_unavailable
 
 
@@ -13,8 +13,8 @@ from tests.utils import module_unavailable
     reason='Individuals module disabled',
 )
 def test_cooccurrence(db, flask_app_client, researcher_1):
-    from app.modules.sightings.models import Sighting, SightingStage
     from app.modules.individuals.models import Individual
+    from app.modules.sightings.models import Sighting, SightingStage
 
     sighting = Sighting(stage=SightingStage.processed)
     sighting.time = test_utils.complex_date_time_now()
@@ -47,7 +47,7 @@ def test_cooccurrence(db, flask_app_client, researcher_1):
         db.session.add(individual_3)
 
     pals = individual_1.get_cooccurring_individuals()
-    assert set(pals) == set([individual_2, individual_3])
+    assert set(pals) == {individual_2, individual_3}
 
     # since its all set up, lets test api as well
     with flask_app_client.login(researcher_1, auth_scopes=('individuals:read',)):
@@ -55,9 +55,10 @@ def test_cooccurrence(db, flask_app_client, researcher_1):
             f'/api/v1/individuals/{str(individual_1.guid)}/cooccurrence'
         )
     assert len(response.json) == 2
-    assert set([response.json[0]['guid'], response.json[1]['guid']]) == set(
-        [str(individual_2.guid), str(individual_3.guid)]
-    )
+    assert {response.json[0]['guid'], response.json[1]['guid']} == {
+        str(individual_2.guid),
+        str(individual_3.guid),
+    }
 
     # tests indiv.get_shared_sightings(list_individual_guids)
     individual_4 = Individual()
@@ -80,7 +81,7 @@ def test_cooccurrence(db, flask_app_client, researcher_1):
         db.session.add(encounter_e)
 
     with_2 = individual_1.get_shared_sightings(individual_2)
-    assert set(with_2) == set([sighting, sighting_two])
+    assert set(with_2) == {sighting, sighting_two}
     with_3 = individual_1.get_shared_sightings(individual_3)
     assert with_3 == [sighting]
     empty = individual_4.get_shared_sightings(individual_3)

--- a/tests/modules/individuals/test_merge.py
+++ b/tests/modules/individuals/test_merge.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
+import datetime
+
+import pytest
+
+from tests import utils as test_utils
 from tests.modules.individuals.resources import utils as individual_utils
 from tests.modules.sightings.resources import utils as sighting_utils
 from tests.modules.social_groups.resources import utils as socgrp_utils
-import pytest
-import datetime
-from tests import utils as test_utils
-
 from tests.utils import module_unavailable
 
 
@@ -99,8 +100,8 @@ def test_merge(db, flask_app_client, researcher_1, request, test_root):
 def test_merge_social_groups(
     db, flask_app_client, researcher_1, admin_user, request, test_root
 ):
-    from app.modules.social_groups.models import SocialGroup
     from app.modules.individuals.models import Individual
+    from app.modules.social_groups.models import SocialGroup
 
     individual1_uuids = individual_utils.create_individual_and_sighting(
         flask_app_client,
@@ -194,13 +195,15 @@ def test_merge_social_groups(
     assert len(social_groupA.members) == 1
     assert str(social_groupA.members[0].individual_guid) == individual1_id
     assert len(social_groupB.members) == 1
-    assert set(social_groupB.get_member(individual1_id).roles) == set(
-        [groupB_role_from_1, groupB_role_from_2]
-    )
+    assert set(social_groupB.get_member(individual1_id).roles) == {
+        groupB_role_from_1,
+        groupB_role_from_2,
+    }
     assert len(social_groupC.members) == 1
-    assert set(social_groupC.get_member(individual1_id).roles) == set(
-        [groupC_shared_role, groupC_role_from_2]
-    )
+    assert set(social_groupC.get_member(individual1_id).roles) == {
+        groupC_shared_role,
+        groupC_role_from_2,
+    }
 
 
 @pytest.mark.skipif(
@@ -208,10 +211,11 @@ def test_merge_social_groups(
     reason='Individuals module disabled',
 )
 def test_merge_request_init(db, flask_app_client, researcher_1, researcher_2, request):
-    from app.modules.individuals.models import Individual
-    from app.modules.encounters.models import Encounter
-    from app.modules.notifications.models import Notification, NotificationType
     from dateutil import parser as dt_parser
+
+    from app.modules.encounters.models import Encounter
+    from app.modules.individuals.models import Individual
+    from app.modules.notifications.models import Notification, NotificationType
 
     # since this is just a simple init-only test, we can use incomplete data (not going to edm etc)
     #   we just want to see that the task starts (it should be ignored and die when triggered in celery)
@@ -271,8 +275,8 @@ def test_merge_request_init(db, flask_app_client, researcher_1, researcher_2, re
     reason='Individuals module disabled',
 )
 def test_merge_hash(db, flask_app_client, researcher_1, researcher_2, request):
-    from app.modules.individuals.models import Individual
     from app.modules.encounters.models import Encounter
+    from app.modules.individuals.models import Individual
 
     individual1 = Individual()
     enc1 = Encounter()
@@ -372,7 +376,7 @@ def test_failure_cases(db, flask_app_client, researcher_1, request):
     )
     assert rtn
     assert len(rtn) == 2
-    assert set([individual1, individual2]) == set(rtn)
+    assert {individual1, individual2} == set(rtn)
 
 
 @pytest.mark.skipif(
@@ -438,7 +442,7 @@ def test_merge_names(db, flask_app_client, researcher_1, admin_user, request, te
         'another',
         'third',
         overridden_context,
-    } == set([name.context for name in individual1.names])
+    } == {name.context for name in individual1.names}
 
     # test fail_on_conflict flag (currently not used anywhere) - should raise ValueError
     individual4_uuids = individual_utils.create_individual_and_sighting(

--- a/tests/modules/integrity/resources/test_integrity.py
+++ b/tests/modules/integrity/resources/test_integrity.py
@@ -2,11 +2,12 @@
 # pylint: disable=invalid-name,missing-docstring
 
 import logging
-import pytest
-from tests.utils import module_unavailable
 
-import tests.modules.integrity.resources.utils as integ_utils
+import pytest
+
 import tests.modules.individuals.resources.utils as ind_utils
+import tests.modules.integrity.resources.utils as integ_utils
+from tests.utils import module_unavailable
 
 log = logging.getLogger(__name__)
 

--- a/tests/modules/job_control/test_models.py
+++ b/tests/modules/job_control/test_models.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name,missing-docstring
 from unittest import mock
-import tests.utils as test_utils
+
 import pytest
+
+import tests.utils as test_utils
 from tests.utils import module_unavailable
 
 
@@ -11,10 +13,11 @@ from tests.utils import module_unavailable
 )
 def test_job_control(flask_app, researcher_1, test_root, db):
     # pylint: disable=invalid-name
+    import uuid
+
     from app.modules.asset_groups.models import AssetGroup, AssetGroupSighting
     from app.modules.job_control.models import JobControl
     from tests.utils import copy_uploaded_file, create_transaction_dir
-    import uuid
 
     asset_group = None
     try:

--- a/tests/modules/keywords/resources/utils.py
+++ b/tests/modules/keywords/resources/utils.py
@@ -4,6 +4,7 @@ Assets resources utils
 -------------
 """
 import json
+
 from tests import utils as test_utils
 
 PATH = '/api/v1/keywords/'
@@ -12,7 +13,7 @@ PATH = '/api/v1/keywords/'
 def patch_keyword(flask_app_client, user, keyword_guid, data, expected_status_code=200):
     with flask_app_client.login(user, auth_scopes=('keywords:write',)):
         response = flask_app_client.patch(
-            '%s%s' % (PATH, keyword_guid),
+            '{}{}'.format(PATH, keyword_guid),
             content_type='application/json',
             data=json.dumps(data),
         )
@@ -82,7 +83,7 @@ def read_all_keywords(flask_app_client, user, expected_status_code=200):
 
 def delete_keyword(flask_app_client, user, keyword_guid, expected_status_code=204):
     with flask_app_client.login(user, auth_scopes=('keywords:write',)):
-        response = flask_app_client.delete('%s%s' % (PATH, keyword_guid))
+        response = flask_app_client.delete('{}{}'.format(PATH, keyword_guid))
 
     if expected_status_code == 204:
         assert response.status_code == 204

--- a/tests/modules/missions/resources/test_create_collection.py
+++ b/tests/modules/missions/resources/test_create_collection.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import tests.modules.missions.resources.utils as mission_utils
-import tests.extensions.tus.utils as tus_utils
 import pytest
 
+import tests.extensions.tus.utils as tus_utils
+import tests.modules.missions.resources.utils as mission_utils
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/missions/resources/test_create_mission.py
+++ b/tests/modules/missions/resources/test_create_mission.py
@@ -1,23 +1,19 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
-from tests import utils
-from tests.modules.missions.resources import utils as mission_utils
-from tests.utils import random_guid, wait_for_elasticsearch_status
-import tests.extensions.tus.utils as tus_utils
 import pytest
 import tqdm
 
-from tests.utils import module_unavailable
+import tests.extensions.tus.utils as tus_utils
+from tests import utils
+from tests.modules.missions.resources import utils as mission_utils
+from tests.utils import module_unavailable, random_guid, wait_for_elasticsearch_status
 
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')
 def test_create_and_delete_mission(flask_app_client, data_manager_1):
     # pylint: disable=invalid-name
-    from app.modules.missions.models import (
-        Mission,
-        MissionUserAssignment,
-    )
+    from app.modules.missions.models import Mission, MissionUserAssignment
 
     nonce, title = mission_utils.make_name('mission')
     response = mission_utils.create_mission(
@@ -95,11 +91,7 @@ def test_mission_permission(
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')
 def test_delete_mission_cleanup(flask_app_client, data_manager_1, test_root):
-    from app.modules.missions.models import (
-        Mission,
-        MissionCollection,
-        MissionTask,
-    )
+    from app.modules.missions.models import Mission, MissionCollection, MissionTask
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     transaction_ids = []
@@ -209,11 +201,7 @@ def test_delete_mission_cleanup(flask_app_client, data_manager_1, test_root):
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')
 def test_mission_scalability(flask_app_client, data_manager_1, test_root):
-    from app.modules.missions.models import (
-        Mission,
-        MissionCollection,
-        MissionTask,
-    )
+    from app.modules.missions.models import Mission, MissionCollection, MissionTask
 
     ASSETS = 1000
     MISSION_COLLECTIONS = 2
@@ -322,11 +310,8 @@ def test_mission_scalability(flask_app_client, data_manager_1, test_root):
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')
 def test_get_mission_assets(flask_app_client, data_manager_1, test_root):
-    from app.modules.missions.models import (
-        Mission,
-        MissionCollection,
-    )
     from app.extensions import elasticsearch as es
+    from app.modules.missions.models import Mission, MissionCollection
 
     if es.is_disabled():
         return

--- a/tests/modules/missions/resources/test_create_task.py
+++ b/tests/modules/missions/resources/test_create_task.py
@@ -1,26 +1,25 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
-from tests import utils
-from tests.modules.missions.resources import utils as mission_utils
-from tests.utils import random_guid, wait_for_elasticsearch_status
-import tests.extensions.tus.utils as tus_utils
 import pytest
 
-from tests.utils import module_unavailable
+import tests.extensions.tus.utils as tus_utils
+from tests import utils
+from tests.modules.missions.resources import utils as mission_utils
+from tests.utils import module_unavailable, random_guid, wait_for_elasticsearch_status
 
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')
 def test_create_and_delete_mission_task(flask_app_client, data_manager_1, test_root, db):
     # pylint: disable=invalid-name
+    from app.extensions import elasticsearch as es
     from app.modules.missions.models import (
         Mission,
         MissionCollection,
         MissionTask,
-        MissionTaskUserAssignment,
         MissionTaskAssetParticipation,
+        MissionTaskUserAssignment,
     )
-    from app.extensions import elasticsearch as es
 
     if es.is_disabled():
         return
@@ -144,10 +143,7 @@ def test_mission_task_permission(
     data_manager_2,
     test_root,
 ):
-    from app.modules.missions.models import (
-        Mission,
-        MissionCollection,
-    )
+    from app.modules.missions.models import Mission, MissionCollection
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     transaction_ids = []
@@ -271,11 +267,7 @@ def test_set_operation_permission(
     data_manager_2,
     test_root,
 ):
-    from app.modules.missions.models import (
-        Mission,
-        MissionCollection,
-        MissionTask,
-    )
+    from app.modules.missions.models import Mission, MissionCollection, MissionTask
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     transaction_ids = []

--- a/tests/modules/missions/resources/test_get_collection.py
+++ b/tests/modules/missions/resources/test_get_collection.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from tests.utils import module_unavailable, random_guid
-from tests.modules.missions.resources import utils as mission_utils
 import tests.extensions.tus.utils as tus_utils
+from tests.modules.missions.resources import utils as mission_utils
+from tests.utils import module_unavailable, random_guid
 
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')

--- a/tests/modules/missions/resources/test_get_mission.py
+++ b/tests/modules/missions/resources/test_get_mission.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from tests.utils import module_unavailable
 from tests.modules.missions.resources import utils as mission_utils
+from tests.utils import module_unavailable
 
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')

--- a/tests/modules/missions/resources/test_get_task.py
+++ b/tests/modules/missions/resources/test_get_task.py
@@ -1,14 +1,10 @@
 # -*- coding: utf-8 -*-
 import pytest
 
-from tests import utils
-from tests.utils import (
-    module_unavailable,
-    random_guid,
-    wait_for_elasticsearch_status,
-)
-from tests.modules.missions.resources import utils as mission_utils
 import tests.extensions.tus.utils as tus_utils
+from tests import utils
+from tests.modules.missions.resources import utils as mission_utils
+from tests.utils import module_unavailable, random_guid, wait_for_elasticsearch_status
 
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')
@@ -20,11 +16,7 @@ def test_get_mission_task_not_found(flask_app_client):
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')
 def test_get_mission_task_by_search(flask_app_client, data_manager_1, test_root):
-    from app.modules.missions.models import (
-        Mission,
-        MissionCollection,
-        MissionTask,
-    )
+    from app.modules.missions.models import Mission, MissionCollection, MissionTask
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     transaction_ids = []

--- a/tests/modules/missions/resources/test_modify_collection.py
+++ b/tests/modules/missions/resources/test_modify_collection.py
@@ -1,13 +1,14 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import tests.modules.missions.resources.utils as mission_utils
-import tests.extensions.tus.utils as tus_utils
-from tests import utils as test_utils
-import pytest
+import os
 import pathlib
 import shutil
-import os
 
+import pytest
+
+import tests.extensions.tus.utils as tus_utils
+import tests.modules.missions.resources.utils as mission_utils
+from tests import utils as test_utils
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/missions/resources/test_modify_mission.py
+++ b/tests/modules/missions/resources/test_modify_mission.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
-from tests import utils
-from tests.modules.missions.resources import utils as mission_utils
 import pytest
 
+from tests import utils
+from tests.modules.missions.resources import utils as mission_utils
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/missions/resources/test_modify_task.py
+++ b/tests/modules/missions/resources/test_modify_task.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
-from tests import utils
-from tests.modules.missions.resources import utils as mission_utils
-from tests.utils import random_guid, wait_for_elasticsearch_status
-import tests.extensions.tus.utils as tus_utils
 import datetime
-import pytest
 import time
 
-from tests.utils import module_unavailable
+import pytest
+
+import tests.extensions.tus.utils as tus_utils
+from tests import utils
+from tests.modules.missions.resources import utils as mission_utils
+from tests.utils import module_unavailable, random_guid, wait_for_elasticsearch_status
 
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')
@@ -17,13 +17,9 @@ def test_modify_mission_task_users(
     db, flask_app_client, data_manager_1, data_manager_2, test_root
 ):
     # pylint: disable=invalid-name
-    from app.modules.missions.models import (
-        Mission,
-        MissionCollection,
-        MissionTask,
-    )
-    from app.modules.assets.models import Asset
     from app.extensions import elasticsearch as es
+    from app.modules.assets.models import Asset
+    from app.modules.missions.models import Mission, MissionCollection, MissionTask
 
     if es.is_disabled():
         return
@@ -156,10 +152,7 @@ def test_modify_mission_task_users(
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')
 def test_owner_permission(flask_app_client, data_manager_1, data_manager_2, test_root):
-    from app.modules.missions.models import (
-        Mission,
-        MissionCollection,
-    )
+    from app.modules.missions.models import Mission, MissionCollection
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     transaction_ids = []

--- a/tests/modules/missions/resources/utils.py
+++ b/tests/modules/missions/resources/utils.py
@@ -8,7 +8,6 @@ from unittest import mock
 
 from tests import utils as test_utils
 
-
 PATH_MISSIONS = '/api/v1/missions/'
 PATH_MISSION_COLLECTIONS = '/api/v1/missions/collections/'
 PATH_MISSION_COLLECTIONS_FOR_MISSION = '/api/v1/missions/%s/collections/'
@@ -29,7 +28,7 @@ ANNOTATION_UUIDS = [
 
 def make_name(class_name='mission'):
     nonce = test_utils.random_nonce(8)
-    name = 'This is a test %s (%s), please ignore' % (
+    name = 'This is a test {} ({}), please ignore'.format(
         class_name,
         nonce,
     )
@@ -57,7 +56,7 @@ def create_mission(flask_app_client, user, title, expected_status_code=200):
 def patch_mission(flask_app_client, mission_guid, user, data, expected_status_code=200):
     with flask_app_client.login(user, auth_scopes=('missions:write',)):
         response = flask_app_client.patch(
-            '%s%s' % (PATH_MISSIONS, mission_guid),
+            '{}{}'.format(PATH_MISSIONS, mission_guid),
             content_type='application/json',
             data=json.dumps(data),
         )
@@ -73,7 +72,7 @@ def patch_mission(flask_app_client, mission_guid, user, data, expected_status_co
 
 def read_mission(flask_app_client, user, mission_guid, expected_status_code=200):
     with flask_app_client.login(user, auth_scopes=('missions:read',)):
-        response = flask_app_client.get('%s%s' % (PATH_MISSIONS, mission_guid))
+        response = flask_app_client.get('{}{}'.format(PATH_MISSIONS, mission_guid))
 
     if expected_status_code == 200:
         test_utils.validate_dict_response(response, 200, {'guid', 'title'})
@@ -123,7 +122,7 @@ def elasticsearch_mission_assets(
 
 def delete_mission(flask_app_client, user, mission_guid, expected_status_code=204):
     with flask_app_client.login(user, auth_scopes=('missions:delete',)):
-        response = flask_app_client.delete('%s%s' % (PATH_MISSIONS, mission_guid))
+        response = flask_app_client.delete('{}{}'.format(PATH_MISSIONS, mission_guid))
 
     if expected_status_code == 204:
         assert response.status_code == 204
@@ -223,8 +222,8 @@ def read_mission_collections_for_mission(
 def delete_mission_collection(
     flask_app_client, user, mission_collection_guid, expected_status_code=204
 ):
-    from app.modules.missions.models import MissionCollection
     from app.extensions.git_store.tasks import delete_remote
+    from app.modules.missions.models import MissionCollection
 
     with mock.patch('app.modules.missions.tasks') as tasks:
         # Do delete_remote in the foreground immediately instead of using a
@@ -234,7 +233,7 @@ def delete_mission_collection(
         )
         with flask_app_client.login(user, auth_scopes=('missions:write',)):
             response = flask_app_client.delete(
-                '%s%s' % (PATH_MISSION_COLLECTIONS, mission_collection_guid)
+                '{}{}'.format(PATH_MISSION_COLLECTIONS, mission_collection_guid)
             )
 
     if expected_status_code == 204:
@@ -270,7 +269,7 @@ def update_mission_task(
 ):
     with flask_app_client.login(user, auth_scopes=('missions:write',)):
         response = flask_app_client.post(
-            '%s%s' % (PATH_MISSION_TASKS, mission_task_guid),
+            '{}{}'.format(PATH_MISSION_TASKS, mission_task_guid),
             content_type='application/json',
             data=json.dumps(data),
         )
@@ -289,7 +288,7 @@ def patch_mission_task(
 ):
     with flask_app_client.login(user, auth_scopes=('missions:write',)):
         response = flask_app_client.patch(
-            '%s%s' % (PATH_MISSION_TASKS, mission_task_guid),
+            '{}{}'.format(PATH_MISSION_TASKS, mission_task_guid),
             content_type='application/json',
             data=json.dumps(data),
         )
@@ -307,7 +306,9 @@ def read_mission_task(
     flask_app_client, user, mission_task_guid, expected_status_code=200
 ):
     with flask_app_client.login(user, auth_scopes=('missions:read',)):
-        response = flask_app_client.get('%s%s' % (PATH_MISSION_TASKS, mission_task_guid))
+        response = flask_app_client.get(
+            '{}{}'.format(PATH_MISSION_TASKS, mission_task_guid)
+        )
 
     if expected_status_code == 200:
         test_utils.validate_dict_response(response, 200, {'guid', 'title'})
@@ -353,7 +354,7 @@ def delete_mission_task(
 ):
     with flask_app_client.login(user, auth_scopes=('missions:delete',)):
         response = flask_app_client.delete(
-            '%s%s' % (PATH_MISSION_TASKS, mission_task_guid)
+            '{}{}'.format(PATH_MISSION_TASKS, mission_task_guid)
         )
 
     if expected_status_code == 204:

--- a/tests/modules/missions/test_collection_tus_creation.py
+++ b/tests/modules/missions/test_collection_tus_creation.py
@@ -2,11 +2,12 @@
 # pylint: disable=invalid-name,missing-docstring
 import os
 import pathlib
-import pytest
 import shutil
 
-from tests.utils import module_unavailable
+import pytest
+
 from tests.extensions.tus import utils as tus_utils
+from tests.utils import module_unavailable
 
 
 @pytest.mark.skipif(module_unavailable('missions'), reason='Missions module disabled')

--- a/tests/modules/missions/test_models.py
+++ b/tests/modules/missions/test_models.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name,missing-docstring
 
-import sqlalchemy
-import pytest
-
 import logging
+
+import pytest
+import sqlalchemy
+
 from tests.utils import module_unavailable
 
 
@@ -12,10 +13,7 @@ from tests.utils import module_unavailable
 def test_mission_add_members(
     db, temp_user, data_manager_1, data_manager_2
 ):  # pylint: disable=unused-argument
-    from app.modules.missions.models import (
-        Mission,
-        MissionUserAssignment,
-    )
+    from app.modules.missions.models import Mission, MissionUserAssignment
 
     temp_mission = Mission(
         title='Temp Mission',

--- a/tests/modules/names/test_models.py
+++ b/tests/modules/names/test_models.py
@@ -3,6 +3,7 @@
 
 import pytest
 import sqlalchemy
+
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/notifications/resources/test_notifications.py
+++ b/tests/modules/notifications/resources/test_notifications.py
@@ -2,16 +2,17 @@
 # pylint: disable=invalid-name,missing-docstring
 
 import logging
+
 import pytest
+
+import tests.modules.notifications.resources.utils as notif_utils
+import tests.modules.users.resources.utils as user_utils
 import tests.utils as test_utils
 from app.modules.notifications.models import (
     Notification,
-    NotificationType,
     NotificationBuilder,
+    NotificationType,
 )
-import tests.modules.notifications.resources.utils as notif_utils
-import tests.modules.users.resources.utils as user_utils
-
 from tests.utils import module_unavailable
 
 log = logging.getLogger(__name__)

--- a/tests/modules/notifications/resources/utils.py
+++ b/tests/modules/notifications/resources/utils.py
@@ -4,6 +4,7 @@ notification resources utils
 -------------
 """
 import json
+
 from tests import utils as test_utils
 
 PATH = '/api/v1/notifications/'

--- a/tests/modules/notifications/test_models.py
+++ b/tests/modules/notifications/test_models.py
@@ -4,19 +4,18 @@
 import logging
 
 import pytest
+
 from app.modules.notifications.models import (
+    NOTIFICATION_DEFAULTS,
     Notification,
+    NotificationBuilder,
     NotificationChannel,
     NotificationType,
-    NotificationBuilder,
-    UserNotificationPreferences,
-    NOTIFICATION_DEFAULTS,
     SystemNotificationPreferences,
+    UserNotificationPreferences,
 )
 from app.utils import HoustonException
-
 from tests.utils import module_unavailable
-
 
 log = logging.getLogger(__name__)
 
@@ -103,9 +102,9 @@ def test_notification_message(db, researcher_1, researcher_2, flask_app, request
 
 def test_validate_preferences():
     from app.modules.notifications.models import (
+        NotificationChannel,
         NotificationPreferences,
         NotificationType,
-        NotificationChannel,
     )
 
     with pytest.raises(HoustonException) as exc:
@@ -115,7 +114,7 @@ def test_validate_preferences():
     with pytest.raises(HoustonException) as exc:
         NotificationPreferences.validate_preferences({'random': 'value'})
 
-    valid_options = sorted([i.value for i in NotificationType.__members__.values()])
+    valid_options = sorted(i.value for i in NotificationType.__members__.values())
     assert (
         str(exc.value)
         == f'Unknown field(s): random, options are {", ".join(valid_options)}.'
@@ -123,7 +122,7 @@ def test_validate_preferences():
 
     with pytest.raises(HoustonException) as exc:
         NotificationPreferences.validate_preferences({'all': {'random': True}})
-    valid_channels = sorted([i.value for i in NotificationChannel.__members__.values()])
+    valid_channels = sorted(i.value for i in NotificationChannel.__members__.values())
     assert (
         str(exc.value)
         == f'"all": Unknown field(s): random, options are {", ".join(valid_channels)}.'

--- a/tests/modules/organizations/resources/disabled_test_create_organization.py
+++ b/tests/modules/organizations/resources/disabled_test_create_organization.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 import json
+
 from tests import utils
 
 PATH = '/api/v1/organizations/'
@@ -31,13 +32,13 @@ def test_create_and_delete_organization(flask_app_client, admin_user, temp_user)
 
     # Try reading it back
     with flask_app_client.login(temp_user, auth_scopes=('organizations:read',)):
-        response = flask_app_client.get('%s%s' % (PATH, organization_guid))
+        response = flask_app_client.get('{}{}'.format(PATH, organization_guid))
 
     utils.validate_dict_response(response, 200, {'guid', 'title'})
 
     # And deleting it
     with flask_app_client.login(temp_user, auth_scopes=('organizations:write',)):
-        response = flask_app_client.delete('%s%s' % (PATH, organization_guid))
+        response = flask_app_client.delete('{}{}'.format(PATH, organization_guid))
 
     assert response.status_code == 204
     read_organization = Organization.query.get(organization_guid)

--- a/tests/modules/organizations/resources/test_get_organization.py
+++ b/tests/modules/organizations/resources/test_get_organization.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
+
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/organizations/test_models.py
+++ b/tests/modules/organizations/test_models.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name,missing-docstring
 
+import logging
+
+import pytest
 import sqlalchemy
 
-import logging
-import pytest
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/projects/resources/disabled_test_create_project.py
+++ b/tests/modules/projects/resources/disabled_test_create_project.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
-from tests.modules.projects.resources import utils as proj_utils
 import pytest
 
+from tests.modules.projects.resources import utils as proj_utils
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/projects/resources/disabled_test_modify_project.py
+++ b/tests/modules/projects/resources/disabled_test_modify_project.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
-from tests import utils
-from tests.modules.projects.resources import utils as proj_utils
 import pytest
 
+from tests import utils
+from tests.modules.projects.resources import utils as proj_utils
 from tests.utils import module_unavailable
 
 
@@ -12,8 +12,8 @@ from tests.utils import module_unavailable
 def test_modify_project(db, flask_app_client, admin_user, researcher_1, researcher_2):
 
     # pylint: disable=invalid-name
-    from app.modules.projects.models import Project
     from app.modules.encounters.models import Encounter
+    from app.modules.projects.models import Project
 
     response = proj_utils.create_project(
         flask_app_client, researcher_1, 'This is a test project, please ignore'
@@ -87,8 +87,8 @@ def test_invalid_encounters(
     test_empty_asset_group_uuid,
 ):
     # pylint: disable=invalid-name
-    from app.modules.projects.models import Project
     from app.modules.encounters.models import Encounter
+    from app.modules.projects.models import Project
 
     response = proj_utils.create_project(
         flask_app_client, researcher_1, 'This is a test project, please ignore'
@@ -208,8 +208,8 @@ def test_owner_permission(flask_app_client, researcher_1, researcher_2):
 
 @pytest.mark.skipif(module_unavailable('projects'), reason='Projects module disabled')
 def test_member_permission(db, flask_app_client, researcher_1, researcher_2):
-    from app.modules.projects.models import Project
     from app.modules.encounters.models import Encounter
+    from app.modules.projects.models import Project
 
     response = proj_utils.create_project(
         flask_app_client, researcher_1, 'This is a test project, please ignore'
@@ -264,8 +264,8 @@ def test_member_permission(db, flask_app_client, researcher_1, researcher_2):
 
 @pytest.mark.skipif(module_unavailable('projects'), reason='Projects module disabled')
 def test_non_member_permission(db, flask_app_client, researcher_1, researcher_2):
-    from app.modules.projects.models import Project
     from app.modules.encounters.models import Encounter
+    from app.modules.projects.models import Project
 
     response = proj_utils.create_project(
         flask_app_client, researcher_1, 'This is a test project, please ignore'

--- a/tests/modules/projects/resources/utils.py
+++ b/tests/modules/projects/resources/utils.py
@@ -4,6 +4,7 @@ Project resources utils
 -------------
 """
 import json
+
 from tests import utils as test_utils
 
 PATH = '/api/v1/projects/'
@@ -28,7 +29,7 @@ def create_project(flask_app_client, user, title, expected_status_code=200):
 def patch_project(flask_app_client, project_guid, user, data, expected_status_code=200):
     with flask_app_client.login(user, auth_scopes=('projects:write',)):
         response = flask_app_client.patch(
-            '%s%s' % (PATH, project_guid),
+            '{}{}'.format(PATH, project_guid),
             content_type='application/json',
             data=json.dumps(data),
         )
@@ -44,7 +45,7 @@ def patch_project(flask_app_client, project_guid, user, data, expected_status_co
 
 def read_project(flask_app_client, user, project_guid, expected_status_code=200):
     with flask_app_client.login(user, auth_scopes=('projects:read',)):
-        response = flask_app_client.get('%s%s' % (PATH, project_guid))
+        response = flask_app_client.get('{}{}'.format(PATH, project_guid))
 
     if expected_status_code == 200:
         test_utils.validate_dict_response(response, 200, {'guid', 'title'})
@@ -70,7 +71,7 @@ def read_all_projects(flask_app_client, user, expected_status_code=200):
 
 def delete_project(flask_app_client, user, project_guid, expected_status_code=204):
     with flask_app_client.login(user, auth_scopes=('projects:delete',)):
-        response = flask_app_client.delete('%s%s' % (PATH, project_guid))
+        response = flask_app_client.delete('{}{}'.format(PATH, project_guid))
 
     if expected_status_code == 204:
         assert response.status_code == 204

--- a/tests/modules/projects/test_models.py
+++ b/tests/modules/projects/test_models.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name,missing-docstring
 
-import sqlalchemy
-
 import logging
+
 import pytest
+import sqlalchemy
 
 from tests.utils import module_unavailable
 
@@ -13,10 +13,7 @@ from tests.utils import module_unavailable
 def test_project_add_members(
     db, temp_user, researcher_1, researcher_2
 ):  # pylint: disable=unused-argument
-    from app.modules.projects.models import (
-        Project,
-        ProjectUserMembershipEnrollment,
-    )
+    from app.modules.projects.models import Project, ProjectUserMembershipEnrollment
 
     temp_proj = Project(
         title='Temp Project',

--- a/tests/modules/projects/test_parameters.py
+++ b/tests/modules/projects/test_parameters.py
@@ -11,8 +11,8 @@ def test_project_remove_encounters(
 ):  # pylint: disable=unused-argument
     # pylint: disable=unused-argument
     from app.modules.asset_groups.models import AssetGroup
-    from app.modules.projects.parameters import PatchProjectDetailsParameters
     from app.modules.projects.models import Project
+    from app.modules.projects.parameters import PatchProjectDetailsParameters
 
     temp_proj = Project(
         title='Temp Project',

--- a/tests/modules/relationships/resources/test_relationship_crud.py
+++ b/tests/modules/relationships/resources/test_relationship_crud.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name,missing-docstring
 
-import logging
-
-from tests.utils import module_unavailable
 import datetime
-import pytest
+import logging
 import uuid
 
+import pytest
+
+from tests.utils import module_unavailable
 
 log = logging.getLogger(__name__)
 
@@ -19,11 +19,11 @@ log = logging.getLogger(__name__)
 def test_create_read_delete_relationship(
     flask_app_client, admin_user, researcher_1, request, test_root
 ):
-    from tests.modules.individuals.resources import utils as individual_utils
+    from app.modules.relationships.models import Relationship
     from tests.modules.encounters.resources import utils as encounter_utils
+    from tests.modules.individuals.resources import utils as individual_utils
     from tests.modules.relationships.resources import utils as relationship_utils
     from tests.modules.site_settings.resources import utils as site_settings_utils
-    from app.modules.relationships.models import Relationship
 
     family_type_guid = '49e85f81-c11a-42be-9097-d22c61345ed8'
     mother_role_guid = '1b62eb1a-0b80-4c2d-b914-923beba8863c'

--- a/tests/modules/relationships/resources/utils.py
+++ b/tests/modules/relationships/resources/utils.py
@@ -3,8 +3,9 @@
 Relationship resources utils
 -------------
 """
-import logging
 import json
+import logging
+
 from tests import utils as test_utils
 
 PATH = '/api/v1/relationships/'
@@ -35,7 +36,7 @@ def read_relationship(
     flask_app_client, regular_user, relationship_guid, expected_status_code=200
 ):
     with flask_app_client.login(regular_user, auth_scopes=('relationships:read',)):
-        response = flask_app_client.get('%s%s' % (PATH, relationship_guid))
+        response = flask_app_client.get('{}{}'.format(PATH, relationship_guid))
 
     assert response.status_code == expected_status_code
     if response.status_code == 200:
@@ -52,7 +53,7 @@ def delete_relationship(
     flask_app_client, user, relationship_guid, expected_status_code=204
 ):
     with flask_app_client.login(user, auth_scopes=('relationships:write',)):
-        response = flask_app_client.delete('%s%s' % (PATH, relationship_guid))
+        response = flask_app_client.delete('{}{}'.format(PATH, relationship_guid))
 
     if expected_status_code == 204:
         assert response.status_code == 204
@@ -72,7 +73,7 @@ def patch_relationship(
 ):
     with flask_app_client.login(user, auth_scopes=('relationships:write',)):
         response = flask_app_client.patch(
-            '%s%s' % (PATH, relationship_guid),
+            '{}{}'.format(PATH, relationship_guid),
             data=json.dumps(patch_data),
             content_type='application/json',
             headers=headers,

--- a/tests/modules/relationships/test_relationship_model.py
+++ b/tests/modules/relationships/test_relationship_model.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name,missing-docstring
 
-from tests.utils import module_unavailable
-import pytest
 import uuid
+
+import pytest
+
+from tests.utils import module_unavailable
 
 
 @pytest.mark.skipif(
@@ -13,7 +15,6 @@ import uuid
 def test_relationship_instantiation(db, staff_user, flask_app_client, request, test_root):
     from app.modules.relationships.models import Relationship
     from app.modules.site_settings.models import SiteSetting
-
     from tests.modules.individuals.resources import utils as indiv_utils
     from tests.modules.relationships.resources import utils as relationship_utils
 

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -1,15 +1,15 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
+import datetime
 import uuid
 
-from tests.modules.sightings.resources import utils as sighting_utils
-from tests.modules.individuals.resources import utils as individual_utils
-from tests.modules.asset_groups.resources import utils as asset_group_utils
-from tests.extensions.tus import utils as tus_utils
-from tests import utils as test_utils
-import datetime
 import pytest
 
+from tests import utils as test_utils
+from tests.extensions.tus import utils as tus_utils
+from tests.modules.asset_groups.resources import utils as asset_group_utils
+from tests.modules.individuals.resources import utils as individual_utils
+from tests.modules.sightings.resources import utils as sighting_utils
 from tests.utils import module_unavailable
 
 timestamp = datetime.datetime.now().isoformat() + '+00:00'
@@ -86,8 +86,8 @@ def test_create_failures(flask_app_client, test_root, researcher_1, request):
 def test_create_and_modify_and_delete_sighting(
     db, flask_app_client, researcher_1, test_root, staff_user, request
 ):
-    from app.modules.sightings.models import Sighting
     from app.modules.complex_date_time.models import Specificities
+    from app.modules.sightings.models import Sighting
 
     # we should end up with these same counts (which _should be_ all zeros!)
     orig_ct = test_utils.all_count(db)
@@ -378,12 +378,12 @@ def test_create_anon_and_delete_sighting(
     sighting = Sighting.query.get(sighting_id)
     assert sighting is not None
     asset_guids.sort()
-    assert sorted([str(a.asset_guid) for a in sighting.sighting_assets]) == asset_guids
+    assert sorted(str(a.asset_guid) for a in sighting.sighting_assets) == asset_guids
 
     # Check assets are returned in GET sighting
     with flask_app_client.login(staff_user, auth_scopes=('sightings:read',)):
         response = flask_app_client.get(f'/api/v1/sightings/{sighting_id}')
-        assert sorted([a['guid'] for a in response.json['assets']]) == asset_guids
+        assert sorted(a['guid'] for a in response.json['assets']) == asset_guids
 
     # test some modification; this should fail (401) cuz anon should not be allowed
     new_loc_id = 'test_2_fail'
@@ -587,9 +587,9 @@ def test_complex_mixed_patch(
 def test_create_sighting_time_test(
     flask_app, flask_app_client, researcher_1, request, test_root
 ):
-    from tests.modules.sightings.resources import utils as sighting_utils
-    from app.modules.sightings.models import Sighting
     from app.modules.complex_date_time.models import Specificities
+    from app.modules.sightings.models import Sighting
+    from tests.modules.sightings.resources import utils as sighting_utils
 
     # test with invalid time
     sighting_data = {

--- a/tests/modules/sightings/resources/test_custom_fields.py
+++ b/tests/modules/sightings/resources/test_custom_fields.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
-from tests.modules.sightings.resources import utils as sighting_utils
-from tests.modules.site_settings.resources import utils as setting_utils
 import pytest
 
+from tests.modules.sightings.resources import utils as sighting_utils
+from tests.modules.site_settings.resources import utils as setting_utils
 from tests.utils import module_unavailable
 
 
@@ -19,8 +19,9 @@ def test_custom_fields_on_sighting(
     test_asset_group_uuid,
     request,
 ):
-    from app.modules.sightings.models import Sighting
     import datetime
+
+    from app.modules.sightings.models import Sighting
 
     cfd_id = setting_utils.custom_field_create(
         flask_app_client, admin_user, 'test_cfd', cls='Sighting'

--- a/tests/modules/sightings/resources/test_delete_cascade.py
+++ b/tests/modules/sightings/resources/test_delete_cascade.py
@@ -14,13 +14,14 @@
 # but there may be some redundancy with these tests in here.
 
 
-from tests.modules.sightings.resources import utils as sighting_utils
-from tests.modules.individuals.resources import utils as individual_utils
-from tests.modules.encounters.resources import utils as encounter_utils
-from tests import utils as test_utils
 import datetime
+
 import pytest
 
+from tests import utils as test_utils
+from tests.modules.encounters.resources import utils as encounter_utils
+from tests.modules.individuals.resources import utils as individual_utils
+from tests.modules.sightings.resources import utils as sighting_utils
 from tests.utils import module_unavailable
 
 timestamp = datetime.datetime.now().isoformat() + '+00:00'

--- a/tests/modules/sightings/resources/test_edm_sighting.py
+++ b/tests/modules/sightings/resources/test_edm_sighting.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import tests.modules.sightings.resources.utils as sighting_utils
-import pytest
 import datetime
 
-from tests.utils import module_unavailable
+import pytest
 
+import tests.modules.sightings.resources.utils as sighting_utils
+from tests.utils import module_unavailable
 
 timestamp = datetime.datetime.now().isoformat() + '+00:00'
 

--- a/tests/modules/sightings/resources/test_identify_sighting.py
+++ b/tests/modules/sightings/resources/test_identify_sighting.py
@@ -1,15 +1,14 @@
 # -*- coding: utf-8 -*-
 import uuid
 
+import pytest
+
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.modules.sightings.resources.utils as sighting_utils
 import tests.utils as test_utils
-
-import pytest
-
 from tests.utils import (
-    module_unavailable,
     extension_unavailable,
+    module_unavailable,
     wait_for_elasticsearch_status,
 )
 
@@ -61,9 +60,9 @@ def test_sighting_identification(
     request,
 ):
     # pylint: disable=invalid-name
-    from app.modules.sightings.models import Sighting, SightingStage
-    from app.modules.annotations.models import Annotation
     from app.extensions import elasticsearch as es
+    from app.modules.annotations.models import Annotation
+    from app.modules.sightings.models import Sighting, SightingStage
 
     if es.is_disabled():
         pytest.skip('Elasticsearch disabled (via command-line)')

--- a/tests/modules/sightings/resources/test_sighting_assets.py
+++ b/tests/modules/sightings/resources/test_sighting_assets.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-from tests import utils
-from tests.modules.sightings.resources import utils as sighting_utils
 import pytest
 
+from tests import utils
+from tests.modules.sightings.resources import utils as sighting_utils
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/sightings/resources/test_sighting_delete_empty.py
+++ b/tests/modules/sightings/resources/test_sighting_delete_empty.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 import logging
-from tests import utils as test_utils
-import pytest
-from tests.utils import module_unavailable
 
+import pytest
+
+from tests import utils as test_utils
+from tests.utils import module_unavailable
 
 log = logging.getLogger(__name__)
 

--- a/tests/modules/sightings/resources/test_sighting_elasticsearch.py
+++ b/tests/modules/sightings/resources/test_sighting_elasticsearch.py
@@ -6,7 +6,6 @@ from tests import utils as test_utils
 from tests.extensions.elasticsearch.resources import utils as es_utils
 from tests.modules.sightings.resources import utils
 
-
 EXPECTED_KEYS = {
     'created',
     'guid',

--- a/tests/modules/sightings/resources/test_sighting_encounter_fields.py
+++ b/tests/modules/sightings/resources/test_sighting_encounter_fields.py
@@ -1,11 +1,12 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
-from tests.modules.sightings.resources import utils as sighting_utils
-from tests.modules.site_settings.resources import utils as setting_utils
-import pytest
 import json
 
+import pytest
+
+from tests.modules.sightings.resources import utils as sighting_utils
+from tests.modules.site_settings.resources import utils as setting_utils
 from tests.utils import (
     module_unavailable,
     random_decimal_latitude,
@@ -25,8 +26,9 @@ def test_mega_data(
     request,
     test_root,
 ):
-    from app.modules.sightings.models import Sighting
     import datetime
+
+    from app.modules.sightings.models import Sighting
 
     # make some customFields in edm
     sighting_cfd_id = setting_utils.custom_field_create(

--- a/tests/modules/sightings/resources/test_sighting_featured_asset_guid.py
+++ b/tests/modules/sightings/resources/test_sighting_featured_asset_guid.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-from tests.modules.sightings.resources import utils as sighting_utils
-from tests.modules.asset_groups.resources import utils as asset_group_utils
-from tests import utils
 import pytest
 
+from tests import utils
+from tests.modules.asset_groups.resources import utils as asset_group_utils
+from tests.modules.sightings.resources import utils as sighting_utils
 from tests.utils import module_unavailable
 
 
@@ -118,8 +118,8 @@ def test_patch_featured_asset_guid_on_sighting(
 
 @pytest.mark.skipif(module_unavailable('sightings'), reason='Sightings module disabled')
 def test_featured_sighting_read(db, flask_app_client, researcher_1, test_root, request):
-    from app.modules.sightings.models import Sighting
     from app.modules.asset_groups.models import AssetGroup
+    from app.modules.sightings.models import Sighting
 
     uuids = sighting_utils.create_large_sighting(
         flask_app_client, researcher_1, request, test_root

--- a/tests/modules/sightings/resources/utils.py
+++ b/tests/modules/sightings/resources/utils.py
@@ -5,9 +5,9 @@ Project resources utils
 """
 import json
 
-from tests import utils as test_utils
 import tests.extensions.tus.utils as tus_utils
 import tests.modules.asset_groups.resources.utils as asset_group_utils
+from tests import utils as test_utils
 
 PATH = '/api/v1/sightings/'
 
@@ -238,7 +238,7 @@ def patch_sighting(
         flask_app_client,
         user,
         'sightings:write',
-        '%s%s' % (PATH, sighting_guid),
+        '{}{}'.format(PATH, sighting_guid),
         patch_data,
         expected_status_code,
         set(),
@@ -257,7 +257,9 @@ def delete_sighting(
     flask_app_client, user, sight_guid, expected_status_code=204, headers=None
 ):
     with flask_app_client.login(user, auth_scopes=('sightings:write',)):
-        response = flask_app_client.delete('%s%s' % (PATH, sight_guid), headers=headers)
+        response = flask_app_client.delete(
+            '{}{}'.format(PATH, sight_guid), headers=headers
+        )
 
     if expected_status_code == 204:
         assert response.status_code == 204, response.json

--- a/tests/modules/sightings/test_models.py
+++ b/tests/modules/sightings/test_models.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name,missing-docstring
 import logging
+
 import pytest
 
-from app.modules.users.models import User
 import tests.utils as test_utils
-
+from app.modules.users.models import User
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/site_settings/resources/test_bundles.py
+++ b/tests/modules/site_settings/resources/test_bundles.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-from tests.modules.site_settings.resources import utils as conf_utils
-from app.modules.site_settings.models import SiteSetting
 import uuid
+
 import pytest
 
-from tests.utils import module_unavailable, extension_unavailable
-
+from app.modules.site_settings.models import SiteSetting
+from tests.modules.site_settings.resources import utils as conf_utils
+from tests.utils import extension_unavailable, module_unavailable
 
 BUNDLE_PATH = 'block'
 

--- a/tests/modules/site_settings/resources/test_file_operations.py
+++ b/tests/modules/site_settings/resources/test_file_operations.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
 from pathlib import Path
 
+import pytest
+
 from app.modules.fileuploads.models import FileUpload
 from app.modules.site_settings.models import SiteSetting
-
 from tests.utils import (
     TemporaryDirectoryUUID,
-    module_unavailable,
     copy_uploaded_file,
+    module_unavailable,
     write_uploaded_file,
 )
-import pytest
 
 
 @pytest.mark.skipif(

--- a/tests/modules/site_settings/resources/test_read_configurations.py
+++ b/tests/modules/site_settings/resources/test_read_configurations.py
@@ -2,10 +2,10 @@
 # pylint: disable=missing-docstring
 import uuid
 
-from tests.modules.site_settings.resources import utils as conf_utils
 import pytest
 
-from tests.utils import module_unavailable, extension_unavailable
+from tests.modules.site_settings.resources import utils as conf_utils
+from tests.utils import extension_unavailable, module_unavailable
 
 
 @pytest.mark.skipif(extension_unavailable('edm'), reason='EDM extension disabled')

--- a/tests/modules/site_settings/resources/test_site_info.py
+++ b/tests/modules/site_settings/resources/test_site_info.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
 from unittest import mock
 
+import pytest
 from requests import Response
 
 import app.version
-import pytest
-
 from tests.utils import extension_unavailable
 
 

--- a/tests/modules/site_settings/test_models.py
+++ b/tests/modules/site_settings/test_models.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
+import uuid
 from pathlib import Path
+
+import pytest
 
 from app.modules.fileuploads.models import FileUpload
 from app.modules.site_settings.models import SiteSetting
-import uuid
-import pytest
-
 from tests.utils import extension_unavailable, is_extension_enabled
 
 

--- a/tests/modules/site_settings/test_regions.py
+++ b/tests/modules/site_settings/test_regions.py
@@ -3,9 +3,7 @@
 
 import pytest
 
-from tests.utils import (
-    extension_unavailable,
-)
+from tests.utils import extension_unavailable
 
 
 @pytest.mark.skipif(extension_unavailable('edm'), reason='EDM extension disabled')

--- a/tests/modules/site_settings/test_taxonomy.py
+++ b/tests/modules/site_settings/test_taxonomy.py
@@ -1,13 +1,11 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 
-from tests.modules.site_settings.resources import utils as setting_utils
-from app.modules.site_settings.models import Taxonomy
 import pytest
 
-from tests.utils import (
-    extension_unavailable,
-)
+from app.modules.site_settings.models import Taxonomy
+from tests.modules.site_settings.resources import utils as setting_utils
+from tests.utils import extension_unavailable
 
 
 @pytest.mark.skipif(extension_unavailable('edm'), reason='EDM extension disabled')

--- a/tests/modules/social_groups/resources/test_social_group.py
+++ b/tests/modules/social_groups/resources/test_social_group.py
@@ -3,14 +3,15 @@
 
 import logging
 import uuid
-import pytest
-from tests.utils import module_unavailable
 
-import tests.modules.social_groups.resources.utils as soc_group_utils
+import pytest
+
+import tests.modules.audit_logs.resources.utils as audit_utils
 import tests.modules.individuals.resources.utils as individual_utils
 import tests.modules.sightings.resources.utils as sighting_utils
-import tests.modules.audit_logs.resources.utils as audit_utils
+import tests.modules.social_groups.resources.utils as soc_group_utils
 from tests import utils as test_utils
+from tests.utils import module_unavailable
 
 log = logging.getLogger(__name__)
 
@@ -294,9 +295,9 @@ def test_role_changes(
     current_roles = get_response.json['response']['configuration']['social_group_roles'][
         'value'
     ]
-    assert set({'Matriarch', 'IrritatingGit'}) == set(
-        [role['label'] for role in current_roles]
-    )
+    assert set({'Matriarch', 'IrritatingGit'}) == {
+        role['label'] for role in current_roles
+    }
 
     # Create some individuals to use in testing
     individuals = create_individuals(flask_app_client, researcher_1, request, test_root)

--- a/tests/modules/social_groups/resources/utils.py
+++ b/tests/modules/social_groups/resources/utils.py
@@ -3,8 +3,8 @@
 social_group resources utils
 -------------
 """
-from tests import utils as test_utils
 import tests.modules.site_settings.resources.utils as setting_utils
+from tests import utils as test_utils
 
 PATH = '/api/v1/social-groups/'
 EXPECTED_KEYS = {'guid', 'name', 'members'}

--- a/tests/modules/test_ia_pipeline.py
+++ b/tests/modules/test_ia_pipeline.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import tests.modules.asset_groups.resources.utils as asset_group_utils
-import tests.modules.sightings.resources.utils as sighting_utils
-import tests.modules.encounters.resources.utils as enc_utils
-import tests.modules.annotations.resources.utils as annot_utils
-import tests.modules.assets.resources.utils as asset_utils
-
 import pytest
+
+import tests.modules.annotations.resources.utils as annot_utils
+import tests.modules.asset_groups.resources.utils as asset_group_utils
+import tests.modules.assets.resources.utils as asset_utils
+import tests.modules.encounters.resources.utils as enc_utils
+import tests.modules.sightings.resources.utils as sighting_utils
 from tests.utils import module_unavailable
 
 

--- a/tests/modules/users/resources/test_admin_init.py
+++ b/tests/modules/users/resources/test_admin_init.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 import json
+
 from app.modules.users.models import User
 
 

--- a/tests/modules/users/resources/test_getting_users_info.py
+++ b/tests/modules/users/resources/test_getting_users_info.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-import pytest
 import datetime
-from . import utils as user_utils
 
-from tests.utils import module_unavailable
+import pytest
+
 from app.modules import is_module_enabled
+from tests.utils import module_unavailable
 
+from . import utils as user_utils
 
 timestamp = datetime.datetime.now().isoformat() + 'Z'
 

--- a/tests/modules/users/resources/test_modifying_users_info.py
+++ b/tests/modules/users/resources/test_modifying_users_info.py
@@ -2,22 +2,18 @@
 # pylint: disable=missing-docstring
 import io
 import json
-from pathlib import Path
 import shutil
 import tempfile
 import uuid
+from pathlib import Path
 
-from app.modules.users.models import User
-from app.modules.fileuploads.models import FileUpload
-from flask_restx_patched import is_extension_enabled
 from PIL import Image
 
-from tests.utils import (
-    TemporaryDirectoryUUID,
-    copy_uploaded_file,
-    write_uploaded_file,
-)
 import tests.modules.users.resources.utils as user_utils
+from app.modules.fileuploads.models import FileUpload
+from app.modules.users.models import User
+from flask_restx_patched import is_extension_enabled
+from tests.utils import TemporaryDirectoryUUID, copy_uploaded_file, write_uploaded_file
 
 
 def test_user_id_not_found(flask_app_client, regular_user):

--- a/tests/modules/users/resources/test_options.py
+++ b/tests/modules/users/resources/test_options.py
@@ -2,7 +2,6 @@
 # pylint: disable=missing-docstring
 import pytest
 
-
 REPLACE_KEY = '<REPLACE_UUID>'
 
 
@@ -28,14 +27,14 @@ def test_users_options_unauthorized(
     'path,expected_allowed_methods',
     (
         ('/api/v1/users/', {'POST', 'OPTIONS'}),
-        ('/api/v1/users/%s' % (REPLACE_KEY,), {'GET', 'OPTIONS', 'PATCH', 'DELETE'}),
+        ('/api/v1/users/{}'.format(REPLACE_KEY), {'GET', 'OPTIONS', 'PATCH', 'DELETE'}),
     ),
 )
 def test_users_options_authorized(
     path, expected_allowed_methods, flask_app_client, regular_user
 ):
     if REPLACE_KEY in path:
-        path = path.replace(REPLACE_KEY, '%s' % (regular_user.guid,))
+        path = path.replace(REPLACE_KEY, '{}'.format(regular_user.guid))
 
     with flask_app_client.login(regular_user, auth_scopes=('users:write', 'users:read')):
         response = flask_app_client.options(path)

--- a/tests/modules/users/resources/test_signup.py
+++ b/tests/modules/users/resources/test_signup.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
-from unittest import mock
 import uuid
+from unittest import mock
+
 import tests.modules.users.resources.utils as user_utils
 from app.modules import is_module_enabled
-
 
 # from config import get_preliminary_config
 

--- a/tests/modules/users/resources/utils.py
+++ b/tests/modules/users/resources/utils.py
@@ -4,8 +4,9 @@ Asset_group resources utils
 -------------
 """
 
-from tests import utils as test_utils
 import json
+
+from tests import utils as test_utils
 
 PATH = '/api/v1/users/'
 
@@ -75,7 +76,7 @@ def patch_user(
 ):
     with flask_app_client.login(running_user, auth_scopes=('users:write',)):
         response = flask_app_client.patch(
-            '%s%s' % (PATH, user_modified.guid),
+            '{}{}'.format(PATH, user_modified.guid),
             content_type='application/json',
             data=json.dumps(data),
         )

--- a/tests/modules/users/test_permissions.py
+++ b/tests/modules/users/test_permissions.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=invalid-name,missing-docstring
-from mock import Mock, patch
 import pytest
-
+from mock import Mock, patch
 from werkzeug.exceptions import HTTPException
+
 import tests.utils as test_utils
-from tests.utils import module_unavailable
-
-
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
+from tests.utils import module_unavailable
 
 
 # helpers to make object and module reading and writing testing more intuitive
@@ -311,8 +309,8 @@ def test_ObjectAccessPermission_admin_user(
 )
 def test_ModuleAccessPermission_anonymous_user(anonymous_user_login):
     # pylint: disable=unused-argument
-    from app.modules.users.models import User
     from app.modules.asset_groups.models import AssetGroup
+    from app.modules.users.models import User
 
     # anon user cannot do anything with most classes
     validate_cannot_read_module(NotARealClass)
@@ -334,8 +332,8 @@ def test_ModuleAccessPermission_anonymous_user(anonymous_user_login):
 )
 def test_ModuleAccessPermission_authenticated_user(authenticated_user_login):
     # pylint: disable=unused-argument
-    from app.modules.users.models import User
     from app.modules.asset_groups.models import AssetGroup
+    from app.modules.users.models import User
 
     # regular users also shouldn't be able to access most classes
     validate_cannot_read_module(NotARealClass)
@@ -357,8 +355,8 @@ def test_ModuleAccessPermission_authenticated_user(authenticated_user_login):
 )
 def test_ModuleAccessPermission_admin_user(admin_user_login):
     # pylint: disable=unused-argument
-    from app.modules.users.models import User
     from app.modules.asset_groups.models import AssetGroup
+    from app.modules.users.models import User
 
     # Admin users cannot do what they like
     validate_cannot_read_module(NotARealClass)
@@ -381,8 +379,8 @@ def test_ModuleAccessPermission_admin_user(admin_user_login):
 )
 def test_ModuleAccessPermission_user_manager_user(user_manager_user_login):
     # pylint: disable=unused-argument
-    from app.modules.users.models import User
     from app.modules.asset_groups.models import AssetGroup
+    from app.modules.users.models import User
 
     # user Admins not especially priviliged
     validate_cannot_read_module(NotARealClass)
@@ -555,9 +553,9 @@ def test_ObjectAccessPermission_user_manager_user(
 def test_data_manager_and_staff_access(
     db, flask_app_client, researcher_1, data_manager_1, staff_user, request, test_root
 ):
+    import tests.modules.encounters.resources.utils as encounter_utils
     import tests.modules.individuals.resources.utils as individual_utils
     import tests.modules.sightings.resources.utils as sighting_utils
-    import tests.modules.encounters.resources.utils as encounter_utils
 
     # testing that staff and data_managers can edit and read these three objects
     uuids = individual_utils.create_individual_and_sighting(

--- a/tests/modules/users/test_schemas.py
+++ b/tests/modules/users/test_schemas.py
@@ -68,14 +68,12 @@ def test_DetailedUserSchema_dump_user_instance(user_instance):
     }
 
     if is_module_enabled('missions'):
-        desired_keys = desired_keys | set(
-            [
-                'owned_missions',
-                'owned_mission_tasks',
-                'assigned_missions',
-                'assigned_mission_tasks',
-            ]
-        )
+        desired_keys = desired_keys | {
+            'owned_missions',
+            'owned_mission_tasks',
+            'assigned_missions',
+            'assigned_mission_tasks',
+        }
 
     assert set(dumped_result.data.keys()) == desired_keys
 

--- a/tests/tasks/app/test_asset_groups.py
+++ b/tests/tasks/app/test_asset_groups.py
@@ -2,11 +2,11 @@
 import io
 import pathlib
 import re
-from unittest import mock
 import uuid
+from unittest import mock
 
-from invoke import MockContext
 import pytest
+from invoke import MockContext
 
 from tests.utils import module_unavailable
 
@@ -56,7 +56,7 @@ def test_create_asset_group_from_path(flask_app, test_root, admin_user, request)
 
     assert asset_group.owner == admin_user
     dir_files = sorted(f.name for f in pathlib.Path(test_root).glob('*'))
-    asset_paths = sorted([a.path for a in asset_group.assets])
+    asset_paths = sorted(a.path for a in asset_group.assets)
     assert dir_files == asset_paths
     assert asset_group.description == 'AssetGroup creation test'
 

--- a/tests/tasks/app/test_job_control.py
+++ b/tests/tasks/app/test_job_control.py
@@ -1,13 +1,12 @@
 # -*- coding: utf-8 -*-
+import pytest
+
 import tests.extensions.tus.utils as tus_utils
 import tests.modules.asset_groups.resources.utils as asset_group_utils
 import tests.utils as test_utils
-
-import pytest
-
 from tests.utils import (
-    module_unavailable,
     extension_unavailable,
+    module_unavailable,
     wait_for_elasticsearch_status,
 )
 
@@ -60,9 +59,9 @@ def test_sighting_identification_jobs(
     request,
 ):
     # pylint: disable=invalid-name
+    from app.extensions import elasticsearch as es
     from app.modules.annotations.models import Annotation
     from app.modules.sightings.models import Sighting, SightingStage
-    from app.extensions import elasticsearch as es
 
     if es.is_disabled():
         pytest.skip('Elasticsearch disabled (via command-line)')

--- a/tests/tasks/app/test_site_settings.py
+++ b/tests/tasks/app/test_site_settings.py
@@ -3,8 +3,9 @@ import io
 from pathlib import Path
 from unittest import mock
 
-from app.modules.site_settings.models import SiteSetting
 from invoke import MockContext
+
+from app.modules.site_settings.models import SiteSetting
 
 
 def test_site_settings(flask_app, db, request, test_root):

--- a/tests/tasks/test_codex_job_control.py
+++ b/tests/tasks/test_codex_job_control.py
@@ -2,8 +2,8 @@
 import importlib
 from unittest import mock
 
-from invoke import MockContext
 import pytest
+from invoke import MockContext
 
 from tests.modules.asset_groups.resources import utils as ag_utils
 from tests.modules.sightings.resources import utils as s_utils

--- a/tests/tasks/test_docker_compose.py
+++ b/tests/tasks/test_docker_compose.py
@@ -3,12 +3,11 @@ import pathlib
 from unittest import mock
 
 import invoke.exceptions
-from invoke import MockContext, Result
 import pytest
+from invoke import MockContext, Result
 
 import tasks.docker_compose
 from tests.utils import extension_unavailable
-
 
 with (pathlib.Path(__file__).parent.parent.parent / 'docker-compose.yml').open() as f:
     DOCKER_COMPOSE = f.read()

--- a/tests/tasks/test_utils.py
+++ b/tests/tasks/test_utils.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-from tasks.utils import download_file
+import hashlib
 import os
 from os.path import abspath, exists
-import hashlib
+
+from tasks.utils import download_file
 
 
 def test_download_file():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,12 +3,12 @@
 import pytest
 
 from config import (
-    configure_app,
     CONFIG_CLS_MAPPER,
     CONTEXT_ENVIRONMENT_VARIABLE,
-    get_preliminary_config,
     VALID_CONTEXTS,
     VALID_ENVIRONMENTS,
+    configure_app,
+    get_preliminary_config,
 )
 from config.utils import import_class
 

--- a/tests/test_tus.py
+++ b/tests/test_tus.py
@@ -7,7 +7,7 @@ import uuid
 
 import pytest
 
-from tests.utils import redis_unavailable, get_stored_path
+from tests.utils import get_stored_path, redis_unavailable
 
 
 def get_file_upload_filename():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -4,26 +4,26 @@ Testing utils
 -------------
 """
 
-from contextlib import contextmanager
 import datetime
 import json
+import logging
+import os
+import random
 import tempfile
+import time
+import uuid
+from contextlib import contextmanager
 
+import redis
 from flask import Response
 from flask.testing import FlaskClient
 from werkzeug.utils import cached_property
+
 from app.extensions.auth import security
-import logging
-import redis
-import time
-import random
-import uuid
-import os
-
 from config import get_preliminary_config
-from . import TEST_ASSET_GROUP_UUID, TEST_EMPTY_ASSET_GROUP_UUID
-
 from flask_restx_patched import is_extension_enabled, is_module_enabled
+
+from . import TEST_ASSET_GROUP_UUID, TEST_EMPTY_ASSET_GROUP_UUID
 
 
 class AutoAuthFlaskClient(FlaskClient):
@@ -199,7 +199,7 @@ def generate_user_instance(
         user_guid = uuid.uuid4()
 
     if email is None:
-        email = '%s@localhost' % (email,)
+        email = '{}@localhost'.format(email)
 
     if password is None:
         password = security.generate_random(128)
@@ -424,7 +424,7 @@ def delete_via_flask(
 def patch_test_op(value, path='current_password', guid=None):
     operation = {
         'op': 'test',
-        'path': '/%s' % (path,),
+        'path': '/{}'.format(path),
         'value': value,
     }
     if guid is not None:
@@ -435,7 +435,7 @@ def patch_test_op(value, path='current_password', guid=None):
 def patch_add_op(path, value, guid=None):
     operation = {
         'op': 'add',
-        'path': '/%s' % (path,),
+        'path': '/{}'.format(path),
         'value': value,
     }
     if guid is not None:
@@ -446,7 +446,7 @@ def patch_add_op(path, value, guid=None):
 def patch_remove_op(path, value=None, guid=None):
     operation = {
         'op': 'remove',
-        'path': '/%s' % (path,),
+        'path': '/{}'.format(path),
     }
     if value:
         operation['value'] = value
@@ -458,7 +458,7 @@ def patch_remove_op(path, value=None, guid=None):
 def patch_replace_op(path, value, guid=None):
     operation = {
         'op': 'replace',
-        'path': '/%s' % (path,),
+        'path': '/{}'.format(path),
         'value': value,
     }
     if guid is not None:
@@ -469,7 +469,7 @@ def patch_replace_op(path, value, guid=None):
 def set_union_op(path, value):
     operation = {
         'op': 'union',
-        'path': '/%s' % (path,),
+        'path': '/{}'.format(path),
         'value': value,
     }
     return operation
@@ -478,7 +478,7 @@ def set_union_op(path, value):
 def set_intersection_op(path, value):
     operation = {
         'op': 'intersection',
-        'path': '/%s' % (path,),
+        'path': '/{}'.format(path),
         'value': value,
     }
     return operation
@@ -487,7 +487,7 @@ def set_intersection_op(path, value):
 def set_difference_op(path, value):
     operation = {
         'op': 'difference',
-        'path': '/%s' % (path,),
+        'path': '/{}'.format(path),
         'value': value,
     }
     return operation
@@ -525,8 +525,8 @@ def all_count(db):
         count[cls.__name__] = row_count(db, cls)
 
     if is_module_enabled('assets', 'asset_groups'):
-        from app.modules.assets.models import Asset
         from app.modules.asset_groups.models import AssetGroup
+        from app.modules.assets.models import Asset
 
         asset_query = Asset.query
         asset_group_query = AssetGroup.query
@@ -618,8 +618,9 @@ def dummy_detection_info():
 
 
 def get_stored_path(full_path):
-    from app.utils import get_stored_filename
     import os
+
+    from app.utils import get_stored_filename
 
     dir, filename = os.path.split(full_path)
     stored_filename = get_stored_filename(filename)
@@ -714,7 +715,7 @@ def wait_for_elasticsearch_status(flask_app_client, user, force=True):
             status = get_elasticsearch_status(flask_app_client, user)
         except json.decoder.JSONDecodeError:
             status = {'error': 'decoding problem'}
-        log.info('Elasticsearch status: %s' % (status,))
+        log.info('Elasticsearch status: {}'.format(status))
 
         # Remove any outdated, disabled, health flags
         remove_keys = [
@@ -768,10 +769,10 @@ def elasticsearch(flask_app_client, user, namespace, data=None, expected_status_
     if data is None:
         data = {}
 
-    scope = '%s:read' % (namespace,)
+    scope = '{}:read'.format(namespace)
     with flask_app_client.login(user, auth_scopes=(scope,)):
         response = flask_app_client.post(
-            '/api/v1/%s/search/' % (namespace,),
+            '/api/v1/{}/search/'.format(namespace),
             content_type='application/json',
             data=json.dumps(data),
         )


### PR DESCRIPTION
A "small" PR that adds two new pre-commit hooks for

1.  upgrading our Python syntax to newer code practices and 
2. sorting and organizing our imports.  

**_Motivation: our imports are a freaking mess and the use of f-strings is wildly inconsistent_**

The first new hook is called [`pyupgrade`](https://github.com/asottile/pyupgrade) and can automate the conversion to f-strings, use less cluttered notation for sets, and comprehensions, and removes various Python language tools that have been needed for prior versions.  

The second hook is called [`isort`](https://pycqa.github.io/isort/index.html) and automates the organization of our imports in each file, ordering them by name and section.

Both code formatting steps are fully compatible with `Black` and `Flake8`.

The file `.pre-commit-config.yaml` was updated to add the following code:
``` yaml
  - repo: https://github.com/asottile/pyupgrade
     rev: v2.32.0
     hooks:
       - id: pyupgrade
         name: pyupgrade
         description: Run PyUpgrade on Python code.
   - repo: https://github.com/pycqa/isort
     rev: 5.10.1
     hooks:
       - id: isort
         args: [--settings-path setup.cfg]
         name: isort
         description: Run import sorting (isort) on Python code.
```
and all other code changes are a result of a one-time fix to apply the two new pre-commit routines