### PR TITLE
1007 sighting re identify

### DIFF
--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -484,6 +484,9 @@ class Sighting(db.Model, FeatherModel):
 
         return details
 
+    def get_id_configs(self):
+        return self.id_configs
+
     def get_jobs_json(self):
         job_data = []
         if not self.jobs:

--- a/app/modules/sightings/parameters.py
+++ b/app/modules/sightings/parameters.py
@@ -45,6 +45,7 @@ class PatchSightingDetailsParameters(PatchJSONParameters):
     )
 
     PATH_CHOICES_HOUSTON = (
+        '/idConfigs',
         '/assetId',
         '/featuredAssetGuid',
         '/name',
@@ -93,5 +94,11 @@ class PatchSightingDetailsParameters(PatchJSONParameters):
 
             elif field == 'time' or field == 'timeSpecificity':
                 ret_val = ComplexDateTime.patch_replace_helper(obj, field, value)
+            elif field == 'idConfigs':
+                from app.modules.asset_groups.metadata import AssetGroupMetadata
 
+                # Raises AssetGroupMetadataError on error which is intentionally unnhandled
+                AssetGroupMetadata.validate_id_configs(value, f'Sighting {obj.guid}')
+                obj.id_configs = value
+                ret_val = True
         return ret_val

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -731,6 +731,34 @@ class SightingSageIdentified(Resource):
             abort(ex.status_code, ex.message, errorFields=ex.get_val('error', 'Error'))
 
 
+@api.route('/<uuid:sighting_guid>/rerun_id')
+@api.login_required(oauth_scopes=['sightings:write'])
+@api.response(
+    code=HTTPStatus.NOT_FOUND,
+    description='Sighting not found.',
+)
+@api.resolve_object_by_model(Sighting, 'sighting')
+class SightingRerunId(Resource):
+    """
+    Rerun ID for whole Sighting
+    """
+
+    @api.permission_required(
+        permissions.ObjectAccessPermission,
+        kwargs_on_request=lambda kwargs: {
+            'obj': kwargs['sighting'],
+            'action': AccessOperation.WRITE,
+        },
+    )
+    def post(self, sighting):
+        try:
+            sighting.stage = SightingStage.identification
+            sighting.ia_pipeline()
+            return sighting.get_detailed_json()
+        except HoustonException as ex:
+            abort(ex.status_code, ex.message, errorFields=ex.get_val('error', 'Error'))
+
+
 @api.route('/<uuid:sighting_guid>/id_result')
 @api.login_required(oauth_scopes=['sightings:read'])
 @api.response(

--- a/app/modules/sightings/schemas.py
+++ b/app/modules/sightings/schemas.py
@@ -150,6 +150,7 @@ class AugmentedEdmSightingSchema(TimedSightingSchema):
         Sighting.config_field_getter('speciesDetectionModel', default=[])
     )
     jobs = base_fields.Function(Sighting.get_jobs_json)
+    idConfigs = base_fields.Function(Sighting.get_id_configs)
 
     class Meta(TimedSightingSchema.Meta):
         """
@@ -169,6 +170,7 @@ class AugmentedEdmSightingSchema(TimedSightingSchema):
             'time',
             'timeSpecificity',
             'speciesDetectionModel',
+            'idConfigs',
         )
 
 

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -364,6 +364,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
         'elasticsearchable': response.json()['elasticsearchable'],
         'jobs': [],
         'speciesDetectionModel': ['african_terrestrial'],
+        'idConfigs': [{'algorithms': ['hotspotter_nosv']}],
         'unreviewed_start_time': response.json()['unreviewed_start_time'],
     }
     # due to task timing, both are valid

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -313,6 +313,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
         'timeSpecificity': 'time',
         'stage': 'un_reviewed',
         'speciesDetectionModel': ['african_terrestrial'],
+        'idConfigs': [{'algorithms': ['hotspotter_nosv']}],
         # 2021-11-16T09:45:26.717432+00:00
         'updatedHouston': response.json()['updatedHouston'],
         'version': sighting_version,

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -147,6 +147,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
         'decimalLatitude': -39.063228,
         'decimalLongitude': 21.832598,
         'speciesDetectionModel': ['african_terrestrial'],
+        'idConfigs': [{'algorithms': ['hotspotter_nosv']}],
         'encounters': [
             {
                 # 2021-11-09T11:15:24.343018+00:00

--- a/tests/modules/sightings/resources/test_create_sighting.py
+++ b/tests/modules/sightings/resources/test_create_sighting.py
@@ -131,6 +131,19 @@ def test_create_and_modify_and_delete_sighting(
     response = sighting_utils.read_sighting(flask_app_client, researcher_1, sighting_id)
     assert response.json['locationId'] == new_loc_id
 
+    new_configs = [{'algorithms': ['hotspotter_nosv']}]
+    sighting_utils.patch_sighting(
+        flask_app_client,
+        researcher_1,
+        sighting_id,
+        patch_data=[
+            {'op': 'replace', 'path': '/idConfigs', 'value': new_configs},
+        ],
+    )
+    # check that change was made
+    response = sighting_utils.read_sighting(flask_app_client, researcher_1, sighting_id)
+    assert response.json['idConfigs'] == new_configs
+
     # Single test that Sighting response has the correct keys
     assert set(response.json.keys()) >= {
         'comments',


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- New API to repeat sighting identification
- Returns the full Sighting data
- Full sighting data now containd idConfigs
- idConfigs can be patched in the same way as for AGS as requested


---

**REST API Updates **

```
[POST] /api/v1/sightings/{sighting_guid}/rerun_id/
{
}
```
Format of idConfigs retured in GET and to be used in PATCH: `[{'algorithms': ['hotspotter_nosv']}]`
