### PR TITLE
Add codex.job-control.check-sighting-jobs and .check-ags-jobs tasks

### DIFF
--- a/scripts/tests/run_tasks_for_coverage.sh
+++ b/scripts/tests/run_tasks_for_coverage.sh
@@ -73,6 +73,8 @@ if [ "$HOUSTON_APP_CONTEXT" == 'codex' ]; then
     coverage run --append `which invoke` codex.encounters.list-all
     coverage run --append `which invoke` codex.organizations.list-all
     coverage run --append `which invoke` codex.projects.list-all
+    coverage run --append `which invoke` codex.job-control.check-ags-jobs
+    coverage run --append `which invoke` codex.job-control.check-sighting-jobs
 fi
 
 coverage run --append `which invoke` dependencies.install-all-ui --on-error skip

--- a/tasks/codex/job_control.py
+++ b/tasks/codex/job_control.py
@@ -7,24 +7,33 @@ from tasks.utils import app_context_task
 import pprint
 
 
+def _get_jobs(model, stage, guid=None):
+    if guid:
+        items = model.query.filter(model.guid == guid)
+        if items.count() == 0:
+            print(f'{str(model)} {guid} not found')
+            return
+    else:
+        items = model.query.filter(model.stage == stage)
+    return items
+
+
 @app_context_task()
-def print_all_ags_jobs(context, ags_guid, verbose=True):
+def print_all_ags_jobs(context, ags_guid=None, verbose=True):
     """Print out the job status for all the detection jobs for the ags"""
-    from app.modules.asset_groups.models import AssetGroupSighting
+    from app.modules.asset_groups.models import (
+        AssetGroupSighting,
+        AssetGroupSightingStage,
+    )
 
-    ags = AssetGroupSighting.query.get(ags_guid)
-    if not ags:
-        print(f'AssetGroupSighting {ags_guid} not found')
-        return
-    pprint.pprint(ags.get_jobs_debug(verbose))
+    for ags in _get_jobs(AssetGroupSighting, AssetGroupSightingStage.detection, ags_guid):
+        pprint.pprint(ags.get_jobs_debug(verbose))
 
 
 @app_context_task()
-def print_all_sighting_jobs(context, sighting_guid, verbose=True):
+def print_all_sighting_jobs(context, sighting_guid=None, verbose=True):
     """Print out the job status for all the identification jobs for the sighting"""
-    from app.modules.sightings.models import Sighting
+    from app.modules.sightings.models import Sighting, SightingStage
 
-    sighting = Sighting.query.get(sighting_guid)
-    if not sighting:
-        print(f'Sighting {sighting_guid} not found')
-    pprint.pprint(sighting.get_job_debug(None, verbose))
+    for sighting in _get_jobs(Sighting, SightingStage.identification, sighting_guid):
+        pprint.pprint(sighting.get_job_debug(None, verbose))

--- a/tasks/codex/job_control.py
+++ b/tasks/codex/job_control.py
@@ -37,3 +37,23 @@ def print_all_sighting_jobs(context, sighting_guid=None, verbose=True):
 
     for sighting in _get_jobs(Sighting, SightingStage.identification, sighting_guid):
         pprint.pprint(sighting.get_job_debug(None, verbose))
+
+
+@app_context_task()
+def check_ags_jobs(context, debug=False):
+    """AssetGroupSighting.check_jobs(), optional --debug to use pdb"""
+    from app.modules.asset_groups.models import AssetGroupSighting
+
+    if debug:
+        breakpoint()
+    AssetGroupSighting.check_jobs()
+
+
+@app_context_task()
+def check_sighting_jobs(context, debug=False):
+    """Sighting.check_jobs(), optional --debug to use pdb"""
+    from app.modules.sightings.models import Sighting
+
+    if debug:
+        breakpoint()
+    Sighting.check_jobs()

--- a/tests/tasks/test_codex_job_control.py
+++ b/tests/tasks/test_codex_job_control.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+import importlib
+from unittest import mock
+
+from invoke import MockContext
+import pytest
+
+from tests.modules.asset_groups.resources import utils as ag_utils
+from tests.modules.sightings.resources import utils as s_utils
+from tests.utils import module_unavailable
+
+
+@pytest.mark.skipif(
+    module_unavailable('asset_groups'), reason='AssetGroups module disabled'
+)
+def test_print_all_ags_jobs(flask_app_client, researcher_1, request, test_root):
+    from app.modules.asset_groups.models import AssetGroupSighting
+
+    ags_guid = ag_utils.create_simple_asset_group(
+        flask_app_client, researcher_1, request, test_root
+    )[1]
+    ags = AssetGroupSighting.query.get(ags_guid)
+    assert ags.stage == 'curation'
+
+    with mock.patch('tasks.utils.app_context_task') as app_context_task:
+        app_context_task.side_effect = lambda: (lambda func: func)
+
+        import tasks.codex.job_control
+
+        importlib.reload(tasks.codex.job_control)
+
+        print_all_ags_jobs = tasks.codex.job_control.print_all_ags_jobs
+
+        with mock.patch.object(ags, 'get_jobs_debug') as get_jobs_debug:
+            print_all_ags_jobs(MockContext(), ags_guid=ags_guid)
+            assert get_jobs_debug.call_count == 1
+            get_jobs_debug.reset_mock()
+
+            print_all_ags_jobs(MockContext())
+            assert get_jobs_debug.call_count == 0
+
+
+@pytest.mark.skipif(module_unavailable('sightings'), reason='Sightings module disabled')
+def test_print_all_sighting_jobs(flask_app_client, researcher_1, request, test_root):
+    from app.modules.sightings.models import Sighting
+
+    s_guid = s_utils.create_sighting(flask_app_client, researcher_1, request, test_root)[
+        'sighting'
+    ]
+    sighting = Sighting.query.get(s_guid)
+    assert sighting.stage == 'identification'
+
+    with mock.patch('tasks.utils.app_context_task') as app_context_task:
+        app_context_task.side_effect = lambda: (lambda func: func)
+
+        import tasks.codex.job_control
+
+        importlib.reload(tasks.codex.job_control)
+
+        print_all_sighting_jobs = tasks.codex.job_control.print_all_sighting_jobs
+
+        with mock.patch.object(sighting, 'get_job_debug') as get_job_debug:
+            print_all_sighting_jobs(MockContext(), sighting_guid=s_guid)
+            assert get_job_debug.call_count == 1
+            get_job_debug.reset_mock()
+
+            print_all_sighting_jobs(MockContext())
+            assert get_job_debug.call_count == 1


### PR DESCRIPTION
- Change codex.job-control tasks to print all job details if guid not given

  `codex.job-control.print-all-ags-jobs` and
  `codex.job-control.print-all-sighting-jobs` tasks take options
  `--ags-guid` and `--sighting-guid` and if these are not given, print all
  the jobs of all "detection" and "identification" jobs.

- Add codex.job-control.check-sighting-jobs and .check-ags-jobs tasks

