### PR TITLE
DEX-539 DEX-541 Add recaptcha to POST /api/v1/asset_groups/

### DIFF
--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -16,6 +16,7 @@ from flask_restx_patched._http import HTTPStatus
 
 from app.extensions import db
 from app.extensions.api import Namespace, abort
+from app.modules.auth.utils import recaptcha_required
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 from app.utils import HoustonException
@@ -72,6 +73,7 @@ class AssetGroups(Resource):
         """
         return AssetGroup.query_search(args=args)
 
+    @recaptcha_required
     @api.permission_required(
         permissions.ModuleAccessPermission,
         kwargs_on_request=lambda kwargs: {

--- a/app/modules/site_settings/models.py
+++ b/app/modules/site_settings/models.py
@@ -149,6 +149,16 @@ class SiteSetting(db.Model, Timestamp):
             'default': '',
             'isApiKey': True,
         },
+        'recaptchaPublicKey': {
+            'type': str,
+            'public': True,
+            'default': lambda: current_app.config.get('RECAPTCHA_PUBLIC_KEY'),
+        },
+        'recaptchaSecretKey': {
+            'type': str,
+            'public': False,
+            'default': lambda: current_app.config.get('RECAPTCHA_SECRET_KEY'),
+        },
     }
 
     if is_extension_enabled('intelligent_agent'):

--- a/config/base.py
+++ b/config/base.py
@@ -230,7 +230,12 @@ class EmailConfig(object):
 
 
 class ReCaptchaConfig(object):
+    RECAPTCHA_SITE_VERIFY_API = os.getenv(
+        'RECAPTCHA_SITE_VERIFY_API',
+        'https://www.google.com/recaptcha/api/siteverify',
+    )
     RECAPTCHA_PUBLIC_KEY = os.getenv('RECAPTCHA_PUBLIC_KEY', 'XXX')
+    RECAPTCHA_SECRET_KEY = os.getenv('RECAPTCHA_SECRET_KEY', 'XXX')
     RECAPTCHA_BYPASS = os.getenv('RECAPTCHA_BYPASS', 'XXX')
 
 

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -47,6 +47,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
     response = session.post(
         codex_url('/api/v1/asset_groups/'),
         json={
+            'token': 'XXX',
             'description': 'This is a test asset group, please ignore',
             'sightings': [
                 {
@@ -391,6 +392,7 @@ def create_individual(
     default_name_context=DEFAULT_NAME_CONTEXT,
 ):
     group_data = {
+        'token': 'XXX',
         'description': 'This is a test asset_group, please ignore',
         'uploadType': 'bulk',
         'speciesDetectionModel': ['None'],
@@ -455,6 +457,7 @@ def test_bulk_upload(session, login, codex_url, test_root, request):
     response = session.post(
         codex_url('/api/v1/asset_groups/'),
         json={
+            'token': 'XXX',
             'description': 'Bulk import from user',
             'uploadType': 'bulk',
             'speciesDetectionModel': ['african_terrestrial'],
@@ -568,6 +571,7 @@ def test_delete_asset_group_sightings(session, login, codex_url, test_root, requ
     response = session.post(
         codex_url('/api/v1/asset_groups/'),
         json={
+            'token': 'XXX',
             'description': 'Bulk import from user',
             'uploadType': 'bulk',
             'speciesDetectionModel': ['african_terrestrial'],

--- a/integration_tests/test_sage_basic_identification.py
+++ b/integration_tests/test_sage_basic_identification.py
@@ -7,6 +7,7 @@ def create_sighting(session, codex_url, test_root, filename, group_data=None):
     transaction_id = utils.upload_to_tus(session, codex_url, [test_root / filename])
     if not group_data:
         group_data = {
+            'token': 'XXX',
             'description': 'This is a test asset_group, please ignore',
             'uploadType': 'form',
             'speciesDetectionModel': ['african_terrestrial'],
@@ -158,6 +159,7 @@ def test_identification_international(session, codex_url, test_root, login):
     # Going to get nasty now and put international characters in here
     filename = 'zebra-named-Sigurður.jpg'
     group_data = {
+        'token': 'XXX',
         'description': description,
         'uploadType': 'form',
         'speciesDetectionModel': ['african_terrestrial'],

--- a/integration_tests/test_sage_detection.py
+++ b/integration_tests/test_sage_detection.py
@@ -10,6 +10,7 @@ def test_create_asset_group_detection(session, codex_url, test_root, login):
     zebra = test_root / 'zebra.jpg'
     transaction_id = utils.upload_to_tus(session, codex_url, [zebra])
     data = {
+        'token': 'XXX',
         'description': 'This is a test asset_group, please ignore',
         'uploadType': 'form',
         'speciesDetectionModel': ['african_terrestrial'],

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -38,6 +38,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
     response = session.post(
         codex_url('/api/v1/asset_groups/'),
         json={
+            'token': 'XXX',
             'description': 'This is a test asset group, please ignore',
             'sightings': [
                 {

--- a/integration_tests/test_social_groups.py
+++ b/integration_tests/test_social_groups.py
@@ -6,6 +6,7 @@ from . import utils
 # encounters,
 def create_sighting(session, codex_url):
     group_data = {
+        'token': 'XXX',
         'description': 'This is a test asset_group, please ignore',
         'uploadType': 'bulk',
         'speciesDetectionModel': ['None'],

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -543,6 +543,8 @@ class AssetGroupCreationData(object):
 def create_asset_group(
     flask_app_client, user, data, expected_status_code=200, expected_error=''
 ):
+    data['token'] = 'XXX'  # Recaptcha bypass
+
     from app.modules.asset_groups.tasks import sage_detection
 
     # Call sage_detection in the foreground by skipping "delay"


### PR DESCRIPTION
- Add a `@recaptcha_required` decorator for resource functions
- Validate the `token` in `request.data` with recaptcha and returns 400
  Bad Request if bot score fails

