### PR TITLE
Remove redundant retry for detection and identification celery tasks

### DIFF
--- a/app/modules/asset_groups/tasks.py
+++ b/app/modules/asset_groups/tasks.py
@@ -4,7 +4,6 @@ import logging
 import git
 from flask import current_app
 import requests.exceptions
-import sqlalchemy.exc
 
 from app.extensions.celery import celery
 from app.extensions.gitlab import GitlabInitializationError
@@ -74,12 +73,7 @@ def git_push(asset_group_guid):
     log.debug(f'...pushed to {repo.head.ref}')
 
 
-# RequestException is a base class for all sorts of errors, inc timeouts so this handles them all
-@celery.task(
-    autoretry_for=(requests.exceptions.RequestException, sqlalchemy.exc.SQLAlchemyError),
-    default_retry_delay=10,
-    max_retries=10,
-)
+@celery.task
 def sage_detection(asset_group_sighting_guid, model):
     from .models import AssetGroupSighting
 

--- a/app/modules/sightings/tasks.py
+++ b/app/modules/sightings/tasks.py
@@ -1,19 +1,12 @@
 # -*- coding: utf-8 -*-
 import logging
 
-import requests.exceptions
-
 from app.extensions.celery import celery
 
 log = logging.getLogger(__name__)
 
 
-# RequestException is a base class for all sorts of errors, inc timeouts so this handles them all
-@celery.task(
-    autoretry_for=(requests.exceptions.RequestException,),
-    default_retry_delay=600,
-    max_retries=10,
-)
+@celery.task
 def send_identification(
     sighting_guid,
     config_id,
@@ -40,12 +33,7 @@ def send_identification(
         )
 
 
-# RequestException is a base class for all sorts of errors, inc timeouts so this handles them all
-@celery.task(
-    autoretry_for=(requests.exceptions.RequestException,),
-    default_retry_delay=600,
-    max_retries=10,
-)
+@celery.task
 # as for the above but this time for everything in the sighting
 def send_all_identification(sighting_guid):
     from .models import Sighting


### PR DESCRIPTION
We already have `JobControl.check_jobs` which periodically starts
detection or identification tasks if they fail to start.  Having the
"retry" on the original tasks complicate things and causing possibly
duplicate requests to acm.

---

This is one of the things on my TODO list from 2 weeks ago, not sure if it's still relevant...