### PR TITLE
Added ability to sort API results based on relationships

### DIFF
--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -371,7 +371,6 @@ if elasticsearch is None:
         def elasticsearch(self, *args, **kwargs):
             return []
 
-
 else:
 
     def register_elasticsearch_model(*args, **kwargs):

--- a/app/extensions/api/namespace.py
+++ b/app/extensions/api/namespace.py
@@ -9,6 +9,7 @@ import logging
 
 import flask_marshmallow
 import flask_sqlalchemy
+from sqlalchemy.inspection import inspect
 import sqlalchemy
 
 from flask_restx_patched.namespace import Namespace as BaseNamespace
@@ -156,13 +157,34 @@ class Namespace(BaseNamespace):
                         default_column = cls.guid
 
                     sort = sort.lower()
+                    outerjoin_cls = None
+
                     if sort in ['default', 'primary']:
                         sort_column = default_column
                     else:
+                        # First, check for columns in the table
                         sort_column = None
-                        for column in list(cls.__table__.columns):
+                        column_names = list(cls.__table__.columns)
+                        for column in column_names:
                             if column.name.lower() == sort:
                                 sort_column = column
+
+                        # Next, check for columns in relationship tables
+                        if '.' in sort:
+                            for attribute, relationship in inspect(
+                                cls
+                            ).relationships.items():
+                                rel_cls = relationship.mapper.class_
+                                column_names = list(rel_cls.__table__.columns)
+                                for column in column_names:
+                                    column_name = '%s.%s' % (
+                                        attribute,
+                                        column.name.lower(),
+                                    )
+                                    if column_name == sort:
+                                        outerjoin_cls = rel_cls
+                                        sort_column = column
+
                         if sort_column is None:
                             log.warning(
                                 'The sort field %r is unrecognized, defaulting to GUID'
@@ -172,6 +194,10 @@ class Namespace(BaseNamespace):
 
                     sort_func_1 = sort_column.desc if reverse else sort_column.asc
                     sort_func_2 = default_column.desc if reverse else default_column.asc
+
+                    if outerjoin_cls is not None:
+                        query = query.outerjoin(outerjoin_cls)
+
                     query = (
                         query.order_by(sort_func_1(), sort_func_2())
                         .offset(offset)

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -107,7 +107,6 @@ if is_extension_enabled('edm'):
             # TODO is this actually needed
             log.warning('User._process_edm_user_organization() not implemented yet')
 
-
 else:
     UserEDMMixin = object
 

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -77,7 +77,11 @@ OBJECT_USER_MAP = {
         'is_admin',
         'is_researcher',
     ],
-    ('Individual', AccessOperation.READ): ['is_staff', 'is_data_manager', 'is_researcher'],
+    ('Individual', AccessOperation.READ): [
+        'is_staff',
+        'is_data_manager',
+        'is_researcher',
+    ],
     ('Individual', AccessOperation.WRITE): ['is_staff', 'is_data_manager'],
     ('AssetGroupSighting', AccessOperation.WRITE_INTERNAL): ['is_internal'],
     ('Encounter', AccessOperation.READ): ['is_staff', 'is_data_manager', 'is_researcher'],

--- a/tests/extensions/test_elasticsearch.py
+++ b/tests/extensions/test_elasticsearch.py
@@ -677,8 +677,8 @@ def test_elasticsearch_utilities(
         es.es_index_all()
 
     # Test tasks
-    es_tasks.es_task_refresh_index_all.s(True).apply().result
-    es_tasks.es_task_invalidate_indexed_timestamps.s(True).apply().result
+    es_tasks.es_task_refresh_index_all(True)
+    es_tasks.es_task_invalidate_indexed_timestamps(True)
 
 
 @pytest.mark.skipif(

--- a/tests/modules/encounters/resources/utils.py
+++ b/tests/modules/encounters/resources/utils.py
@@ -75,6 +75,26 @@ def read_encounter(flask_app_client, user, enc_guid, expected_status_code=200):
     return response
 
 
+def read_all_encounters_pagination(
+    flask_app_client, user, expected_status_code=200, **kwargs
+):
+    assert set(kwargs.keys()) <= {'limit', 'offset', 'sort', 'reverse', 'reverse_after'}
+
+    with flask_app_client.login(user, auth_scopes=('encounters:read',)):
+        response = flask_app_client.get(
+            PATH,
+            query_string=kwargs,
+        )
+
+    if expected_status_code == 200:
+        test_utils.validate_list_response(response, 200)
+    else:
+        test_utils.validate_dict_response(
+            response, expected_status_code, {'status', 'message'}
+        )
+    return response
+
+
 # This returns a sighting debug object so acn't reuse above method as expected fields are way different
 def read_encounter_debug(flask_app_client, user, enc_guid, expected_status_code=200):
     response = test_utils.get_dict_via_flask(


### PR DESCRIPTION
All listing APIs (Houston and Elasticsearch) support a `sort` input argument.  This is reserved for Houston database table columns for a given model class, but now can support attributes of any relationship on the model class as well.  For example, an `Encounter` can be sorted on `guid` or `version`.  The Encounter also has a relationship called `time` that points into `ComplexDateTime`.  This time is an object relationship into a different table, but sorting Encounters with `time.datetime` allows for them to be sorted appropriately.