### PR TITLE
Add environment variables for default email settings

### DIFF
--- a/app/modules/site_settings/models.py
+++ b/app/modules/site_settings/models.py
@@ -39,9 +39,18 @@ class SiteSetting(db.Model, Timestamp):
                     ]
                 },
             },
+            'default': lambda: current_app.config.get('DEFAULT_EMAIL_SERVICE'),
         },
-        'email_service_username': {'type': str, 'public': False},
-        'email_service_password': {'type': str, 'public': False},
+        'email_service_username': {
+            'type': str,
+            'public': False,
+            'default': lambda: current_app.config.get('DEFAULT_EMAIL_SERVICE_USERNAME'),
+        },
+        'email_service_password': {
+            'type': str,
+            'public': False,
+            'default': lambda: current_app.config.get('DEFAULT_EMAIL_SERVICE_PASSWORD'),
+        },
         'email_default_sender_email': {
             'type': str,
             'public': False,

--- a/app/modules/site_settings/resources.py
+++ b/app/modules/site_settings/resources.py
@@ -307,9 +307,10 @@ class MainConfiguration(Resource):
                     )
             data['response']['configuration']['site.images'] = ss_json
 
-            for key in SiteSetting.get_setting_keys():
+            for key, type_def in SiteSetting.HOUSTON_SETTINGS.items():
                 key_data = SiteSetting.get_as_edm_format(key)
-                data['response']['configuration'][key] = key_data
+                if user_is_admin or type_def.get('public', True):
+                    data['response']['configuration'][key] = key_data
         elif (
             'response' in data
             and data['response'].get('private', False)

--- a/config/base.py
+++ b/config/base.py
@@ -214,6 +214,9 @@ class EmailConfig(object):
     MAIL_USE_SSL = bool(os.getenv('MAIL_USE_SSL', False))
     MAIL_USERNAME = os.getenv('MAIL_USERNAME', 'dev@wildme.org')
     MAIL_PASSWORD = os.getenv('MAIL_PASSWORD', 'XXX')
+    DEFAULT_EMAIL_SERVICE = os.getenv('DEFAULT_EMAIL_SERVICE')
+    DEFAULT_EMAIL_SERVICE_USERNAME = os.getenv('DEFAULT_EMAIL_SERVICE_USERNAME')
+    DEFAULT_EMAIL_SERVICE_PASSWORD = os.getenv('DEFAULT_EMAIL_SERVICE_PASSWORD')
 
     @property
     def MAIL_DEFAULT_SENDER(self):

--- a/config/codex.py
+++ b/config/codex.py
@@ -95,12 +95,12 @@ class ProductionConfig(BaseCodexConfig):
 class DevelopmentConfig(BaseCodexConfig):
     DEBUG = True
 
-    MAIL_OVERRIDE_RECIPIENTS = [
-        'testing@wildme.org',
-    ]
-    MAIL_ERROR_RECIPIENTS = [
-        'mail-errors@wildme.org',
-    ]
+    MAIL_OVERRIDE_RECIPIENTS = os.getenv(
+        'MAIL_OVERRIDE_RECIPIENTS', 'testing@wildme.org'
+    ).split(',')
+    MAIL_ERROR_RECIPIENTS = os.getenv(
+        'MAIL_ERROR_RECIPIENTS', 'mail-errors@wildme.org'
+    ).split(',')
 
     SECRET_KEY = 'DEVELOPMENT_SECRET_KEY'
     SENTRY_DSN = os.getenv('SENTRY_DSN_DEVELOPMENT', None)

--- a/config/mws.py
+++ b/config/mws.py
@@ -83,12 +83,12 @@ class ProductionConfig(BaseMWSConfig):
 class DevelopmentConfig(BaseMWSConfig):
     DEBUG = True
 
-    MAIL_OVERRIDE_RECIPIENTS = [
-        'testing@wildme.org',
-    ]
-    MAIL_ERROR_RECIPIENTS = [
-        'mail-errors@wildme.org',
-    ]
+    MAIL_OVERRIDE_RECIPIENTS = os.getenv(
+        'MAIL_OVERRIDE_RECIPIENTS', 'testing@wildme.org'
+    ).split(',')
+    MAIL_ERROR_RECIPIENTS = os.getenv(
+        'MAIL_ERROR_RECIPIENTS', 'mail-errors@wildme.org'
+    ).split(',')
 
     SECRET_KEY = 'DEVELOPMENT_SECRET_KEY'
     SENTRY_DSN = os.getenv('SENTRY_DSN_DEVELOPMENT', None)

--- a/tasks/app/email.py
+++ b/tasks/app/email.py
@@ -30,7 +30,7 @@ def send(
     if password:
         SiteSetting.set('email_service_password', string=password)
 
-    msg = Email(subject, recipients=[recipient])
+    msg = Email(subject=subject, recipients=[recipient])
     msg.body = body
     msg.email_type = EmailTypes.invite
     resp = msg.send_message()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,10 @@ log = logging.getLogger('pytest.conftest')  # pylint: disable=invalid-name
 
 # Force FLASK_ENV to be testing instead of using what's defined in the environment
 os.environ['FLASK_ENV'] = 'testing'
+# Remove MAIL_DEFAULT_SENDER_EMAIL environment variable so the generated
+# one is used in tests
+if 'MAIL_DEFAULT_SENDER_EMAIL' in os.environ:
+    del os.environ['MAIL_DEFAULT_SENDER_EMAIL']
 
 
 # Import all models first for db.relationship to avoid model look up

--- a/tests/modules/site_settings/resources/test_read_configurations.py
+++ b/tests/modules/site_settings/resources/test_read_configurations.py
@@ -287,11 +287,9 @@ def test_alter_houston_settings(flask_app_client, admin_user, researcher_1):
     assert admin_configuration['email_service_username']['valueNotSet'] is False
     assert admin_configuration['email_service_password']['value'] == password
     assert admin_configuration['email_service_password']['valueNotSet'] is False
-    assert researcher_configuration['email_service_username']['value'] == ''
-    assert researcher_configuration['email_service_username']['valueNotSet'] is True
-    assert researcher_configuration['email_service_password']['value'] == ''
-    assert researcher_configuration['email_service_password']['valueNotSet'] is True
-    assert 'currentValue' not in researcher_definition['email_service_username'].keys()
-    assert 'currentValue' not in researcher_definition['email_service_password'].keys()
+    assert 'email_service_username' not in researcher_configuration
+    assert 'email_service_password' not in researcher_configuration
+    assert 'currentValue' not in researcher_definition['email_service_username']
+    assert 'currentValue' not in researcher_definition['email_service_password']
     assert admin_definition['email_service_username']['currentValue'] == username
     assert admin_definition['email_service_password']['currentValue'] == password

--- a/tests/tasks/test_app_email.py
+++ b/tests/tasks/test_app_email.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from unittest import mock
+
+from invoke import MockContext
+
+
+def test_send(flask_app):
+    with mock.patch('app.create_app') as create_app:
+        create_app.return_value = flask_app
+
+        from tasks.app.email import send as send_task
+
+        with mock.patch('app.extensions.email.mail.send') as mock_send:
+            send_task(MockContext(), 'nobody@example.org', 'test body')
+            assert mock_send.call_count == 1
+            email = mock_send.call_args[0][0]
+            assert email.recipients == ['nobody@example.org']
+            assert email.subject == 'Codex test subject'
+            assert email.body == 'test body'


### PR DESCRIPTION
- Add environment variables for default email settings

  This is so we can set email settings without touching the database for
  our own sites.  This doesn't affect the ability to set email settings in
  the database and from the frontend.  The environment variables are only
  defaults.

- Fix app.email.send task and add test

  I broke the app.email.send task when I changed the `Email()` signature,
  it's probably best to add a test.

