### PR TITLE
851 sighting cascade delete reporting

### DIFF
--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -258,12 +258,18 @@ class EncounterByID(Resource):
                 f'Encounter.delete {encounter.guid} failed: ({ex.status_code} / edm={edm_status_code}) {ex.message}'
             )
             ex_response_data = ex.get_val('response_data', {})
-            abort(
-                400,
-                'Delete failed',
-                vulnerableIndividualGuid=ex_response_data.get('vulnerableIndividual'),
-                vulnerableSightingGuid=ex_response_data.get('vulnerableSighting'),
-            )
+            if (
+                'vulnerableIndividual' in ex_response_data
+                or 'vulnerableSighting' in ex_response_data
+            ):
+                abort(
+                    400,
+                    'Delete failed because it would cause a delete cascade',
+                    vulnerableIndividualGuid=ex_response_data.get('vulnerableIndividual'),
+                    vulnerableSightingGuid=ex_response_data.get('vulnerableSighting'),
+                )
+            else:
+                abort(400, 'Delete failed')
 
         # we have to roll our own response here (to return) as it seems the only way we can add a header
         #   (which we are using to denote the encounter DELETE also triggered a sighting DELETE, since

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -629,12 +629,18 @@ class SightingByID(Resource):
                 f'Sighting.delete {sighting.guid} failed: ({ex.status_code} / edm={edm_status_code}) {ex.message}'
             )
             ex_response_data = ex.get_val('response_data', {})
-            abort(
-                400,
-                'Delete failed',
-                vulnerableIndividualGuid=ex_response_data.get('vulnerableIndividual'),
-                vulnerableEncounterGuid=ex_response_data.get('vulnerableEncounter'),
-            )
+            if (
+                'vulnerableIndividual' in ex_response_data or
+                'vulnerableEncounter' in ex_response_data
+            ):
+                abort(
+                    400,
+                    'Delete failed because it would cause a delete cascade.',
+                    vulnerableIndividualGuid=ex_response_data.get('vulnerableIndividual'),
+                    vulnerableEncounterGuid=ex_response_data.get('vulnerableEncounter'),
+                )
+            else:
+                abort(400, 'Delete failed')
 
         # we have to roll our own response here (to return) as it seems the only way we can add a header
         #   (which we are using to denote the encounter DELETE also triggered a individual DELETE, since

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -630,8 +630,8 @@ class SightingByID(Resource):
             )
             ex_response_data = ex.get_val('response_data', {})
             if (
-                'vulnerableIndividual' in ex_response_data or
-                'vulnerableEncounter' in ex_response_data
+                'vulnerableIndividual' in ex_response_data
+                or 'vulnerableEncounter' in ex_response_data
             ):
                 abort(
                     400,

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -628,7 +628,13 @@ class SightingByID(Resource):
             log.warning(
                 f'Sighting.delete {sighting.guid} failed: ({ex.status_code} / edm={edm_status_code}) {ex.message}'
             )
-            abort(400, 'Delete failed')
+            ex_response_data = ex.get_val('response_data', {})
+            abort(
+                400,
+                'Delete failed',
+                vulnerableIndividualGuid=ex_response_data.get('vulnerableIndividual'),
+                vulnerableEncounterGuid=ex_response_data.get('vulnerableEncounter'),
+            )
 
         # we have to roll our own response here (to return) as it seems the only way we can add a header
         #   (which we are using to denote the encounter DELETE also triggered a individual DELETE, since

--- a/tests/modules/sightings/resources/test_delete_cascade.py
+++ b/tests/modules/sightings/resources/test_delete_cascade.py
@@ -199,6 +199,8 @@ def test_multi_cascade(flask_app_client, test_root, researcher_1, request, db):
     response = sighting_utils.delete_sighting(
         flask_app_client, researcher_1, sighting_id, expected_status_code=400
     )
+    assert(individual1_id == response.json['vulnerableIndividualGuid'])
+    # additional ids, eg individual2 and encounters, not currently returned from EDM
 
     # lets say we are okay - should delete *two* individuals
     headers = (('x-allow-delete-cascade-individual', True),)

--- a/tests/modules/sightings/resources/test_delete_cascade.py
+++ b/tests/modules/sightings/resources/test_delete_cascade.py
@@ -199,7 +199,7 @@ def test_multi_cascade(flask_app_client, test_root, researcher_1, request, db):
     response = sighting_utils.delete_sighting(
         flask_app_client, researcher_1, sighting_id, expected_status_code=400
     )
-    assert(individual1_id == response.json['vulnerableIndividualGuid'])
+    assert individual1_id == response.json['vulnerableIndividualGuid']
     # additional ids, eg individual2 and encounters, not currently returned from EDM
 
     # lets say we are okay - should delete *two* individuals


### PR DESCRIPTION
Simple PR that includes vulnerableIndividual / vulnerableEncounter guids in a Sighting delete error message when the error was due to cascade delete issues.

Also updates error message from "Delete failed" to "Delete failed because it would cause a delete cascade" for sighting and encounter cascade delete failures.

At present, this only returns one guid per error. This is because the error goes back to a java error on the EDM delete operation which itself returns only one object which was blocking the delete. So for example, if a sighting delete will delete two individuals, it will take a bit more work wrenching around our EDM java exception class `ApiDeleteCascadeException` to warn about both individuals instead of just one.