### PR TITLE
DEX-981: NLP date parsing utilization

### DIFF
--- a/tests/extensions/intelligent_agent/test_agents.py
+++ b/tests/extensions/intelligent_agent/test_agents.py
@@ -268,3 +268,20 @@ def test_linked_tweet_and_misc(researcher_1, flask_app_client, admin_user):
 
     # cleanup
     researcher_1.linked_accounts = None
+
+
+@pytest.mark.skipif(
+    extension_unavailable('intelligent_agent'),
+    reason='Intelligent Agent extension disabled',
+)
+def test_nlp_date():
+    from app.extensions.intelligent_agent.models import TwitterTweet
+
+    tweet = get_fake_tweet()
+    tt = TwitterTweet(tweet)
+
+    # right now we do not have ability to test actual NLP, so this falls back to using created_at
+    tt.raw_content = {'created_at': '2000-01-02T03:04:05Z'}
+    cdt = tt.derive_time()
+    assert cdt
+    assert cdt.isoformat_in_timezone() == '2000-01-02T03:04:05+00:00'

--- a/tests/modules/assets/resources/test_assets.py
+++ b/tests/modules/assets/resources/test_assets.py
@@ -228,6 +228,9 @@ def test_read_all_assets(
     request,
     test_root,
 ):
+    from app.modules.assets.models import Asset
+
+    Asset.query.delete()
     uuids = asset_group_utils.create_large_asset_group_uuids(
         flask_app_client, researcher_1, request, test_root
     )


### PR DESCRIPTION
## Pull Request Overview

- Updates `IntelligentAgent` base class to utilize NLP date-parsing in `derive_time()`
- Test for same

---

**Review Notes**

Testing does _not_ actually test NLP functionality, but only the fallback behavior when not fully installed.  This is because test environment does not currently include full functionality to support NLP.