### PR TITLE
965 /id_result API additions to annot and a couple for /encounter too 

### DIFF
--- a/app/modules/encounters/schemas.py
+++ b/app/modules/encounters/schemas.py
@@ -91,7 +91,9 @@ class DetailedEncounterSchema(BaseEncounterSchema):
 
 class AugmentedEdmEncounterSchema(BaseEncounterSchema):
     annotations = base_fields.Nested(
-        'BaseAnnotationSchema', many=True, only=('guid', 'asset_guid', 'ia_class')
+        'DetailedAnnotationSchema',
+        many=True,
+        only=('guid', 'asset_guid', 'ia_class', 'asset_src', 'bounds'),
     )
 
     createdHouston = base_fields.DateTime(attribute='created')

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -1076,11 +1076,13 @@ class Sighting(db.Model, FeatherModel):
                 'asset_dimensions': annot.asset.get_dimensions(),
                 'bounds': annot.bounds,
                 'sighting_guid': self.guid,
-                'sighting_time': self.get_edm_data_field('time'),
-                'sighting_time_specificity': self.get_edm_data_field('timeSpecificity'),
+                'sighting_time': self.get_time_isoformat_in_timezone(),
+                'sighting_time_specificity': self.get_time_specificity(),
                 'encounter_guid': annot.encounter.guid if annot.encounter else None,
                 'asset_filename': annot.asset.filename,
-                'individual_first_name': individual.names[0] if individual else None,
+                'individual_first_name': individual.get_first_name()
+                if individual
+                else None,
             }
 
         if (

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -1073,6 +1073,11 @@ class Sighting(db.Model, FeatherModel):
                 'image_url': annot.asset.get_image_url(),
                 'asset_dimensions': annot.asset.get_dimensions(),
                 'bounds': annot.bounds,
+                'sighting_guid': self.guid,
+                'sighting_time': self.get_edm_data_field('time'),
+                'sighting_time_specificity': self.get_edm_data_field('timeSpecificity'),
+                'encounter_guid': annot.encounter.guid if annot.encounter else None,
+                'asset_filename': annot.asset.filename,
             }
 
         if (

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -1059,7 +1059,9 @@ class Sighting(db.Model, FeatherModel):
     # Helper to ensure that the required annot and individual data is present
     def _ensure_annot_data_in_response(self, annot, response):
 
+        # will populate individual_first_name in next block to save a database hit
         individual_guid = annot.encounter.individual_guid if annot.encounter else None
+        individual = Individual.query.get(individual_guid) if individual_guid else None
 
         if annot.guid not in response['annotation_data'].keys():
             encounter_location = (
@@ -1078,6 +1080,7 @@ class Sighting(db.Model, FeatherModel):
                 'sighting_time_specificity': self.get_edm_data_field('timeSpecificity'),
                 'encounter_guid': annot.encounter.guid if annot.encounter else None,
                 'asset_filename': annot.asset.filename,
+                'individual_first_name': individual.names[0] if individual else None,
             }
 
         if (
@@ -1086,6 +1089,7 @@ class Sighting(db.Model, FeatherModel):
         ):
             individual = Individual.query.get(individual_guid)
             assert individual
+
             # add individual data
             response['individual_data'][str(individual_guid)] = {
                 'names': [

--- a/integration_tests/test_sage_basic_identification.py
+++ b/integration_tests/test_sage_basic_identification.py
@@ -124,6 +124,16 @@ def test_create_asset_group_identification(session, codex_url, test_root, login)
     assert query_annot['status'] == 'complete'
     assert query_annot['guid'] in id_resp['annotation_data'].keys()
 
+    # look for additional annotation metadata
+    first_annot_key = next(iter(id_data['annotation_data']))
+    first_annot = id_resp['annotation_data'][first_annot_key]
+
+    assert 'sighting_guid' in first_annot
+    assert 'sighting_time' in first_annot
+    assert 'encounter_guid' in first_annot
+    assert 'asset_filename' in first_annot
+    assert 'sighting_time_specificity' in first_annot
+
     # Check that we got job data back
     zebra_sighting = session.get(
         codex_url(f"/api/v1/sightings/{zebra2_guids['sighting']}")

--- a/integration_tests/test_sage_basic_identification.py
+++ b/integration_tests/test_sage_basic_identification.py
@@ -125,7 +125,7 @@ def test_create_asset_group_identification(session, codex_url, test_root, login)
     assert query_annot['guid'] in id_resp['annotation_data'].keys()
 
     # look for additional annotation metadata
-    first_annot_key = next(iter(id_data['annotation_data']))
+    first_annot_key = next(iter(id_resp['annotation_data']))
     first_annot = id_resp['annotation_data'][first_annot_key]
 
     assert 'sighting_guid' in first_annot

--- a/tests/modules/encounters/resources/test_modify_encounter.py
+++ b/tests/modules/encounters/resources/test_modify_encounter.py
@@ -191,9 +191,11 @@ def test_modify_encounter(
 
     enc1_annotations = [
         {
-            'asset_guid': str(ann.asset.guid),
+            'asset_guid': '/api/v1/assets/src/' + str(ann.asset.guid),
+            'asset_src': str(ann.asset.guid),
             'ia_class': 'test',
             'guid': str(ann.guid),
+            'bounds': {'rect': [0, 1, 2, 3], 'theta': 0},
         }
         for ann in new_encounter_1.annotations
     ]

--- a/tests/modules/sightings/resources/test_identify_sighting.py
+++ b/tests/modules/sightings/resources/test_identify_sighting.py
@@ -151,3 +151,12 @@ def test_sighting_identification(
         ][0]['guid']
         in id_data['annotation_data'].keys()
     )
+
+    first_annot_key = next(iter(id_data['annotation_data']))
+    first_annot = id_data['annotation_data'][first_annot_key]
+
+    assert 'sighting_guid' in first_annot
+    assert 'sighting_time' in first_annot
+    assert 'encounter_guid' in first_annot
+    assert 'asset_filename' in first_annot
+    assert 'sighting_time_specificity' in first_annot


### PR DESCRIPTION
Requested id_response API additions from DEX-965. These keys:
```
    "sighting_time":
    "sighting_time_specificity": 
    "asset_filename":
    "individual_first_name":
    "sighting_guid":
    "encounter_guid:
```
Added to the annotation_data block for /id_result endpoint. Testing for new keys added to unit and integration.

Bonus tidbit: 

Added 'bounds' and 'asset_src' to the single /encounter GET. Lazily tested in encounter PATCH.

