### PR TITLE
1003 individual elasticsearch response schema

### DIFF
--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -223,7 +223,7 @@ class Individual(db.Model, FeatherModel):
         return tx
 
     # commented out for now due to duplication introduced by method above
-    #def get_taxonomy_names(self):
+    # def get_taxonomy_names(self):
     #    tx = self.get_taxonomy_object()
     #    if not tx:
     #        return []
@@ -267,6 +267,12 @@ class Individual(db.Model, FeatherModel):
 
     def get_encounters(self):
         return self.encounters
+
+    def get_encounter_guids(self):
+        return [encounter.guid for encounter in self.encounters]
+
+    def num_encounters(self):
+        return len(self.encounters)
 
     def add_encounters(self, encounters):
         for encounter in encounters:

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -235,7 +235,7 @@ class IndividualElasticsearch(Resource):
             'action': AccessOperation.READ,
         },
     )
-    @api.response(schemas.DetailedIndividualSchema(many=True))
+    @api.response(schemas.ElasticsearchIndividualSchema(many=True))
     @api.paginate()
     def get(self, args):
         search = {}
@@ -249,7 +249,7 @@ class IndividualElasticsearch(Resource):
             'action': AccessOperation.READ,
         },
     )
-    @api.response(schemas.DetailedIndividualSchema(many=True))
+    @api.response(schemas.ElasticsearchIndividualSchema(many=True))
     @api.paginate()
     def post(self, args):
         search = request.get_json()

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -235,7 +235,7 @@ class IndividualElasticsearch(Resource):
             'action': AccessOperation.READ,
         },
     )
-    @api.response(schemas.ElasticsearchIndividualSchema(many=True))
+    @api.response(schemas.ElasticsearchIndividualReturnSchema(many=True))
     @api.paginate()
     def get(self, args):
         search = {}
@@ -249,7 +249,7 @@ class IndividualElasticsearch(Resource):
             'action': AccessOperation.READ,
         },
     )
-    @api.response(schemas.ElasticsearchIndividualSchema(many=True))
+    @api.response(schemas.ElasticsearchIndividualReturnSchema(many=True))
     @api.paginate()
     def post(self, args):
         search = request.get_json()

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -119,8 +119,7 @@ class DetailedIndividualSchema(NamedIndividualSchema):
 
 class ElasticsearchIndividualSchema(ModelSchema):
     """
-    ElasticsearchIndividualSchema is used for both indexing individuals for ES
-    and showing them to the user upon return.
+    ElasticsearchIndividualSchema is used for indexing individuals for ES
     """
 
     featuredAssetGuid = base_fields.Function(Individual.get_featured_asset_guid)
@@ -156,6 +155,62 @@ class ElasticsearchIndividualSchema(ModelSchema):
             'social_groups',
             'sex',
             'encounters',
+            'birth',
+            'death',
+            'comments',
+            'customFields',
+            'has_annotations',
+            'last_seen',
+            'taxonomy_names',
+        )
+        dump_only = (
+            Individual.guid.key,
+            Individual.created.key,
+            Individual.updated.key,
+        )
+
+
+class ElasticsearchIndividualReturnSchema(ModelSchema):
+    """
+    ElasticsearchIndividualSchema is used for showing results to the user upon return.
+    """
+
+    featuredAssetGuid = base_fields.Function(Individual.get_featured_asset_guid)
+    names = base_fields.Function(Individual.get_name_values)
+    firstName = base_fields.Function(Individual.get_first_name)
+    adoptionName = base_fields.Function(Individual.get_adoption_name)
+    social_groups = base_fields.Function(Individual.get_social_groups_json)
+    sex = base_fields.Function(Individual.get_sex)
+    birth = base_fields.Function(Individual.get_time_of_birth)
+    death = base_fields.Function(Individual.get_time_of_death)
+    comments = base_fields.Function(Individual.get_comments)
+    customFields = base_fields.Function(Individual.get_custom_fields)
+    taxonomy_guid = base_fields.Function(Individual.get_taxonomy_guid_inherit_encounters)
+    has_annotations = base_fields.Function(Individual.has_annotations)
+    last_seen = base_fields.Function(Individual.get_last_seen_time)
+    taxonomy_names = base_fields.Function(Individual.get_taxonomy_names)
+
+    encounters = base_fields.Function(Individual.get_encounter_guids)
+    num_encounters = base_fields.Function(Individual.num_encounters)
+
+    class Meta:
+        # pylint: disable=missing-docstring
+        model = Individual
+        fields = (
+            Individual.guid.key,
+            'elasticsearchable',
+            Individual.indexed.key,
+            Individual.created.key,
+            Individual.updated.key,
+            'featuredAssetGuid',
+            'names',
+            'firstName',
+            'adoptionName',
+            'taxonomy_guid',
+            'social_groups',
+            'sex',
+            'encounters',
+            'num_encounters',
             'birth',
             'death',
             'comments',

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -119,7 +119,8 @@ class DetailedIndividualSchema(NamedIndividualSchema):
 
 class ElasticsearchIndividualSchema(ModelSchema):
     """
-    Base Individual schema exposes only the most general fields.
+    ElasticsearchIndividualSchema is used for both indexing individuals for ES
+    and showing them to the user upon return.
     """
 
     featuredAssetGuid = base_fields.Function(Individual.get_featured_asset_guid)

--- a/tests/modules/individuals/resources/test_elasticsearch.py
+++ b/tests/modules/individuals/resources/test_elasticsearch.py
@@ -14,7 +14,7 @@ import pytest
     module_unavailable('individuals'), reason='Individuals module disabled'
 )
 @pytest.mark.skipif(
-    test_utils.extension_unavailable('elasticsearch'),
+    extension_unavailable('elasticsearch'),
     reason='Elasticsearch extension disabled',
 )
 def test_individual_elasticsearch_mappings(
@@ -64,49 +64,11 @@ def test_individual_elasticsearch_mappings(
     module_unavailable('individuals'), reason='Individuals module disabled'
 )
 @pytest.mark.skipif(
-    extension_unavailable('elasticsearch') or module_unavailable('elasticsearch'),
-    reason='Elasticsearch extension or module disabled',
+    extension_unavailable('elasticsearch'),
+    reason='Elasticsearch extension disabled',
 )
-def test_elasticsearch_names(db, flask_app_client, researcher_1, request, test_root):
+def test_returned_schema(flask_app_client, researcher_1, admin_user, request, test_root):
     from app.modules.individuals.models import Individual
-    from app.modules.individuals.schemas import ElasticsearchIndividualSchema
-
-    create_resp = individual_utils.create_individual_and_sighting(
-        flask_app_client,
-        researcher_1,
-        request,
-        test_root,
-        individual_data={
-            'names': [
-                {'context': 'firstName', 'value': 'Z432'},
-                {'context': 'Christian name', 'value': 'Zachariah'},
-            ],
-        },
-    )
-    ind = Individual.query.get(create_resp['individual'])
-    with es.session.begin(blocking=True, forced=True):
-        ind.index()
-    body = {}
-    indy = Individual.elasticsearch(body)[0]
-    # actually load the ES schema
-    es_schema = ElasticsearchIndividualSchema()
-    es_indy = es_schema.dump(indy).data
-    assert type(es_indy['names']) is list
-    assert es_indy['names'] == ['Z432', 'Zachariah']
-
-
-@pytest.mark.skipif(
-    module_unavailable('individuals'), reason='Individuals module disabled'
-)
-@pytest.mark.skipif(
-    extension_unavailable('elasticsearch') or module_unavailable('elasticsearch'),
-    reason='Elasticsearch extension or module disabled',
-)
-def test_elasticsearch_taxonomy(
-    db, flask_app_client, admin_user, researcher_1, request, test_root
-):
-    from app.modules.individuals.models import Individual
-    from app.modules.individuals.schemas import ElasticsearchIndividualSchema
     from tests.modules.site_settings.resources import utils as setting_utils
     import datetime
 
@@ -145,22 +107,35 @@ def test_elasticsearch_taxonomy(
         'taxonomies': tx_guid,
     }
 
-    uuids = individual_utils.create_individual_and_sighting(
+    # note that taxonomy is not set on the individual in this test (we are checking it will inherit from encounters)
+    individual_data = {
+        'sex': 'female',
+        'names': [
+            {'context': 'firstName', 'value': 'Z432'},
+            {'context': 'Christian name', 'value': 'Zachariah'},
+        ],
+    }
+
+    # from IPython import embed
+    # print('test embed')
+    # embed()
+
+    create_resp = individual_utils.create_individual_and_sighting(
         flask_app_client,
         researcher_1,
         request,
         test_root,
+        individual_data=individual_data,
         sighting_data=sighting_data,
     )
-    individual_id = uuids['individual']
-
-    ind = Individual.query.get(individual_id)
+    individual_guid = create_resp['individual']
     with es.session.begin(blocking=True, forced=True):
-        ind.index()
-    body = {}
-    indy = Individual.elasticsearch(body)[0]
-    # actually load the ES schema
-    es_schema = ElasticsearchIndividualSchema()
-    es_indy = es_schema.dump(indy).data
+        Individual.query.get(individual_guid).index()
 
+    search_resp = test_utils.elasticsearch(flask_app_client, researcher_1, 'individuals')
+    es_indy = search_resp.json[0]
+
+    assert es_indy['guid'] == individual_guid
+    assert es_indy['sex'] == 'female'
+    assert es_indy['names'] == ['Z432', 'Zachariah']
     assert es_indy['taxonomy_guid'] == tx_guid

--- a/tests/modules/individuals/resources/test_elasticsearch.py
+++ b/tests/modules/individuals/resources/test_elasticsearch.py
@@ -129,6 +129,7 @@ def test_returned_schema(flask_app_client, researcher_1, admin_user, request, te
         sighting_data=sighting_data,
     )
     individual_guid = create_resp['individual']
+    enc_guid = create_resp['encounters'][0]
     with es.session.begin(blocking=True, forced=True):
         Individual.query.get(individual_guid).index()
 
@@ -139,3 +140,7 @@ def test_returned_schema(flask_app_client, researcher_1, admin_user, request, te
     assert es_indy['sex'] == 'female'
     assert es_indy['names'] == ['Z432', 'Zachariah']
     assert es_indy['taxonomy_guid'] == tx_guid
+
+    # check encounter is just a guid
+    assert es_indy['encounters'] == [enc_guid]
+    assert es_indy['num_encounters'] == 1


### PR DESCRIPTION
Updates the individual elasticsearch endpoint to use the same ES schema we use for indexing individuals on ES. Previously, frontend was getting DetailedIndividualSchema, which included none of the EDM fields for runtime considerations, but as a result would not include almost any of the meaningful fields a user would search on. We decided in meetings the runtime hit is worth it so that users can see e.g. the sex of their search results after searching on the sex field.

The test covering this is `tests/modules/individuals/resources/test_elasticsearch.py::test_returned_schema`. That test also subsumes two prior tests on the ES schema, which did not actually go through the ES endpoint (I wrote those, oops!). 