### PR TITLE
1024 user asset group sightings in reverse created order

### DIFF
--- a/app/extensions/api/parameters.py
+++ b/app/extensions/api/parameters.py
@@ -70,3 +70,15 @@ class PaginationParameters(Parameters):
         description='the field to reverse the sorted results (after paging has been performed), default is False',
         missing=False,
     )
+
+
+class PaginationParametersLatestFirst(PaginationParameters):
+
+    sort = base_fields.String(
+        description='the field to sort the results by, default is the created key column',
+        missing='created',
+    )
+    reverse = base_fields.Boolean(
+        description='the field to reverse the sorted results (before paging has been performed), default is True',
+        missing=True,
+    )

--- a/app/modules/collaborations/parameters.py
+++ b/app/modules/collaborations/parameters.py
@@ -9,19 +9,11 @@ import logging
 
 from . import schemas
 from flask_login import current_user
-from app.extensions.api.parameters import PaginationParameters
 from app.modules.users.permissions.types import AccessOperation
 from app.modules.users.permissions import rules
 from app.utils import HoustonException
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
-
-
-class GetCollaborationsParameters(PaginationParameters):
-    sort = base_fields.String(
-        description='the field to sort the results by, default is "created"',
-        missing='created',
-    )
 
 
 class CreateCollaborationParameters(Parameters, schemas.DetailedCollaborationSchema):

--- a/app/modules/collaborations/resources.py
+++ b/app/modules/collaborations/resources.py
@@ -21,6 +21,7 @@ from app.modules.users.permissions.types import AccessOperation
 from app.utils import HoustonException
 from app.modules.users import permissions
 import app.extensions.logging as AuditLog
+from app.extensions.api.parameters import PaginationParametersLatestFirst
 
 from . import parameters, schemas
 from .models import Collaboration
@@ -47,7 +48,7 @@ class Collaborations(Resource):
         },
     )
     @api.response(schemas.BaseCollaborationSchema(many=True))
-    @api.paginate(parameters.GetCollaborationsParameters())
+    @api.paginate(PaginationParametersLatestFirst())
     def get(self, args):
         """
         List of Collaboration.

--- a/app/modules/notifications/parameters.py
+++ b/app/modules/notifications/parameters.py
@@ -9,19 +9,6 @@ from flask_restx_patched import Parameters, PatchJSONParameters
 
 from . import schemas
 from .models import Notification, NOTIFICATION_CONFIG  # NOQA
-from app.extensions.api.parameters import PaginationParameters
-from flask_marshmallow import base_fields
-
-
-class ListAllUnreadNotifications(PaginationParameters):
-    sort = base_fields.String(
-        description='the field to sort the results by, default is "created"',
-        missing='created',
-    )
-    reverse = base_fields.Boolean(
-        description='the field to reverse the sorted results (before paging has been performed), default is True',
-        missing=True,
-    )
 
 
 class CreateNotificationParameters(Parameters, schemas.DetailedNotificationSchema):

--- a/app/modules/notifications/resources.py
+++ b/app/modules/notifications/resources.py
@@ -16,7 +16,10 @@ from app.extensions.api import abort
 
 from app.extensions import db
 from app.extensions.api import Namespace
-from app.extensions.api.parameters import PaginationParameters
+from app.extensions.api.parameters import (
+    PaginationParameters,
+    PaginationParametersLatestFirst,
+)
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 
@@ -168,7 +171,7 @@ class AllUnreadNotifications(Resource):
         },
     )
     @api.response(schemas.DetailedNotificationSchema(many=True))
-    @api.paginate(parameters.ListAllUnreadNotifications())
+    @api.paginate(PaginationParametersLatestFirst())
     def get(self, args):
         """
         List of Notifications for all users with no preferences applied.

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -11,7 +11,10 @@ from flask import current_app, send_file, request, url_for, redirect, session
 from flask_login import current_user
 from flask_restx_patched import Resource
 from flask_restx_patched._http import HTTPStatus
-from app.extensions.api.parameters import PaginationParameters
+from app.extensions.api.parameters import (
+    PaginationParameters,
+    PaginationParametersLatestFirst,
+)
 from app.extensions.api import Namespace, abort
 import app.extensions.logging as AuditLog
 from app.extensions import is_extension_enabled
@@ -538,7 +541,7 @@ if is_module_enabled('asset_groups'):
             },
         )
         @api.response(BaseAssetGroupSightingSchema(many=True))
-        @api.paginate()
+        @api.paginate(PaginationParametersLatestFirst())
         def get(self, args, user):
             """
             Get AssetGroupSightings for user

--- a/tests/modules/collaborations/resources/test_collaboration_create.py
+++ b/tests/modules/collaborations/resources/test_collaboration_create.py
@@ -49,10 +49,10 @@ def test_create_collaboration(
 
         # which should contain the same Users
         assert len(all_resp.json) == 2
-        assert set(all_resp.json[0]['members'].keys()) == set(
+        assert set(all_resp.json[1]['members'].keys()) == set(
             {str(readonly_user.guid), str(researcher_2.guid)}
         )
-        assert set(all_resp.json[1]['members'].keys()) == set(
+        assert set(all_resp.json[0]['members'].keys()) == set(
             {str(researcher_1.guid), str(researcher_2.guid)}
         )
 


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Added new pagination params util to sort the items in reverse created order (Latest first)
- Used this for the User AssetGroupSightings

