### PR TITLE
DEX-981 (addendum): fixes/improvements to NLP date/time parsing

### DIFF
--- a/app/extensions/intelligent_agent/models.py
+++ b/app/extensions/intelligent_agent/models.py
@@ -756,7 +756,7 @@ class TwitterBot(IntelligentAgent):
         assert text
         # this helps prevent sending identical outgoing (and may help dbugging?)
         stamp = str(uuid.uuid4())[0:4]
-        text += '   ' + stamp
+        text += '    〈' + stamp + '〉'
         log.info(
             f'create_tweet_direct(): {self} tweeting [re: {in_reply_to}] [media {media_paths}] >>> {text}'
         )

--- a/app/extensions/intelligent_agent/models.py
+++ b/app/extensions/intelligent_agent/models.py
@@ -704,13 +704,14 @@ class TwitterBot(IntelligentAgent):
                 f'collect(since_id={since_id}) on {self} retrieved no tweets with query "{query}"'
             )
             return tweets
+        # we update this immediately so next iteration doesnt use old since_id
+        newest_id = res.meta.get('newest_id')
+        if newest_id:
+            self.set_persisted_value('since_id', int(newest_id))
         log.info(
-            f'collect(since_id={since_id}) on {self} retrieved {len(res.data)} tweet(s) with query "{query}"'
+            f'collect(since_id={since_id}) on {self} retrieved {len(res.data)} tweet(s) with query "{query}", newest_id={newest_id}'
         )
-        latest_id = 0
         for twt in res.data:
-            if twt.id > latest_id:
-                latest_id = twt.id
             try:
                 tt = TwitterTweet(twt, res.includes)
             except Exception as ex:
@@ -746,7 +747,6 @@ class TwitterBot(IntelligentAgent):
             db.session.refresh(tt)
             if ok:
                 tt.wait_for_detection_results()
-        self.set_persisted_value('since_id', latest_id)
         return tweets
 
     # this should be used with caution -- use create_tweet_queued() to be safer

--- a/tests/extensions/intelligent_agent/test_agents.py
+++ b/tests/extensions/intelligent_agent/test_agents.py
@@ -289,7 +289,10 @@ def test_nlp_date():
     tt = TwitterTweet(tweet)
 
     # right now we do not have ability to test actual NLP, so this falls back to using created_at
-    tt.raw_content = {'created_at': '2000-01-02T03:04:05Z'}
+    tt.raw_content = {
+        'text': 'happened right at 2000-01-02T03:04:05',
+        'created_at': '2000-01-02T03:04:05Z',
+    }
     cdt = tt.derive_time()
     assert cdt
     assert cdt.isoformat_in_timezone() == '2000-01-02T03:04:05+00:00'

--- a/tests/extensions/intelligent_agent/test_agents.py
+++ b/tests/extensions/intelligent_agent/test_agents.py
@@ -136,6 +136,7 @@ def test_twitter_tweet_io(flask_app_client):
 
     fake_res = Dummy()
     fake_res.data = []
+    fake_res.meta = {'newest_id': 123}
     me_value = Dummy()
     me_value.data = Dummy()
     me_value.data.username = 'A'

--- a/tests/modules/complex_date_time/test_basics.py
+++ b/tests/modules/complex_date_time/test_basics.py
@@ -239,5 +239,18 @@ def test_nlp_time():
     assert cdt.isoformat_in_timezone() == '2019-07-01T00:00:00+00:00'
     assert cdt.specificity == Specificities.month
 
+    # some of the nasty range-y stuff
+    text = 'during last winter'
+    cdt = nlp_parse_complex_date_time(text, reference_date=refdate)
+    assert cdt
+    assert cdt.isoformat_in_timezone() == '2018-01-01T00:00:00+00:00'
+    assert cdt.specificity == Specificities.month
+
+    text = 'yesterday morning'
+    cdt = nlp_parse_complex_date_time(text, reference_date=refdate)
+    assert cdt
+    assert cdt.isoformat_in_timezone() == '2019-08-14T09:00:00+00:00'
+    assert cdt.specificity == Specificities.time
+
     cdt = nlp_parse_complex_date_time('i have no idea')
     assert not cdt

--- a/tests/modules/complex_date_time/test_basics.py
+++ b/tests/modules/complex_date_time/test_basics.py
@@ -254,3 +254,192 @@ def test_nlp_time():
 
     cdt = nlp_parse_complex_date_time('i have no idea')
     assert not cdt
+
+
+@pytest.mark.skipif(
+    module_unavailable('complex_date_time'), reason='ComplexDateTime module disabled'
+)
+def test_nlp_time_mocked():
+    from app.utils import nlp_parse_complex_date_time
+    import sutime
+    from unittest.mock import patch
+
+    class mock_SUTime(object):
+        def parse(self, val, reference_date=None):
+            return []
+
+    mock_sutime = mock_SUTime()
+    with patch.object(sutime, 'SUTime', return_value=mock_sutime):
+        cdt = nlp_parse_complex_date_time('')
+        assert not cdt
+
+    class mock_SUTime(object):
+        def parse(self, val, reference_date=None):
+            return [{}]
+
+    mock_sutime = mock_SUTime()
+    with patch.object(sutime, 'SUTime', return_value=mock_sutime):
+        cdt = nlp_parse_complex_date_time('')
+        assert not cdt
+
+    class mock_SUTime(object):
+        def parse(self, val, reference_date=None):
+            return [
+                {
+                    'type': 'DATE',
+                    'value': '2022-SP',
+                }
+            ]
+
+    mock_sutime = mock_SUTime()
+    with patch.object(sutime, 'SUTime', return_value=mock_sutime):
+        cdt = nlp_parse_complex_date_time('was spring')
+        assert cdt
+        assert cdt.isoformat_in_timezone() == '2022-03-01T00:00:00+00:00'
+
+    class mock_SUTime(object):
+        def parse(self, val, reference_date=None):
+            return [
+                {
+                    'type': 'DATE',
+                    'value': '2022-SU',
+                }
+            ]
+
+    mock_sutime = mock_SUTime()
+    with patch.object(sutime, 'SUTime', return_value=mock_sutime):
+        cdt = nlp_parse_complex_date_time('in summer')
+        assert cdt
+        assert cdt.isoformat_in_timezone() == '2022-06-01T00:00:00+00:00'
+
+    class mock_SUTime(object):
+        def parse(self, val, reference_date=None):
+            return [
+                {
+                    'type': 'DATE',
+                    'value': '2022-FA',
+                }
+            ]
+
+    mock_sutime = mock_SUTime()
+    with patch.object(sutime, 'SUTime', return_value=mock_sutime):
+        cdt = nlp_parse_complex_date_time('fall')
+        assert cdt
+        assert cdt.isoformat_in_timezone() == '2022-09-01T00:00:00+00:00'
+
+    class mock_SUTime(object):
+        def parse(self, val, reference_date=None):
+            return [
+                {
+                    'type': 'DATE',
+                    'value': '2022-WI',
+                }
+            ]
+
+    mock_sutime = mock_SUTime()
+    with patch.object(sutime, 'SUTime', return_value=mock_sutime):
+        cdt = nlp_parse_complex_date_time('winter time brr')
+        assert cdt
+        assert cdt.isoformat_in_timezone() == '2022-01-01T00:00:00+00:00'
+
+    class mock_SUTime(object):
+        def parse(self, val, reference_date=None):
+            return [
+                {
+                    'type': 'DATE',
+                    'value': '0-0-0',
+                }
+            ]
+
+    mock_sutime = mock_SUTime()
+    with patch.object(sutime, 'SUTime', return_value=mock_sutime):
+        cdt = nlp_parse_complex_date_time('gives warning, no result')
+        assert not cdt
+
+    class mock_SUTime(object):
+        def parse(self, val, reference_date=None):
+            return [
+                {
+                    'type': 'TIME',
+                    'value': '2022-01-02TMO',
+                }
+            ]
+
+    mock_sutime = mock_SUTime()
+    with patch.object(sutime, 'SUTime', return_value=mock_sutime):
+        cdt = nlp_parse_complex_date_time('morning')
+        assert cdt
+        assert cdt.isoformat_in_timezone() == '2022-01-02T09:00:00+00:00'
+
+    class mock_SUTime(object):
+        def parse(self, val, reference_date=None):
+            return [
+                {
+                    'type': 'TIME',
+                    'value': '2022-01-02TAF',
+                }
+            ]
+
+    mock_sutime = mock_SUTime()
+    with patch.object(sutime, 'SUTime', return_value=mock_sutime):
+        cdt = nlp_parse_complex_date_time('afternoon')
+        assert cdt
+        assert cdt.isoformat_in_timezone() == '2022-01-02T13:00:00+00:00'
+
+    class mock_SUTime(object):
+        def parse(self, val, reference_date=None):
+            return [
+                {
+                    'type': 'TIME',
+                    'value': '2022-01-02TEV',
+                }
+            ]
+
+    mock_sutime = mock_SUTime()
+    with patch.object(sutime, 'SUTime', return_value=mock_sutime):
+        cdt = nlp_parse_complex_date_time('evening')
+        assert cdt
+        assert cdt.isoformat_in_timezone() == '2022-01-02T17:00:00+00:00'
+
+    class mock_SUTime(object):
+        def parse(self, val, reference_date=None):
+            return [
+                {
+                    'type': 'TIME',
+                    'value': '2022-01-02TNI',
+                }
+            ]
+
+    mock_sutime = mock_SUTime()
+    with patch.object(sutime, 'SUTime', return_value=mock_sutime):
+        cdt = nlp_parse_complex_date_time('night time')
+        assert cdt
+        assert cdt.isoformat_in_timezone() == '2022-01-02T22:00:00+00:00'
+
+    class mock_SUTime(object):
+        def parse(self, val, reference_date=None):
+            return [
+                {
+                    'type': 'TIME',
+                    'value': 'broken',
+                }
+            ]
+
+    mock_sutime = mock_SUTime()
+    with patch.object(sutime, 'SUTime', return_value=mock_sutime):
+        cdt = nlp_parse_complex_date_time('broken')
+        assert not cdt
+
+    class mock_SUTime(object):
+        def parse(self, val, reference_date=None):
+            return [
+                {
+                    'type': 'UNKNOWN',
+                    'value': 'broken',
+                }
+            ]
+
+    mock_sutime = mock_SUTime()
+    with patch.object(sutime, 'SUTime', return_value=mock_sutime):
+        cdt = nlp_parse_complex_date_time('broken')
+        assert not cdt


### PR DESCRIPTION
## Pull Request Overview

- Better handles (not) blowing up on unknown responses
- Properly parses seasons and day-pieces (morning, afternoon, evening, night)
- Improved tests
- Also bugfix on race-condition in setting Twitter `since_id` when collecting tweets