### PR TITLE
955 ind es taxonomy

### DIFF
--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -179,10 +179,23 @@ class Individual(db.Model, FeatherModel):
     def get_taxonomy_guid(self):
         return self.get_edm_data_field('taxonomy')
 
-    def get_taxonomy_names(self):
-        taxonomy_guid = self.get_edm_data_field('taxonomy')
+    def get_taxonomy_guid_inherit_encounters(self, sighting_fallback=True):
+        tx_guid = self.get_edm_data_field('taxonomy')
+        if tx_guid is None:
+            for encounter in self.encounters:
+                tx_guid = encounter.get_taxonomy_guid(sighting_fallback)
+                if tx_guid:
+                    break
+        return tx_guid
+
+    # convenience method for frontend, display, search schema. Note the default inherit_encounters behavior.
+    def get_taxonomy_names(self, inherit_encounters=True):
+        if inherit_encounters:
+            taxonomy_guid = self.get_taxonomy_guid_inherit_encounters()
+        else:
+            taxonomy_guid = self.get_edm_data_field('taxonomy')
+
         taxonomy_names = []
-        # Taxonomy guid is optional in the response from EDM
         if taxonomy_guid:
             from app.modules.site_settings.models import SiteSetting
 

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -133,7 +133,7 @@ class ElasticsearchIndividualSchema(ModelSchema):
     death = base_fields.Function(Individual.get_time_of_death)
     comments = base_fields.Function(Individual.get_comments)
     customFields = base_fields.Function(Individual.get_custom_fields)
-    taxonomy_guid = base_fields.Function(Individual.get_taxonomy_guid)
+    taxonomy_guid = base_fields.Function(Individual.get_taxonomy_guid_inherit_encounters)
     has_annotations = base_fields.Function(Individual.has_annotations)
     last_seen = base_fields.Function(Individual.get_last_seen_time)
     taxonomy_names = base_fields.Function(Individual.get_taxonomy_names)

--- a/tests/modules/individuals/resources/test_elasticsearch.py
+++ b/tests/modules/individuals/resources/test_elasticsearch.py
@@ -4,7 +4,8 @@
 from tests import utils as test_utils
 from tests.modules.elasticsearch.resources import utils as es_utils
 from tests.modules.individuals.resources import utils as individual_utils
-from tests.utils import module_unavailable
+from tests.utils import module_unavailable, extension_unavailable
+from app.extensions import elasticsearch as es
 
 import pytest
 
@@ -20,7 +21,6 @@ def test_individual_elasticsearch_mappings(
     flask_app_client, researcher_1, request, test_root
 ):
     from app.modules.individuals.models import Individual
-    from app.extensions import elasticsearch as es
 
     individual1_uuids = individual_utils.create_individual_and_sighting(
         flask_app_client, researcher_1, request, test_root
@@ -58,3 +58,38 @@ def test_individual_elasticsearch_mappings(
         expected_status_code=200,
         response_200=EXPECTED_KEYS,
     )
+
+
+@pytest.mark.skipif(
+    module_unavailable('individuals'), reason='Individuals module disabled'
+)
+@pytest.mark.skipif(
+    extension_unavailable('elasticsearch') or module_unavailable('elasticsearch'),
+    reason='Elasticsearch extension or module disabled',
+)
+def test_elasticsearch_names(db, flask_app_client, researcher_1, request, test_root):
+    from app.modules.individuals.models import Individual
+    from app.modules.individuals.schemas import ElasticsearchIndividualSchema
+
+    create_resp = individual_utils.create_individual_and_sighting(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root,
+        individual_data={
+            'names': [
+                {'context': 'firstName', 'value': 'Z432'},
+                {'context': 'Christian name', 'value': 'Zachariah'},
+            ],
+        },
+    )
+    ind = Individual.query.get(create_resp['individual'])
+    with es.session.begin(blocking=True, forced=True):
+        ind.index()
+    body = {}
+    indy = Individual.elasticsearch(body)[0]
+    # actually load the ES schema
+    es_schema = ElasticsearchIndividualSchema()
+    es_indy = es_schema.dump(indy).data
+    assert type(es_indy['names']) is list
+    assert es_indy['names'] == ['Z432', 'Zachariah']


### PR DESCRIPTION
Updates individual elastic search schema to display a taxonomy that was set on its encounters as requested by DEX-955.

Note we haven't changed the taxonomy setting logic at all. This will show a taxonomy on an individual that does _not_ have a taxonomy set, via inheritance of encounter/sighting taxonomy, in this one schema only. But frontend wants to show taxonomy after setting it on submission/bulk upload without explicitly setting that at the individual level so here we are.

This is done with new method `get_taxonomy_guid_inherit_encounters` on the Individual model. That is plugged in as default guid getter on the existing `get_taxonomy_names`. These functions are only used in the elastic search individual schema to populate taxonomy fields.

Added test in `individual/resources/test_elasticsearch.py::test_elasticsearch_taxonomy`. I also moved the elasticsearch individual name test into this file for consistency, as it shares a lot of logic with this new taxonomy test.