### PR TITLE
918 individual es name fix

### DIFF
--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -196,9 +196,7 @@ class Individual(db.Model, FeatherModel):
         return taxonomy_names
 
     def get_name_values(self):
-        name_vals = ''
-        for name in self.names:
-            name_vals += f'{name.value}, '
+        name_vals = [name.value for name in self.names]
         return name_vals
 
     def get_first_name(self):

--- a/tests/modules/individuals/resources/test_elasticsearch.py
+++ b/tests/modules/individuals/resources/test_elasticsearch.py
@@ -42,7 +42,7 @@ def test_individual_elasticsearch_mappings(
         'updated',
         # 'social_groups',
         'indexed',
-        'names',
+        # 'names',
         'last_seen',
         'death',
         'comments',

--- a/tests/modules/individuals/resources/test_individual_names.py
+++ b/tests/modules/individuals/resources/test_individual_names.py
@@ -494,7 +494,13 @@ def test_name_validation(
 
     assert validation_resp.json == desired_resp
 
-
+@pytest.mark.skipif(
+    module_unavailable('individuals'), reason='Individuals module disabled'
+)
+@pytest.mark.skipif(
+    extension_unavailable('elasticsearch') or module_unavailable('elasticsearch'),
+    reason='Elasticsearch extension or module disabled',
+)
 def test_elasticsearch_name_schema(
     db, flask_app_client, researcher_1, request, test_root
 ):

--- a/tests/modules/individuals/resources/test_individual_names.py
+++ b/tests/modules/individuals/resources/test_individual_names.py
@@ -493,3 +493,30 @@ def test_name_validation(
     ]
 
     assert validation_resp.json == desired_resp
+
+
+def test_elasticsearch_name_schema(
+    db, flask_app_client, researcher_1, request, test_root
+):
+    from app.modules.individuals.models import Individual
+    from app.modules.individuals.schemas import ElasticsearchIndividualSchema
+
+    individual_utils.create_individual_and_sighting(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root,
+        individual_data={
+            'names': [
+                {'context': 'firstName', 'value': 'Z432'},
+                {'context': 'Christian name', 'value': 'Zachariah'},
+            ],
+        },
+    )
+    body = {}
+    indy = Individual.elasticsearch(body)[0]
+    # actually load the ES schema
+    es_schema = ElasticsearchIndividualSchema()
+    es_indy = es_schema.dump(indy).data
+    assert type(es_indy['names']) is list
+    assert es_indy['names'] == ['Z432', 'Zachariah']

--- a/tests/modules/individuals/resources/test_individual_names.py
+++ b/tests/modules/individuals/resources/test_individual_names.py
@@ -500,8 +500,9 @@ def test_elasticsearch_name_schema(
 ):
     from app.modules.individuals.models import Individual
     from app.modules.individuals.schemas import ElasticsearchIndividualSchema
+    from app.extensions import elasticsearch as es
 
-    individual_utils.create_individual_and_sighting(
+    create_resp = individual_utils.create_individual_and_sighting(
         flask_app_client,
         researcher_1,
         request,
@@ -513,6 +514,9 @@ def test_elasticsearch_name_schema(
             ],
         },
     )
+    ind = Individual.query.get(create_resp['individual'])
+    with es.session.begin(blocking=True, forced=True):
+        ind.index()
     body = {}
     indy = Individual.elasticsearch(body)[0]
     # actually load the ES schema

--- a/tests/modules/individuals/resources/test_individual_names.py
+++ b/tests/modules/individuals/resources/test_individual_names.py
@@ -7,7 +7,7 @@ from tests.modules.sightings.resources import utils as sighting_utils
 
 import pytest
 
-from tests.utils import module_unavailable
+from tests.utils import module_unavailable, extension_unavailable
 
 
 @pytest.mark.skipif(
@@ -493,6 +493,7 @@ def test_name_validation(
     ]
 
     assert validation_resp.json == desired_resp
+
 
 @pytest.mark.skipif(
     module_unavailable('individuals'), reason='Individuals module disabled'


### PR DESCRIPTION
Simple change to individual elasticsearch schema so names are returned as a list of strings rather than a single squashed-together string. From ticket https://wildme.atlassian.net/jira/software/projects/WB/boards/10?selectedIssue=DEX-918 .

The test is a little hacky because it manually applies the schema to an individual object which was (as an object, sans-schema) returned from the Individual.elasticsearch method. Did a little digging on how to call ES loading that schema but didn't feel worth more time since FE is already getting the correct schema loaded anyway.