### PR TITLE
DEX-988 Add dummy frontend routes for url generation

### DIFF
--- a/app/extensions/email/__init__.py
+++ b/app/extensions/email/__init__.py
@@ -4,7 +4,6 @@ import datetime
 from io import StringIO
 import logging
 import re
-from urllib.parse import urljoin
 
 from flask import current_app, render_template, url_for
 from flask_mail import Mail, Message, email_dispatched
@@ -169,7 +168,7 @@ class Email(Message):
         self.set_language()
         global pmail
         if pmail is None:
-            pmail_kwargs['base_url'] = urljoin(url_for('api.root', _external=True), '/')
+            pmail_kwargs['base_url'] = url_for('frontend.root', _external=True)
             pmail = Premailer(**pmail_kwargs)  # REF: https://pypi.org/project/premailer/
         log.info('Using premailer = %r' % (pmail))
 

--- a/app/extensions/intelligent_agent/models.py
+++ b/app/extensions/intelligent_agent/models.py
@@ -13,7 +13,7 @@ import logging
 from app.extensions import db
 import app.extensions.logging as AuditLog  # NOQA
 from app.extensions import HoustonModel
-from flask import current_app
+from flask import current_app, url_for
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 _ = gettext.gettext
@@ -488,7 +488,6 @@ class IntelligentAgentContent(db.Model, HoustonModel):
 
     def detection_complete(self):
         from app.modules.assets.models import Asset
-        from app.utils import full_api_url
         import traceback
 
         annots = []
@@ -536,7 +535,9 @@ class IntelligentAgentContent(db.Model, HoustonModel):
             if self.owner and not self.owner.is_public_user():
                 ags = self.get_asset_group_sighting()
                 assert ags, f'no AGS for {self}'
-                url = full_api_url(f'pending-sightings/{str(ags.guid)}')
+                url = url_for(
+                    'frontend.pending-sightings', guid=str(ags.guid), _external=True
+                )
                 self.respond_to(
                     _(
                         'We found more than one animal. You must login and curate this data. '
@@ -616,11 +617,9 @@ class IntelligentAgentContent(db.Model, HoustonModel):
         db.session.refresh(self)
 
     def identification_complete(self):
-        from app.utils import full_api_url
-
         sighting = self.get_sighting()
         assert sighting, f'no sighting for {self}'
-        url = full_api_url(f'sightings/{str(sighting.guid)}')
+        url = url_for('frontend.sightings', guid=str(sighting.guid), _external=True)
         log.warning(
             f'intelligent_agent: completed identification for {sighting} on {self}'
         )

--- a/app/modules/app_ui.py
+++ b/app/modules/app_ui.py
@@ -3,7 +3,6 @@
 import datetime
 import logging
 from functools import wraps
-from urllib.parse import urljoin
 
 # from app.modules.users.permissions import PasswordRequiredPermissionMixin
 import flask
@@ -44,10 +43,21 @@ def init_app(app):
     app.register_blueprint(backend_blueprint)
 
 
+@frontend_blueprint.route('/', endpoint='root')
+@frontend_blueprint.route('/auth/code/<string:code>', endpoint='auth-code')
+@frontend_blueprint.route(
+    '/pending-sightings/<string:guid>', endpoint='pending-sightings'
+)
+@frontend_blueprint.route('/sightings/<string:guid>', endpoint='sightings')
+def dummy_view(*args, **kwargs):
+    """This view is created just for frontend route generation"""
+    raise NotImplementedError
+
+
 def _render_template(template, **kwargs):
     now = datetime.datetime.now(tz=current_app.config.get('TIMEZONE'))
     config = {
-        'base_url': urljoin(url_for('backend.home'), '/'),
+        'base_url': url_for('frontend.root'),
         'google_analytics_tag': current_app.config.get('GOOGLE_ANALYTICS_TAG'),
         'stripe_public_key': current_app.config.get('STRIPE_PUBLIC_KEY'),
         'year': now.year,

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -6,7 +6,6 @@ RESTful API User resources
 """
 import json
 import logging
-from urllib.parse import urljoin
 
 from flask import current_app, send_file, request, url_for, redirect, session
 from flask_login import current_user
@@ -431,11 +430,7 @@ class UserResetPasswordEmail(Resource):
             return
         code = user.get_account_recovery_code()
         msg = Email(recipients=[user])
-        # /auth/code/ instead of /api/v1/auth/code/ because we want the user to
-        # go to the frontend page
-        reset_link = urljoin(
-            url_for('api.root', _external=True), f'/auth/code/{code.accept_code}'
-        )
+        reset_link = url_for('frontend.auth-code', code=code.accept_code, _external=True)
         msg.template('misc/password_reset', reset_link=reset_link)
         msg.send_message()
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -168,17 +168,6 @@ def nlp_parse_complex_date_time(
     raise ValueError(f'unknown type in results: {res}')
 
 
-# this really should be moved to our baseclass to auto-complete the full path based on class
-#  e.g. sighting.url() => url for sighting.  but i cant figure out how to get the api/route to pass:
-#       url_for('api.encounters_encounters') => 'http://localhost/api/v1/encounters/'
-#       url_for('api.sightings_sightings') => 'http://localhost/api/v1/sightings/'
-def full_api_url(suffix_path=None):
-    from urllib.parse import urljoin
-    from flask import url_for
-
-    return urljoin(url_for('api.root', _external=True), suffix_path)
-
-
 # match is a string, and candidates can be one of:
 #   * list (of text strings)
 #   * dict with { id0: text0, id1: text1, ... }


### PR DESCRIPTION
When we need to generate a frontend url, for example, to the password
reset form, we used to do:

```
urljoin(url_for('api.root', _external=True), f'/auth/code/{code}')
```

but now we can do:

```
url_for('frontend.auth-code', code=code, _external=True)
```

