### PR TITLE
abox format (draws annot boxes on image)

### DIFF
--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -400,7 +400,7 @@ class Asset(db.Model, HoustonModel):
         return res_image
 
     def draw_box(self, image, rect):
-        from PIL import ImageDraw
+        from PIL import ImageDraw  # noqa
 
         # h/t https://stackoverflow.com/a/43620169 for this wack ish
         overlay = Image.new('RGBA', image.size, (255, 0, 0, 0))

--- a/tests/modules/assets/test_abox.py
+++ b/tests/modules/assets/test_abox.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+from PIL import Image
+import pytest
+
+# import tests.utils as test_utils
+from tests.utils import module_unavailable
+
+
+@pytest.mark.skipif(
+    module_unavailable('asset_groups'), reason='AssetGroups module disabled'
+)
+def test_abox_format():
+    from app.modules.assets.models import Asset
+    from app.modules.annotations.models import Annotation
+
+    asset = Asset()
+    image = Image.new('RGB', (1000, 800))
+    rtn = asset.draw_annotations(image)
+    assert rtn == image
+
+    annot = Annotation(bounds={'rect': [0, 1, 2, 3]})
+    asset.annotations.append(annot)
+
+    # no dimensions on asset, so...
+    with pytest.raises(ValueError) as ve:
+        asset.draw_annotations(image)
+        assert str(ve) == 'unable to get original dimensions'
+
+    # fake dimensions on asset, now should work
+    asset.meta = {'derived': {'width': 100, 'height': 80}}
+    rtn = asset.draw_annotations(image)
+    assert rtn.width == image.width
+    assert not rtn == image
+
+    rtn = asset.draw_box(image, [1, 2, 3, 4])
+    assert rtn
+    assert rtn.width == image.width
+    assert not rtn == image
+    assert rtn.mode == 'RGB'

--- a/tests/modules/assets/test_models.py
+++ b/tests/modules/assets/test_models.py
@@ -163,6 +163,7 @@ def test_derived_images_and_rotation(test_asset_group_uuid, request):
     assert get_format_sizes(zebra) == {
         'master': (1000, 664),
         'mid': (1000, 664),
+        'abox': (1000, 664),
         'thumb': (256, 170),
     }
 
@@ -178,6 +179,7 @@ def test_derived_images_and_rotation(test_asset_group_uuid, request):
     assert get_format_sizes(zebra) == {
         'master': (664, 1000),
         'mid': (664, 1000),
+        'abox': (664, 1000),
         'thumb': (170, 256),
     }
 
@@ -196,6 +198,7 @@ def test_derived_images_and_rotation(test_asset_group_uuid, request):
     assert get_format_sizes(zebra) == {
         'master': (664, 1000),
         'mid': (664, 1000),
+        'abox': (664, 1000),
         'thumb': (170, 256),
     }
 


### PR DESCRIPTION
## Pull Request Overview

- New Asset _format_ `abox` which draws boxes on image where Annotations appear
- Part of _Intelligent Agent_ spec, but can be used generically

**Example**
`/api/v1/assets/src/abox/3dae59c5-42d7-4506-8f58-7628ff1766e2`
