### PR TITLE
DEX-956 Return sightings search using Sighting.get_elasticsearch_schema()

### DIFF
--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -200,7 +200,13 @@ class Sighting(db.Model, FeatherModel):
 
         from app.modules.site_settings.models import Regions
 
-        regions = Regions()
+        try:
+            regions = Regions()
+        except ValueError as e:
+            if str(e) == 'no region data available':
+                log.warning(str(e))
+                return None
+            raise
         region_data = regions.find(location_id, id_only=False)
         if region_data:
             location_id_value = region_data[0].get('name', location_id)

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -410,7 +410,7 @@ class SightingElasticsearch(Resource):
             'action': AccessOperation.READ,
         },
     )
-    @api.response(schemas.BaseSightingSchema(many=True))
+    @api.response(Sighting.get_elasticsearch_schema()(many=True))
     @api.paginate()
     def get(self, args):
         search = {}
@@ -424,7 +424,7 @@ class SightingElasticsearch(Resource):
             'action': AccessOperation.READ,
         },
     )
-    @api.response(schemas.BaseSightingSchema(many=True))
+    @api.response(Sighting.get_elasticsearch_schema()(many=True))
     @api.paginate()
     def post(self, args):
         search = request.get_json()

--- a/tests/modules/sightings/resources/test_sighting_elasticsearch.py
+++ b/tests/modules/sightings/resources/test_sighting_elasticsearch.py
@@ -1,26 +1,30 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
+import pytest
 
 from tests import utils as test_utils
 from tests.modules.elasticsearch.resources import utils as es_utils
+from tests.modules.sightings.resources import utils
+
+
+EXPECTED_KEYS = {
+    'created',
+    'guid',
+    'updated',
+    'indexed',
+    'comments',
+    'time',
+    'timeSpecificity',
+    'locationId_id',
+    'locationId_value',
+    'owners',
+    'taxonomy_guid',
+    'customFields',
+}
 
 
 # Likewise, this should work but no sighting has been indexed properly so cannot run this test
 def no_test_sighting_elasticsearch_mappings(flask_app_client, researcher_1):
-    EXPECTED_KEYS = {
-        'created',
-        'guid',
-        'updated',
-        'indexed',
-        'comments',
-        'time',
-        'timeSpecificity',
-        'location',
-        'owners',
-        'taxonomy_guid',
-        'customFields',
-    }
-
     # Get the response and just validate that it has the correct keys
     test_utils.get_dict_via_flask(
         flask_app_client,
@@ -29,4 +33,29 @@ def no_test_sighting_elasticsearch_mappings(flask_app_client, researcher_1):
         path=es_utils.get_mapping_path('sighting'),
         expected_status_code=200,
         response_200=EXPECTED_KEYS,
+    )
+
+
+@pytest.mark.skipif(
+    test_utils.module_unavailable('sightings'), reason='Sightings module disabled'
+)
+def test_search(flask_app_client, researcher_1, request, test_root):
+    from app.modules.sightings.models import Sighting
+
+    sighting_guid = utils.create_sighting(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root,
+    )['sighting']
+    # Force created sighting to be indexed in elasticsearch
+    Sighting.query.get(sighting_guid).index()
+
+    test_utils.get_list_via_flask(
+        flask_app_client,
+        researcher_1,
+        scopes='sightings:read',
+        path='/api/v1/sightings/search',
+        expected_status_code=200,
+        expected_fields=EXPECTED_KEYS,
     )


### PR DESCRIPTION
We were using `BaseSightingSchema` which only returns `guid`,
`elasticsearchable` and `indexed`.

Change `Sighting.get_location_id_value` to not die if edm doesn't have
region data.

