### PR TITLE
DEX-937: backend addendum to allow user.twitter_username manipulation

### DIFF
--- a/app/modules/users/parameters.py
+++ b/app/modules/users/parameters.py
@@ -152,6 +152,7 @@ class PatchUserDetailsParameters(PatchJSONParameters):
         User.is_contributor.fget.__name__,
         User.in_beta.fget.__name__,
         User.in_alpha.fget.__name__,
+        User.twitter_username.key,
     )
 
     SENSITIVE_FIELDS = (
@@ -277,6 +278,8 @@ class PatchUserDetailsParameters(PatchJSONParameters):
 
         if field == User.profile_fileupload_guid.key:
             obj.remove_profile_file()
+        if field == User.twitter_username.key:
+            obj.twitter_username = None
 
         return True
 

--- a/app/modules/users/schemas.py
+++ b/app/modules/users/schemas.py
@@ -135,4 +135,5 @@ class PersonalUserSchema(DetailedUserSchema):
             User.show_email_in_profile.key,
             User.use_usa_date_format.key,
             User.accepted_user_agreement.key,
+            User.twitter_username.key,
         )


### PR DESCRIPTION
## Pull Request Overview

- `user.twitter_username` (as a field) was introduced via DEX-888 as a _temporary_ way to connect a user to a twitter account
- This PR adds `PATCH` support on a user (`op=add` and `op=remove`) for this field
- Also adds this field to the `/user/me` schema
- Required for frontend DEX-937 task
