### PR TITLE
543 annot patch unused params removal

### DIFF
--- a/app/modules/annotations/parameters.py
+++ b/app/modules/annotations/parameters.py
@@ -48,13 +48,9 @@ class PatchAnnotationDetailsParameters(PatchJSONParameters):
         '/%s' % field
         for field in (
             'encounter_guid',
-            'ia_class',
-            'bounds',
             'keywords',
         )
     )
-
-    NON_NULL_PATHS = ('/ia_class',)
 
     @classmethod
     def _check_keyword_value(cls, obj, field, value, state, create=True):

--- a/tests/modules/annotations/resources/test_patch_annotation.py
+++ b/tests/modules/annotations/resources/test_patch_annotation.py
@@ -2,7 +2,6 @@
 # pylint: disable=missing-docstring
 import uuid
 
-from tests import utils as test_utils
 from tests.modules.annotations.resources import utils as annot_utils
 from tests.modules.sightings.resources import utils as sighting_utils
 import pytest
@@ -69,59 +68,6 @@ def test_patch_annotation(
     assert len(first_encounter.annotations) == 0
     assert len(second_encounter.annotations) == 1
     assert second_encounter.annotations[0].guid == uuid.UUID(annotation_guid)
-
-    # change ia_class via patch
-    assert read_annotation.ia_class == 'test'
-    new_ia_class = 'test2'
-    patch_arg = [
-        test_utils.patch_replace_op('ia_class', new_ia_class),
-    ]
-    annot_utils.patch_annotation(
-        flask_app_client, annotation_guid, researcher_1, patch_arg
-    )
-    read_annotation = Annotation.query.get(annotation_guid)
-    assert read_annotation.ia_class == new_ia_class
-
-    # fail setting ia_class null
-    patch_arg = [
-        test_utils.patch_replace_op('ia_class', None),
-    ]
-    annot_utils.patch_annotation(
-        flask_app_client,
-        annotation_guid,
-        researcher_1,
-        patch_arg,
-        expected_status_code=422,
-    )
-    read_annotation = Annotation.query.get(annotation_guid)
-    assert read_annotation.ia_class == new_ia_class  # unchanged from before
-
-    # change bounds via patch
-    new_bounds = {'rect': [100, 200, 300, 400]}
-    patch_arg = [
-        test_utils.patch_replace_op('bounds', new_bounds),
-    ]
-    annot_utils.patch_annotation(
-        flask_app_client, annotation_guid, researcher_1, patch_arg
-    )
-    read_annotation = Annotation.query.get(annotation_guid)
-    assert read_annotation.bounds == new_bounds
-
-    # change bounds via patch, but invalid bounds value
-    new_bounds = {'rect': [100, 200]}
-    patch_arg = [
-        test_utils.patch_replace_op('bounds', new_bounds),
-    ]
-    response = annot_utils.patch_annotation(
-        flask_app_client,
-        annotation_guid,
-        researcher_1,
-        patch_arg,
-        expected_status_code=422,
-    )
-    assert response.json['message'] == 'bounds value is invalid'
-    read_annotation = Annotation.query.get(annotation_guid)
-    assert read_annotation.bounds != new_bounds
 
     # And deleting it
     annot_utils.delete_annotation(flask_app_client, researcher_1, annotation_guid)


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Remove the support for the bounds and ia class patching on the annotation as requested

