### PR TITLE
DEX-539 DEX-541 Skip recaptcha if recaptchaPublicKey not set

### DIFF
--- a/config/base.py
+++ b/config/base.py
@@ -234,8 +234,8 @@ class ReCaptchaConfig(object):
         'RECAPTCHA_SITE_VERIFY_API',
         'https://www.google.com/recaptcha/api/siteverify',
     )
-    RECAPTCHA_PUBLIC_KEY = os.getenv('RECAPTCHA_PUBLIC_KEY', 'XXX')
-    RECAPTCHA_SECRET_KEY = os.getenv('RECAPTCHA_SECRET_KEY', 'XXX')
+    RECAPTCHA_PUBLIC_KEY = os.getenv('RECAPTCHA_PUBLIC_KEY')
+    RECAPTCHA_SECRET_KEY = os.getenv('RECAPTCHA_SECRET_KEY')
     RECAPTCHA_BYPASS = os.getenv('RECAPTCHA_BYPASS', 'XXX')
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -236,6 +236,7 @@ def flask_app(gitlab_remote_login_pat, disable_elasticsearch):
         # Override values that might be defined in docker-compose.override.yml
         config_override['DEFAULT_EMAIL_SERVICE_USERNAME'] = None
         config_override['DEFAULT_EMAIL_SERVICE_PASSWORD'] = None
+        config_override['RECAPTCHA_PUBLIC_KEY'] = None
 
         app = create_app(config_override=config_override)
         from app.extensions import db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,6 +233,10 @@ def flask_app(gitlab_remote_login_pat, disable_elasticsearch):
         config_override['UPLOADS_DATABASE_PATH'] = str(pathlib.Path(td) / 'uploads')
         config_override['FILEUPLOAD_BASE_PATH'] = str(pathlib.Path(td) / 'fileuploads')
 
+        # Override values that might be defined in docker-compose.override.yml
+        config_override['DEFAULT_EMAIL_SERVICE_USERNAME'] = None
+        config_override['DEFAULT_EMAIL_SERVICE_PASSWORD'] = None
+
         app = create_app(config_override=config_override)
         from app.extensions import db
 

--- a/tests/modules/auth/test_utils.py
+++ b/tests/modules/auth/test_utils.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+import json
+from unittest import mock
+
+import pytest
+import requests.exceptions
+import werkzeug.exceptions
+
+from app.modules.auth.utils import recaptcha_required
+
+
+def test_recaptcha_required_skipped(flask_app):
+    # recaptchaPublicKey not set up
+    result = mock.Mock()
+
+    with flask_app.test_request_context():
+
+        @recaptcha_required
+        def f():
+            return result
+
+        assert f() == result
+
+
+def test_recaptcha_required_bypass(flask_app, request):
+    from app.modules.site_settings.models import SiteSetting
+
+    SiteSetting.set_key_value('recaptchaPublicKey', 'public')
+    request.addfinalizer(lambda: SiteSetting.forget_key_value('recaptchaPublicKey'))
+    SiteSetting.set_key_value('recaptchaSecretKey', 's-e-c-r-e-t')
+    request.addfinalizer(lambda: SiteSetting.forget_key_value('recaptchaSecretKey'))
+    result = mock.Mock()
+
+    with flask_app.test_request_context():
+        with mock.patch('app.modules.auth.utils.request') as flask_request:
+            flask_request.data = json.dumps({'token': 'XXX'})
+
+            @recaptcha_required
+            def f():
+                return result
+
+            assert f() == result
+
+
+def test_recaptcha_required_verify_token(flask_app, request):
+    from app.modules.site_settings.models import SiteSetting
+
+    SiteSetting.set_key_value('recaptchaPublicKey', 'public')
+    request.addfinalizer(lambda: SiteSetting.forget_key_value('recaptchaPublicKey'))
+    SiteSetting.set_key_value('recaptchaSecretKey', 's-e-c-r-e-t')
+    request.addfinalizer(lambda: SiteSetting.forget_key_value('recaptchaSecretKey'))
+
+    # Patch log so it doesn't do anything
+    patch_log = mock.patch('app.modules.auth.utils.log')
+    patch_log.start()
+    request.addfinalizer(patch_log.stop)
+
+    # Patch time.sleep so it doesn't sleep
+    patch_sleep = mock.patch('time.sleep')
+    patch_sleep.start()
+    request.addfinalizer(patch_sleep.stop)
+
+    result = mock.Mock()
+
+    # Patch requests.post
+    patch_requests_post = mock.patch('requests.post')
+    post = patch_requests_post.start()
+    request.addfinalizer(patch_requests_post.stop)
+
+    with flask_app.test_request_context():
+        # Patch flask.request
+        patch_request = mock.patch('app.modules.auth.utils.request')
+        flask_request = patch_request.start()
+        request.addfinalizer(patch_request.stop)
+
+        flask_request.data = json.dumps({'token': 'qwerty123456'})
+
+        @recaptcha_required
+        def f():
+            return result
+
+        # Case 1: score > 0.5 (human)
+        response = mock.Mock()
+        response.json.return_value = {'success': True, 'score': 0.9}
+        post.return_value = response
+
+        assert f() == result
+
+        # Case 2: score < 0.5 (bot)
+        response.json.return_value = {'success': True, 'score': 0.1}
+
+        with pytest.raises(werkzeug.exceptions.BadRequest) as exc:
+            f()
+        assert str(exc.value) == '400 Bad Request: Recaptcha bot score failed'
+
+        # Case 3: success is False
+        response.json.return_value = {
+            'success': False,
+            'error-codes': ['invalid-input-response'],
+        }
+
+        with pytest.raises(werkzeug.exceptions.BadRequest) as exc:
+            f()
+        assert (
+            str(exc.value)
+            == "400 Bad Request: Recaptcha response failure: {'success': False, 'error-codes': ['invalid-input-response']}"
+        )
+
+        # Case 4: ConnectionError or RequestException
+        post.reset_mock()
+
+        def mock_post(*args, **kwargs):
+            if post.call_count < 3:
+                raise requests.exceptions.ConnectionError
+            elif post.call_count < 11:
+                raise requests.exceptions.RequestException
+            return response
+
+        post.side_effect = mock_post
+
+        with pytest.raises(werkzeug.exceptions.BadRequest) as exc:
+            f()
+
+        assert str(exc.value) == '400 Bad Request: Recaptcha response failure: {}'
+        assert post.call_count == 10
+
+        post.reset_mock()
+
+        def mock_post(*args, **kwargs):
+            if post.call_count < 3:
+                raise requests.exceptions.ConnectionError
+            elif post.call_count < 4:
+                raise requests.exceptions.RequestException
+            return response
+
+        response.json.return_value = {'success': True, 'score': 0.9}
+
+        post.side_effect = mock_post
+
+        assert f() == result
+
+        assert post.call_count == 4


### PR DESCRIPTION
- Set DEFAULT_EMAIL_SERVICE_USERNAME and PASSWORD to None in tests

  I set the `DEFAULT_EMAIL_SERVICE_USERNAME` and
  `DEFAULT_EMAIL_SERVICE_PASSWORD` in `docker-compose.override.yml`
  causing `test_alter_houston_settings` in
  `tests/modules/site_settings/resources/test_read_configurations.py` to
  fail because it's checks `email_service_username` and
  `email_service_password` site settings.

- DEX-539 DEX-541 Skip recaptcha if recaptchaPublicKey not set
