### PR TITLE
DEX-1040: get entire matching-set from elasticsearch

### DIFF
--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -253,7 +253,7 @@ class Annotation(db.Model, HoustonModel):
             query = self.get_matching_set_default_query()
         else:
             query = self.resolve_matching_set_query(query)
-        matching_set = self.elasticsearch(query, load=load)
+        matching_set = self.elasticsearch(query, load=load, limit=None)
         log.info(
             f'annot.get_matching_set(): finding matching set for {self} using (resolved) query {query} => {len(matching_set)} annots'
         )


### PR DESCRIPTION
## Pull Request Overview

- Need to pass `limit=None` to force `elasticsearch()` to give us all matches
