### PR TITLE
947 ignore missing asset refs in detection creation

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -554,7 +554,10 @@ class AssetGroupSighting(db.Model, HoustonModel):
         else:
             for filename in self.config.get('assetReferences'):
                 asset = self.asset_group.get_asset_for_file(filename)
-                assert asset
+                if not asset:
+                    logging.warning(f'Asset ref {filename}, cannot find asset, skipping')
+                    continue
+
                 asset_url = url_for(
                     'api.assets_asset_src_raw_by_id',
                     asset_guid=str(asset.guid),


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Scenario seen occasionally where asset ref points to asset we no longer have
- This change replaces the assert with a trace message. There is no recovery action possible and the current implementation would mean that the AG can never move out of the stage

