### PR TITLE
Format result in codex.integrity tasks using pprint

### DIFF
--- a/tasks/codex/integrity.py
+++ b/tasks/codex/integrity.py
@@ -5,10 +5,11 @@ Application AssetGroup management related tasks for Invoke.
 
 from tasks.utils import app_context_task
 from app.extensions import db
+import pprint
 
 
 def print_result(result):
-    print(
+    pprint.pprint(
         f'Integrity check : GUID:{result.guid} created: {result.created} result: {result.result}'
     )
 


### PR DESCRIPTION
This is something we have on codex-qa, I'm not sure who added it but
let's just include it.  Using pprint means we'll have one uuid per line
instead of everything on one line.

