### PR TITLE
DEX-1086: sighting.get_submission_time() and API usage of

### DIFF
--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -377,6 +377,10 @@ class AssetGroupSighting(db.Model, HoustonModel):
         else:
             return None
 
+    # this is to mirror same method on Sighting
+    def get_submission_time(self):
+        return self.created
+
     # Don't store detection start time directly. It's either the creation time if we ever had detection
     # jobs or None if no detection was done (and hence no jobs exist)
     def get_detection_start_time(self):

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -98,6 +98,7 @@ class BaseAssetGroupSightingSchema(ModelSchema):
     locationId = base_fields.Function(
         AssetGroupSighting.config_field_getter('locationId')
     )
+    submissionTime = base_fields.Function(AssetGroupSighting.get_submission_time)
 
     class Meta:
         # pylint: disable=missing-docstring
@@ -110,6 +111,7 @@ class BaseAssetGroupSightingSchema(ModelSchema):
             'time',
             'timeSpecificity',
             'locationId',
+            'submissionTime',
         )
         dump_only = (AssetGroupSighting.guid.key,)
 
@@ -276,6 +278,7 @@ class AssetGroupSightingAsSightingSchema(ModelSchema):
     identification_start_time = base_fields.String(default=None)
     unreviewed_start_time = base_fields.String(default=None)
     review_time = base_fields.String(default=None)
+    submissionTime = base_fields.Function(AssetGroupSighting.get_submission_time)
 
     hasView = base_fields.Boolean(default=True)
     hasEdit = base_fields.Boolean(default=True)

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -426,6 +426,15 @@ class Sighting(db.Model, FeatherModel):
         if guid in asset_guids:
             self.featured_asset_guid = guid
 
+    # this is (from user perspective) when this "started", so really means
+    #   AssetGroupSighting creation (if applicable)
+    def get_submission_time(self):
+        return (
+            self.asset_group_sighting.created
+            if self.asset_group_sighting
+            else self.created
+        )
+
     def get_detection_start_time(self):
         if self.asset_group_sighting:
             return self.asset_group_sighting.get_detection_start_time()

--- a/app/modules/sightings/schemas.py
+++ b/app/modules/sightings/schemas.py
@@ -70,6 +70,7 @@ class ElasticsearchSightingSchema(BaseSightingSchema):
     comments = base_fields.Function(Sighting.get_comments)
     taxonomy_guid = base_fields.Function(Sighting.get_taxonomy_guid)
     customFields = base_fields.Function(Sighting.get_custom_fields)
+    submissionTime = base_fields.Function(Sighting.get_submission_time)
 
     class Meta:
         # pylint: disable=missing-docstring
@@ -89,6 +90,7 @@ class ElasticsearchSightingSchema(BaseSightingSchema):
             'owners',
             'taxonomy_guid',
             'customFields',
+            'submissionTime',
         )
         dump_only = (
             Sighting.guid.key,
@@ -158,6 +160,7 @@ class AugmentedEdmSightingSchema(TimedSightingSchema):
     )
     jobs = base_fields.Function(Sighting.get_jobs_json)
     idConfigs = base_fields.Function(Sighting.get_id_configs)
+    submissionTime = base_fields.Function(Sighting.get_submission_time)
 
     class Meta(TimedSightingSchema.Meta):
         """
@@ -178,6 +181,7 @@ class AugmentedEdmSightingSchema(TimedSightingSchema):
             'timeSpecificity',
             'speciesDetectionModel',
             'idConfigs',
+            'submissionTime',
         )
 
 

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -148,6 +148,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
                 'creator': creator_data,
                 'curation_start_time': ags['curation_start_time'],
                 'detection_start_time': ags['detection_start_time'],
+                'submissionTime': ags['submissionTime'],
                 'elasticsearchable': ags['elasticsearchable'],
                 'guid': ags_guid,
                 'indexed': ags['indexed'],

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -377,6 +377,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
         'updatedHouston': response.json()['updatedHouston'],
         'curation_start_time': response.json()['curation_start_time'],
         'detection_start_time': response.json()['detection_start_time'],
+        'submissionTime': response.json()['submissionTime'],
         'identification_start_time': None,
         'progress_identification': response.json()['progress_identification'],
         'review_time': None,

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -158,6 +158,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
                 'sighting_guid': None,
                 'stage': 'detection',
                 'locationId': 'PYTEST',
+                'submissionTime': ags['submissionTime'],
                 'time': '2000-01-01T01:01:01+00:00',
                 'timeSpecificity': 'time',
             },

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -158,7 +158,6 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
                 'sighting_guid': None,
                 'stage': 'detection',
                 'locationId': 'PYTEST',
-                'submissionTime': ags['submissionTime'],
                 'time': '2000-01-01T01:01:01+00:00',
                 'timeSpecificity': 'time',
             },
@@ -263,6 +262,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
         'locationId': 'PYTEST',
         'stage': 'curation',
         'speciesDetectionModel': ['african_terrestrial'],
+        'submissionTime': response.json()['submissionTime'],
         'time': '2000-01-01T01:01:01+00:00',
         'timeSpecificity': 'time',
         # 2021-11-12T18:28:32.744135+00:00

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -330,6 +330,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
         'created': response.json()['created'],
         'updated': response.json()['updated'],
         'indexed': response.json()['indexed'],
+        'submissionTime': response.json()['submissionTime'],
         'detection_start_time': response.json()['detection_start_time'],
         'curation_start_time': response.json()['curation_start_time'],
         'identification_start_time': None,

--- a/integration_tests/test_sightings.py
+++ b/integration_tests/test_sightings.py
@@ -200,6 +200,7 @@ def test_sightings(session, login, codex_url, test_root, admin_name):
         'created': response.json()['created'],
         'updated': response.json()['updated'],
         'indexed': response.json()['indexed'],
+        'submissionTime': response.json()['submissionTime'],
         'detection_start_time': response.json()['detection_start_time'],
         'elasticsearchable': response.json()['elasticsearchable'],
         'curation_start_time': response.json()['curation_start_time'],


### PR DESCRIPTION
## Pull Request Overview

- Implements `sighting.get_submission_time()`
- Uses above in various API endpoint schema:
  - GET sightings/GUID
  - GET asset_groups/as_sighting/GUID
  - GET sightings (list)
  - ES index schema
  - ES results schema
