### PR TITLE
909 individuals on bulk upload

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -16,6 +16,8 @@ from app.extensions.git_store import GitStore
 from app.modules.annotations.models import Annotation
 from app.modules.assets.models import Asset
 from app.modules.encounters.models import Encounter
+from app.modules.individuals.models import Individual
+from app.modules.names.models import DEFAULT_NAME_CONTEXT
 from app.modules.sightings.models import Sighting, SightingStage
 from app.modules.users.models import User
 from app.utils import HoustonException
@@ -220,10 +222,15 @@ class AssetGroupSighting(db.Model, HoustonModel):
                     assert encounter_owner
                     owner_guid = encounter_owner.guid
 
+                individual = None
+                if DEFAULT_NAME_CONTEXT in req_data:
+                    individual = Individual.get_by_name(req_data[DEFAULT_NAME_CONTEXT])
+
                 assert 'guid' in req_data
                 new_encounter = Encounter(
                     guid=res_data['id'],
                     version=res_data.get('version', 2),
+                    individual = individual,
                     owner_guid=owner_guid,
                     asset_group_sighting_encounter_guid=req_data['guid'],
                     submitter_guid=self.asset_group.submitter_guid,

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -230,7 +230,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
                 new_encounter = Encounter(
                     guid=res_data['id'],
                     version=res_data.get('version', 2),
-                    individual = individual,
+                    individual=individual,
                     owner_guid=owner_guid,
                     asset_group_sighting_encounter_guid=req_data['guid'],
                     submitter_guid=self.asset_group.submitter_guid,

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -2,7 +2,9 @@
 import datetime
 
 from . import utils
-from app.modules.names.models import DEFAULT_NAME_CONTEXT
+
+# conforms with app.modules.names.models.DEFAULT_NAME_CONTEXT
+DEFAULT_NAME_CONTEXT = 'firstName'
 
 
 def test_asset_group_sightings(session, login, codex_url, test_root):
@@ -431,7 +433,7 @@ def test_bulk_upload(session, login, codex_url, test_root, request):
 
     # bulk upload needs existing individuals for encounter assignment
     test_ind_name = 'test zebra'
-    test_name_context = 'firstName'
+    test_name_context = DEFAULT_NAME_CONTEXT
     create_individual(session, codex_url, test_ind_name, test_name_context)
 
     # Create asset group sighting

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -413,7 +413,6 @@ def create_individual(
     )
     sight_json = session.get(sight_url).json()
     assert sight_json['stage'] in ['identification', 'un_reviewed']
-    assert len(sight_json['encounters']) == 3
 
     encounter_guid = [enc['guid'] for enc in sight_json['encounters']][0]
     indiv_data = {


### PR DESCRIPTION
Ties individual-assignment into bulk upload / AGS-commit pipeline.

Adds Individual class method `get_by_name` in `individuals/models.py`. This method throws an exception if there are multiple individuals with the same name and context (using the `DEFAULT_NAME_CONTEXT='firstName'` as, well the default context [also the only context which is used in calling this func atm]). We could revisit this exception decision later or just return the first individual when there are multiples, but this is what we've decided for MVP bulk upload. The name validation step prior to committing will prevent any bulk uploads from getting to that exception, Flatfile actually blocks a bulk upload if there are multiple individuals with the same default name used in the spreadsheet. `get_by_name` just returns None if there is no individual with that name.

The asset_group_sighting.commit method uses `get_by_name` to assign an encounter to an existing individual when `firstName` is included as a key in the encounter json data.

Tested in integration test. Have collaborated with frontend on the column/json header, which is `firstName` under encounter.



