### PR TITLE
Hardening Fix-ups

### DIFF
--- a/app/extensions/git_store/__init__.py
+++ b/app/extensions/git_store/__init__.py
@@ -588,7 +588,7 @@ class GitStore(db.Model, HoustonModel):
     def init_progress_identification(self, overwrite=False):
         from app.modules.progress.models import Progress
 
-        if self.progress_identification is not None:
+        if self.progress_identification:
             if not overwrite:
                 log.warning(
                     'Git Store %r already has a progress identification %r'
@@ -614,7 +614,7 @@ class GitStore(db.Model, HoustonModel):
     def init_progress_detection(self, overwrite=False):
         from app.modules.progress.models import Progress
 
-        if self.progress_detection is not None:
+        if self.progress_detection:
             if not overwrite:
                 log.warning(
                     'Git Store %r already has a progress detection %r'
@@ -640,7 +640,7 @@ class GitStore(db.Model, HoustonModel):
     def init_progress_preparation(self, overwrite=False):
         from app.modules.progress.models import Progress
 
-        if self.progress_preparation is not None:
+        if self.progress_preparation:
             if not overwrite:
                 log.warning(
                     'Git Store %r already has a progress preparation %r'

--- a/app/extensions/git_store/__init__.py
+++ b/app/extensions/git_store/__init__.py
@@ -461,8 +461,7 @@ class GitStore(db.Model, HoustonModel):
     def git_commit_delay(self, input_filenames):
         # Start the git_commit that will process the assets (update=True) and commit the new files to the Git repo (commit=True)
         description = 'Tus collect commit for GitStore {!r}'.format(self.guid)
-        if True or current_app.testing:
-            # TODO (HARDENING): Remove True to the above conditional when tus-hardening is ready in the _frontend.codex/ repo
+        if current_app.testing:
             # When testing, run on-demand and don't use celery workers
             self.git_commit_worker(description, input_filenames)
             promise = None

--- a/app/extensions/git_store/__init__.py
+++ b/app/extensions/git_store/__init__.py
@@ -699,6 +699,7 @@ class GitStore(db.Model, HoustonModel):
 
         git_store.init_progress_preparation()
         git_store.init_progress_detection()
+        git_store.init_progress_identification()
 
         if metadata.tus_transaction_id:
             try:
@@ -755,6 +756,7 @@ class GitStore(db.Model, HoustonModel):
 
         git_store.init_progress_preparation()
         git_store.init_progress_detection()
+        git_store.init_progress_identification()
 
         added = None
         try:

--- a/app/extensions/git_store/__init__.py
+++ b/app/extensions/git_store/__init__.py
@@ -663,7 +663,11 @@ class GitStore(db.Model, HoustonModel):
         db.session.refresh(self)
 
     @classmethod
-    def create_from_metadata(cls, metadata, foreground=False, **kwargs):
+    def create_from_metadata(cls, metadata, foreground=None, **kwargs):
+
+        if foreground is None:
+            foreground = current_app.testing
+
         if metadata.owner is not None and not metadata.owner.is_anonymous:
             git_store_owner = metadata.owner
         else:
@@ -728,9 +732,12 @@ class GitStore(db.Model, HoustonModel):
         transaction_id,
         paths=[],
         submitter=None,
-        foreground=False,
+        foreground=None,
         **kwargs,
     ):
+        if foreground is None:
+            foreground = current_app.testing
+
         assert transaction_id is not None
         if owner is not None and not owner.is_anonymous:
             git_store_owner = owner
@@ -775,9 +782,12 @@ class GitStore(db.Model, HoustonModel):
         return git_store, original_filenames
 
     def import_tus_files(
-        self, transaction_id=None, paths=None, foreground=False, purge_dir=True
+        self, transaction_id=None, paths=None, foreground=None, purge_dir=True
     ):
         from app.extensions.tus import tus_filepaths_from, tus_purge
+
+        if foreground is None:
+            foreground = current_app.testing
 
         self.ensure_repository()
 
@@ -1060,54 +1070,62 @@ class GitStore(db.Model, HoustonModel):
             local_asset_filepath_list = [
                 file_data.pop('filepath', None) for file_data in files
             ]
-            # TODO: slim down this DB context
-            with db.session.begin(subtransactions=True):
-                zipped = list(zip(files, local_asset_filepath_list))
-                for index, zip_data in enumerate(zipped):
-                    assert self.exists
+            zipped = list(zip(files, local_asset_filepath_list))
+            for index, zip_data in enumerate(zipped):
+                assert self.exists
 
-                    file_data, local_asset_filepath = zip_data
+                file_data, local_asset_filepath = zip_data
 
-                    semantic_guid = file_data.get('semantic_guid', None)
-                    asset = Asset.query.filter(
-                        Asset.semantic_guid == semantic_guid
-                    ).first()
-                    if asset is None:
-                        # Check if we can recycle existing GUID from symlink
-                        recycle_guid = existing_filepath_guid_mapping.get(
-                            local_asset_filepath, None
-                        )
-                        if recycle_guid is not None:
-                            file_data['guid'] = recycle_guid
+                semantic_guid = file_data.get('semantic_guid', None)
+                asset = Asset.query.filter(Asset.semantic_guid == semantic_guid).first()
+                if asset is None:
+                    log.info(
+                        'Making new asset for semantic_guid = {!r}'.format(semantic_guid)
+                    )
 
-                        # Create record if asset is new
+                    # Check if we can recycle existing GUID from symlink
+                    recycle_guid = existing_filepath_guid_mapping.get(
+                        local_asset_filepath, None
+                    )
+                    if recycle_guid is not None:
+                        file_data['guid'] = recycle_guid
+
+                    # Create record if asset is new
+                    with db.session.begin(subtransactions=True):
                         asset = Asset(**file_data)
                         db.session.add(asset)
-                    else:
-                        # Update record if Asset exists
-                        search_keys = [
-                            'filesystem_guid',
-                            'semantic_guid',
-                            'git_store_guid',
-                        ]
+                else:
+                    log.info(
+                        'Found asset {!r} for semantic_guid = {!r}'.format(
+                            asset, semantic_guid
+                        )
+                    )
 
+                    # Update record if Asset exists
+                    search_keys = [
+                        'filesystem_guid',
+                        'semantic_guid',
+                        'git_store_guid',
+                    ]
+
+                    with db.session.begin(subtransactions=True):
                         for key in file_data:
                             if key in search_keys:
                                 continue
                             value = file_data[key]
                             setattr(asset, key, value)
                         db.session.merge(asset)
-                    assets.append(asset)
+                assets.append(asset)
 
-                    if self.progress_preparation:
-                        numerator = index
-                        denominator = len(zipped)
-                        percentage = numerator / denominator
-                        offset = 20.0
-                        domain = 60.0
-                        new_percentage = offset + (domain * percentage)
-                        new_percentage = max(offset, min(offset + domain, new_percentage))
-                        self.progress_preparation.set(new_percentage)
+                if self.progress_preparation:
+                    numerator = index
+                    denominator = len(zipped)
+                    percentage = numerator / denominator
+                    offset = 20.0
+                    domain = 60.0
+                    new_percentage = offset + (domain * percentage)
+                    new_percentage = max(offset, min(offset + domain, new_percentage))
+                    self.progress_preparation.set(new_percentage)
 
             if self.progress_preparation:
                 self.progress_preparation.set(80)
@@ -1124,7 +1142,7 @@ class GitStore(db.Model, HoustonModel):
                 asset.update_symlink(local_asset_filepath)
                 asset.set_derived_meta()
 
-                log.debug(filepath)
+                log.debug(local_asset_filepath)
                 log.debug('\tAsset         : {}'.format(asset))
                 log.debug('\tSemantic GUID : {}'.format(asset.semantic_guid))
                 log.debug('\tMIME type     : {}'.format(asset.mime_type))

--- a/app/extensions/intelligent_agent/models.py
+++ b/app/extensions/intelligent_agent/models.py
@@ -458,7 +458,7 @@ class IntelligentAgentContent(db.Model, HoustonModel):
         metadata = AssetGroupMetadata(metadata_json)
         metadata.process_request()
         metadata.owner = self.owner  # override!
-        self.asset_group, _ = AssetGroup.create_from_metadata(metadata, foreground=True)
+        self.asset_group, _ = AssetGroup.create_from_metadata(metadata)
         # this should kick off detection
         self.state = IntelligentAgentContentState.active_detection
         self.asset_group.begin_ia_pipeline(metadata)

--- a/app/extensions/intelligent_agent/models.py
+++ b/app/extensions/intelligent_agent/models.py
@@ -458,7 +458,7 @@ class IntelligentAgentContent(db.Model, HoustonModel):
         metadata = AssetGroupMetadata(metadata_json)
         metadata.process_request()
         metadata.owner = self.owner  # override!
-        self.asset_group, _ = AssetGroup.create_from_metadata(metadata)
+        self.asset_group, _ = AssetGroup.create_from_metadata(metadata, foreground=True)
         # this should kick off detection
         self.state = IntelligentAgentContentState.active_detection
         self.asset_group.begin_ia_pipeline(metadata)

--- a/app/extensions/sage/__init__.py
+++ b/app/extensions/sage/__init__.py
@@ -563,7 +563,7 @@ class SageManager(RestManager):
         log.info('Jobs (%d)' % (len(sage_jobs),))
         for job_id, status in sage_jobs:
             log.info(
-                '\t%s: %d'
+                '\t%s: %s'
                 % (
                     job_id.ljust(14),
                     status,
@@ -584,7 +584,7 @@ class SageManager(RestManager):
         log.info('Sync Jobs (%d)' % (len(sage_jobs),))
         for job_id, status in sage_jobs:
             log.info(
-                '\t%s: %d'
+                '\t%s: %s'
                 % (
                     job_id.ljust(14),
                     status,

--- a/app/extensions/sage/__init__.py
+++ b/app/extensions/sage/__init__.py
@@ -326,33 +326,34 @@ class SageManager(RestManager):
         unknown_jobs = []
         corrupt_jobs = []
         for asset_group_sighting in tqdm.tqdm(asset_group_sightings):
-            for job_id in asset_group_sighting.jobs:
-                job_metadata = asset_group_sighting.jobs[job_id]
-                job_data = (asset_group_sighting, job_id)
+            if asset_group_sighting.jobs:
+                for job_id in asset_group_sighting.jobs:
+                    job_metadata = asset_group_sighting.jobs[job_id]
+                    job_data = (asset_group_sighting, job_id)
 
-                if job_metadata.keys() < start_keys:
-                    corrupt_jobs.append(job_data)
-                elif job_metadata.get('active'):
-                    if job_id in sage_completed_job_guids:
-                        fetch_jobs.append(job_data)
-                    elif job_id in sage_failed_job_guids:
-                        failed_jobs.append(job_data)
-                    elif job_id in sage_pending_job_guids:
-                        pending_jobs.append(job_data)
-                    else:
-                        unknown_jobs.append(job_data)
-                else:
-                    if job_metadata.keys() < end_keys:
+                    if job_metadata.keys() < start_keys:
+                        corrupt_jobs.append(job_data)
+                    elif job_metadata.get('active'):
                         if job_id in sage_completed_job_guids:
                             fetch_jobs.append(job_data)
                         elif job_id in sage_failed_job_guids:
-                            corrupt_jobs.append(job_data)
+                            failed_jobs.append(job_data)
                         elif job_id in sage_pending_job_guids:
-                            corrupt_jobs.append(job_data)
+                            pending_jobs.append(job_data)
                         else:
-                            corrupt_jobs.append(job_data)
+                            unknown_jobs.append(job_data)
                     else:
-                        completed += 1
+                        if job_metadata.keys() < end_keys:
+                            if job_id in sage_completed_job_guids:
+                                fetch_jobs.append(job_data)
+                            elif job_id in sage_failed_job_guids:
+                                corrupt_jobs.append(job_data)
+                            elif job_id in sage_pending_job_guids:
+                                corrupt_jobs.append(job_data)
+                            else:
+                                corrupt_jobs.append(job_data)
+                        else:
+                            completed += 1
 
         if verbose:
             log.info('Detection Jobs')
@@ -397,33 +398,34 @@ class SageManager(RestManager):
         unknown_jobs = []
         corrupt_jobs = []
         for sighting in tqdm.tqdm(sightings):
-            for job_id in sighting.jobs:
-                job_metadata = sighting.jobs[job_id]
-                job_data = (sighting, job_id)
+            if sighting.jobs:
+                for job_id in sighting.jobs:
+                    job_metadata = sighting.jobs[job_id]
+                    job_data = (sighting, job_id)
 
-                if job_metadata.keys() < start_keys:
-                    corrupt_jobs.append(job_data)
-                elif job_metadata.get('active'):
-                    if job_id in sage_completed_job_guids:
-                        fetch_jobs.append(job_data)
-                    elif job_id in sage_failed_job_guids:
-                        failed_jobs.append(job_data)
-                    elif job_id in sage_pending_job_guids:
-                        pending_jobs.append(job_data)
-                    else:
-                        unknown_jobs.append(job_data)
-                else:
-                    if job_metadata.keys() < end_keys:
+                    if job_metadata.keys() < start_keys:
+                        corrupt_jobs.append(job_data)
+                    elif job_metadata.get('active'):
                         if job_id in sage_completed_job_guids:
                             fetch_jobs.append(job_data)
                         elif job_id in sage_failed_job_guids:
-                            corrupt_jobs.append(job_data)
+                            failed_jobs.append(job_data)
                         elif job_id in sage_pending_job_guids:
-                            corrupt_jobs.append(job_data)
+                            pending_jobs.append(job_data)
                         else:
-                            corrupt_jobs.append(job_data)
+                            unknown_jobs.append(job_data)
                     else:
-                        completed += 1
+                        if job_metadata.keys() < end_keys:
+                            if job_id in sage_completed_job_guids:
+                                fetch_jobs.append(job_data)
+                            elif job_id in sage_failed_job_guids:
+                                corrupt_jobs.append(job_data)
+                            elif job_id in sage_pending_job_guids:
+                                corrupt_jobs.append(job_data)
+                            else:
+                                corrupt_jobs.append(job_data)
+                        else:
+                            completed += 1
 
         if verbose:
             log.info('Identification Jobs')

--- a/app/extensions/sage/__init__.py
+++ b/app/extensions/sage/__init__.py
@@ -289,18 +289,20 @@ class SageManager(RestManager):
             if status not in ['completed', 'exception', 'None']
         }
 
-        self.sync_jobs_detection(
+        pending = 0
+        pending += self.sync_jobs_detection(
             sage_completed_job_guids,
             sage_failed_job_guids,
             sage_pending_job_guids,
             verbose=verbose,
         )
-        self.sync_jobs_identification(
+        pending += self.sync_jobs_identification(
             sage_completed_job_guids,
             sage_failed_job_guids,
             sage_pending_job_guids,
             verbose=verbose,
         )
+        return pending
 
     def sync_jobs_detection(
         self,
@@ -377,6 +379,8 @@ class SageManager(RestManager):
 
             asset_group_sighting.detected(job_id, response)
 
+        return len(pending_jobs) + len(fetch_jobs)
+
     def sync_jobs_identification(
         self,
         sage_completed_job_guids,
@@ -448,6 +452,8 @@ class SageManager(RestManager):
                 sighting.set_stage(SightingStage.identification)
 
             sighting.identified(job_id, response)
+
+        return len(pending_jobs) + len(fetch_jobs)
 
     def get_status(self):
         from app.modules.annotations.models import Annotation

--- a/app/extensions/sage/tasks.py
+++ b/app/extensions/sage/tasks.py
@@ -5,7 +5,8 @@ from flask import current_app
 
 from app.extensions.celery import celery
 
-SAGE_SYNC_FREQUENCY = 60 * 60
+# SAGE_SYNC_FREQUENCY = 60 * 60
+SAGE_SYNC_FREQUENCY = None
 
 
 log = logging.getLogger(__name__)

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -203,7 +203,7 @@ class Annotation(db.Model, HoustonModel, SageModel):
             'annot_species_list': [self.ia_class],
             'annot_bbox_list': [self.bounds['rect']],
             'annot_name_list': [annot_name],
-            'annot_theta_list': [self.bounds['theta']],
+            'annot_theta_list': [self.bounds.get('theta', 0)],
         }
         sage_response = current_app.sage.request_passthrough_result(
             'annotation.create', 'post', {'json': sage_request}, target='sync'

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -145,19 +145,27 @@ class Annotation(db.Model, HoustonModel, SageModel):
     ):
         from app.extensions.sage import SAGE_UNKNOWN_NAME, from_sage_uuid, to_sage_uuid
 
+        if self.asset is None:
+            log.error(
+                'Annotation {!r} has no asset, cannot send annotation to Sage'.format(
+                    self
+                )
+            )
+
+            return
         # First, ensure that the annotation's asset has been synced with Sage
         if not skip_asset:
             self.asset.sync_with_sage(
                 ensure=ensure, force=force, bulk_sage_uuids=bulk_sage_uuids, **kwargs
             )
 
-            if self.asset.content_guid is None:
-                log.error(
-                    'Asset for Annotation %r failed to send, cannot send annotation to Sage'
-                    % (self,)
-                )
-                # We tried to sync the asset's content GUID, but that failed... it is likely that the asset's file is missing
-                return
+        if self.asset.content_guid is None:
+            log.error(
+                'Asset for Annotation %r failed to send, cannot send annotation to Sage'
+                % (self,)
+            )
+            # We tried to sync the asset's content GUID, but that failed... it is likely that the asset's file is missing
+            return
 
         if force:
             with db.session.begin(subtransactions=True):

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -236,7 +236,7 @@ class Annotation(db.Model, HoustonModel, SageModel):
     def init_progress_identification(self, parent=None, overwrite=False):
         from app.modules.progress.models import Progress
 
-        if self.progress_identification is not None:
+        if self.progress_identification:
             if not overwrite:
                 log.warning(
                     'Annotation %r already has a progress identification %r'

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -153,6 +153,7 @@ class Annotation(db.Model, HoustonModel, SageModel):
             )
 
             return
+
         # First, ensure that the annotation's asset has been synced with Sage
         if not skip_asset:
             self.asset.sync_with_sage(
@@ -205,6 +206,15 @@ class Annotation(db.Model, HoustonModel, SageModel):
             annot_name = str(self.encounter.individual.guid)
         else:
             annot_name = SAGE_UNKNOWN_NAME
+
+        try:
+            self.validate_bounds(self.bounds)
+        except Exception:
+            log.error(
+                'Annotation %r failed to pass validate_bounds(), cannot send annotation to Sage'
+                % (self,)
+            )
+            return
 
         sage_request = {
             'image_uuid_list': [to_sage_uuid(self.asset.content_guid)],

--- a/app/modules/app_ui.py
+++ b/app/modules/app_ui.py
@@ -78,7 +78,7 @@ def admin_required(func):
     @wraps(func)
     def decorated_function(*args, **kwargs):
         if not current_user and not current_user.is_admin:
-            return redirect(url_for('backend.user_login'))
+            return redirect(url_for('frontend.user_login'))
         return func(*args, **kwargs)
 
     return decorated_function
@@ -104,6 +104,7 @@ def home(*args, **kwargs):
 
 
 @backend_blueprint.route('/login', methods=['POST'])
+@frontend_blueprint.route('/login', methods=['POST'])
 @ensure_admin_exists
 def user_login(email=None, password=None, remember=None, refer=None, *args, **kwargs):
     # pylint: disable=unused-argument
@@ -125,7 +126,7 @@ def user_login(email=None, password=None, remember=None, refer=None, *args, **kw
             log.error('User gave insecure next URL: {!r}'.format(refer))
             refer = None
 
-    failure_refer = 'backend.home'
+    failure_refer = 'frontend.home'
 
     user = User.find(email=email, password=password)
 
@@ -196,7 +197,7 @@ def user_logout(refer=None, *args, **kwargs):
     flash('You were successfully logged out.', 'warning')
 
     if refer is None:
-        redirect = url_for('backend.home')
+        redirect = url_for('frontend.home')
     else:
         redirect = refer
 
@@ -204,6 +205,7 @@ def user_logout(refer=None, *args, **kwargs):
 
 
 @backend_blueprint.route('/admin_init', methods=['GET'])
+@frontend_blueprint.route('/admin_init', methods=['GET'])
 def admin_init(*args, **kwargs):
     """
     This endpoint is for initial admin user creation
@@ -242,7 +244,7 @@ def create_admin_user(email=None, password=None, repeat_password=None, *args, **
                 if admin.is_admin:
                     message = 'Success creating startup admin user.'
                     # update configuration value for admin user created
-                    return flask.redirect(url_for('backend.home'))
+                    return flask.redirect(url_for('frontend.home'))
                 else:
                     message = 'We failed to create or update the user as an admin.'
             else:

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -155,7 +155,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
         if self.stage != AssetGroupSightingStage.preparation:
             return
 
-        self.init_progress_detection(overwrite=True)
+        self.init_progress_detection()
 
         # Allow sightings to have no Assets, they go straight to curation
         if (
@@ -1205,6 +1205,8 @@ class AssetGroupSighting(db.Model, HoustonModel):
         if foreground is None:
             foreground = current_app.testing
 
+        self.init_progress_detection(overwrite=True)
+
         log.info('Rerunning Sage detection')
 
         if self.stage == AssetGroupSightingStage.curation:
@@ -1306,7 +1308,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
         assert len(self.detection_configs) > 0
         assert self.stage == AssetGroupSightingStage.detection
 
-        self.init_progress_detection(overwrite=True)
+        self.init_progress_detection()
 
         if self.progress_detection:
             # Set the status to healthy and 0%

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -155,7 +155,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
         if self.stage != AssetGroupSightingStage.preparation:
             return
 
-        self.init_progress_detection()
+        self.init_progress_detection(overwrite=True)
 
         if self.progress_detection:
             # Set the status to healthy and 0%
@@ -974,8 +974,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
                     'start': datetime.datetime.utcnow().isoformat(),
                     'asset_guids': asset_guids,
                 }
-                # This is necessary because we can only mark self as modified if
-                # we assign to one of the database attributes
+
                 if self.progress_detection:
                     self.progress_detection.set(5)
 
@@ -1206,6 +1205,8 @@ class AssetGroupSighting(db.Model, HoustonModel):
             self.set_stage(AssetGroupSightingStage.curation)
             return
 
+        log.info('Rerunning Sage detection')
+
         if foreground is None:
             foreground = current_app.testing
 
@@ -1214,8 +1215,6 @@ class AssetGroupSighting(db.Model, HoustonModel):
         if self.progress_detection:
             # Set the status to healthy and 0%
             self.progress_detection = self.progress_detection.config()
-
-        log.info('Rerunning Sage detection')
 
         if self.stage == AssetGroupSightingStage.curation:
             self.set_stage(AssetGroupSightingStage.detection)

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -983,7 +983,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
 
                     self.jobs = self.jobs
                     log.info(
-                        f'Started Detection job, on AssetGroupSighting {self.guid}, self.jobs= {self.jobs}'
+                        f'Started Detection job, on AssetGroupSighting {self.guid}, self.jobs={self.jobs}'
                     )
                     self.detection_attempts += 1
                     db.session.merge(self)

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -117,8 +117,6 @@ class AssetGroupSighting(db.Model, HoustonModel):
 
         self.set_stage(AssetGroupSightingStage.preparation)
 
-        self.init_progress_detection(overwrite=True)
-
         if not self.asset_group.progress_preparation:
             self.post_preparation_hook()
         elif self.asset_group.progress_preparation.complete:
@@ -156,6 +154,8 @@ class AssetGroupSighting(db.Model, HoustonModel):
     def post_preparation_hook(self):
         if self.stage != AssetGroupSightingStage.preparation:
             return
+
+        self.init_progress_detection(overwrite=True)
 
         # Allow sightings to have no Assets, they go straight to curation
         if (
@@ -1228,7 +1228,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
     def init_progress_detection(self, overwrite=False):
         from app.modules.progress.models import Progress
 
-        if self.progress_detection is not None:
+        if self.progress_detection:
             if not overwrite:
                 log.warning(
                     'Asset Group Sighting %r already has a progress detection %r'
@@ -1264,7 +1264,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
     def init_progress_identification(self, overwrite=False):
         from app.modules.progress.models import Progress
 
-        if self.progress_identification is not None:
+        if self.progress_identification:
             if not overwrite:
                 log.warning(
                     'Asset Group Sighting %r already has a progress identification %r'

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -157,6 +157,10 @@ class AssetGroupSighting(db.Model, HoustonModel):
 
         self.init_progress_detection()
 
+        if self.progress_detection:
+            # Set the status to healthy and 0%
+            self.progress_detection = self.progress_detection.config()
+
         # Allow sightings to have no Assets, they go straight to curation
         if (
             'assetReferences' not in self.sighting_config
@@ -1207,6 +1211,10 @@ class AssetGroupSighting(db.Model, HoustonModel):
 
         self.init_progress_detection(overwrite=True)
 
+        if self.progress_detection:
+            # Set the status to healthy and 0%
+            self.progress_detection = self.progress_detection.config()
+
         log.info('Rerunning Sage detection')
 
         if self.stage == AssetGroupSightingStage.curation:
@@ -1307,12 +1315,6 @@ class AssetGroupSighting(db.Model, HoustonModel):
 
         assert len(self.detection_configs) > 0
         assert self.stage == AssetGroupSightingStage.detection
-
-        self.init_progress_detection()
-
-        if self.progress_detection:
-            # Set the status to healthy and 0%
-            self.progress_detection = self.progress_detection.config()
 
         # Temporary restriction for MVP
         assert len(self.detection_configs) == 1

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -115,7 +115,7 @@ class AssetGroups(Resource):
             )
 
         try:
-            asset_group, _ = AssetGroup.create_from_metadata(metadata, foreground=True)
+            asset_group, _ = AssetGroup.create_from_metadata(metadata)
         except HoustonException as ex:
             log.warning(
                 f'AssetGroup creation for transaction_id={metadata.tus_transaction_id} failed'
@@ -830,6 +830,6 @@ class AssetGroupTusCollect(Resource):
             # We have checked the asset_group manager and cannot find this asset_group, raise 404 manually
             raise werkzeug.exceptions.NotFound
 
-        asset_group.import_tus_files(foreground=True)
+        asset_group.import_tus_files()
 
         return asset_group

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -115,7 +115,8 @@ class AssetGroups(Resource):
             )
 
         try:
-            asset_group, _ = AssetGroup.create_from_metadata(metadata)
+            asset_group, _ = AssetGroup.create_from_metadata(metadata, foreground=True)
+            # TODO (HARDENING): Remove the above `foreground=True`
         except HoustonException as ex:
             log.warning(
                 f'AssetGroup creation for transaction_id={metadata.tus_transaction_id} failed'
@@ -832,6 +833,7 @@ class AssetGroupTusCollect(Resource):
             # We have checked the asset_group manager and cannot find this asset_group, raise 404 manually
             raise werkzeug.exceptions.NotFound
 
-        asset_group.import_tus_files()
+        asset_group.import_tus_files(foreground=True)
+        # TODO (HARDENING): Remove the above `foreground=True`
 
         return asset_group

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -116,7 +116,6 @@ class AssetGroups(Resource):
 
         try:
             asset_group, _ = AssetGroup.create_from_metadata(metadata, foreground=True)
-            # TODO (HARDENING): Remove the above `foreground=True`
         except HoustonException as ex:
             log.warning(
                 f'AssetGroup creation for transaction_id={metadata.tus_transaction_id} failed'
@@ -834,6 +833,5 @@ class AssetGroupTusCollect(Resource):
             raise werkzeug.exceptions.NotFound
 
         asset_group.import_tus_files(foreground=True)
-        # TODO (HARDENING): Remove the above `foreground=True`
 
         return asset_group

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -115,7 +115,7 @@ class AssetGroups(Resource):
             )
 
         try:
-            asset_group, _ = AssetGroup.create_from_metadata(metadata, foreground=True)
+            asset_group, _ = AssetGroup.create_from_metadata(metadata)
         except HoustonException as ex:
             log.warning(
                 f'AssetGroup creation for transaction_id={metadata.tus_transaction_id} failed'
@@ -832,6 +832,6 @@ class AssetGroupTusCollect(Resource):
             # We have checked the asset_group manager and cannot find this asset_group, raise 404 manually
             raise werkzeug.exceptions.NotFound
 
-        asset_group.import_tus_files(foreground=True)
+        asset_group.import_tus_files()
 
         return asset_group

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -150,6 +150,8 @@ class AssetGroups(Resource):
             abort(400, f'Asset preparation failed {message}')
             raise
 
+        db.session.refresh(asset_group)
+
         return asset_group
 
 

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -62,17 +62,17 @@ class DetailedAssetGroupSchema(DetailedGitStoreSchema):
     )
 
     progress_preparation = base_fields.Nested(
-        'BaseProgressSchema',
+        'DetailedProgressSchema',
         many=False,
     )
 
     progress_detection = base_fields.Nested(
-        'BaseProgressSchema',
+        'DetailedProgressSchema',
         many=False,
     )
 
     progress_identification = base_fields.Nested(
-        'BaseProgressSchema',
+        'DetailedProgressSchema',
         many=False,
     )
 
@@ -152,17 +152,17 @@ class DetailedAssetGroupSightingSchema(BaseAssetGroupSightingSchema):
     jobs = base_fields.Function(AssetGroupSighting.get_detailed_jobs_json)
 
     progress_preparation = base_fields.Nested(
-        'BaseProgressSchema',
+        'DetailedProgressSchema',
         many=False,
     )
 
     progress_detection = base_fields.Nested(
-        'BaseProgressSchema',
+        'DetailedProgressSchema',
         many=False,
     )
 
     progress_identification = base_fields.Nested(
-        'BaseProgressSchema',
+        'DetailedProgressSchema',
         many=False,
     )
 
@@ -288,17 +288,17 @@ class AssetGroupSightingAsSightingSchema(ModelSchema):
     hasEdit = base_fields.Boolean(default=True)
 
     progress_preparation = base_fields.Nested(
-        'BaseProgressSchema',
+        'DetailedProgressSchema',
         many=False,
     )
 
     progress_detection = base_fields.Nested(
-        'BaseProgressSchema',
+        'DetailedProgressSchema',
         many=False,
     )
 
     progress_identification = base_fields.Nested(
-        'BaseProgressSchema',
+        'DetailedProgressSchema',
         many=False,
     )
 

--- a/app/modules/job_control/tasks.py
+++ b/app/modules/job_control/tasks.py
@@ -5,8 +5,7 @@ from app.extensions.celery import celery
 
 log = logging.getLogger(__name__)
 
-# JOB_CONTROL_CHECK_FREQUENCY = 120
-JOB_CONTROL_CHECK_FREQUENCY = None
+JOB_CONTROL_CHECK_FREQUENCY = 120
 
 
 @celery.on_after_configure.connect

--- a/app/modules/job_control/tasks.py
+++ b/app/modules/job_control/tasks.py
@@ -5,10 +5,18 @@ from app.extensions.celery import celery
 
 log = logging.getLogger(__name__)
 
+# JOB_CONTROL_CHECK_FREQUENCY = 120
+JOB_CONTROL_CHECK_FREQUENCY = None
+
 
 @celery.on_after_configure.connect
-def setup_periodic_tasks(sender, **kwargs):
-    sender.add_periodic_task(120.0, check_jobs.s(), name='Job Control Checking')
+def job_control_task_setup_periodic_tasks(sender, **kwargs):
+    if JOB_CONTROL_CHECK_FREQUENCY is not None:
+        sender.add_periodic_task(
+            JOB_CONTROL_CHECK_FREQUENCY,
+            check_jobs.s(),
+            name='Job Control Checking',
+        )
 
 
 @celery.task

--- a/app/modules/progress/models.py
+++ b/app/modules/progress/models.py
@@ -153,7 +153,7 @@ class Progress(db.Model, Timestamp):
         if self.celery_guid is None and self.sage_guid is None:
             return None
 
-        if self.celery_guid is not None:
+        if self.celery_guid:
             if BROKER is None:
                 BROKER = redis.Redis(
                     host=current_app.config['REDIS_HOST'],
@@ -174,7 +174,7 @@ class Progress(db.Model, Timestamp):
                     message = BROKER.lindex(DEFAULT_CELERY_QUEUE_NAME, index)
                     data = json.loads(message)
                     celery_guid = data.get('headers', {}).get('id', None)
-                    if celery_guid is not None:
+                    if celery_guid:
                         celery_guid = uuid.UUID(celery_guid)
                         if celery_guid == self.celery_guid:
                             ahead = total - 1 - index
@@ -183,7 +183,7 @@ class Progress(db.Model, Timestamp):
                 except Exception:
                     pass
 
-        if self.sage_guid is not None:
+        if self.sage_guid:
             jobs = current_app.sage.request_passthrough_result(
                 'engine.list', 'get', target='default'
             )['json_result']
@@ -221,7 +221,7 @@ class Progress(db.Model, Timestamp):
 
     def __iter__(self):
         assert (
-            self.items is not None and self.pgeta is not None
+            self.items and self.pgeta
         ), 'Items is not configured, use obj = obj.config(items) to setup'
         self.pgeta.numerator = 0
         self.set(0, force=True)
@@ -317,7 +317,7 @@ class Progress(db.Model, Timestamp):
 
         if self.items is None or self.pgeta is None:
             self.config(items)
-        elif steps is not None and self.pgeta.denominator != steps:
+        elif steps and self.pgeta.denominator != steps:
             self.config(items)
 
         step = Progress.query.get(step_guid)

--- a/app/modules/progress/models.py
+++ b/app/modules/progress/models.py
@@ -129,6 +129,10 @@ class Progress(db.Model, Timestamp):
         )
 
     @property
+    def completed(self):
+        return self.complete
+
+    @property
     def failed(self):
         return self.status in [ProgressStatus.failed]
 
@@ -187,9 +191,7 @@ class Progress(db.Model, Timestamp):
             jobs = current_app.sage.request_passthrough_result(
                 'engine.list', 'get', target='default'
             )['json_result']
-            statuses, sage_jobs = current_app.sage.get_job_status(
-                jobs, exclude_done=False
-            )
+            statuses, sage_jobs = current_app.sage.get_job_status(jobs, exclude_done=True)
 
             total = len(sage_jobs)
             for index, sage_job in enumerate(sage_jobs):

--- a/app/modules/progress/schemas.py
+++ b/app/modules/progress/schemas.py
@@ -4,8 +4,6 @@ Serialization schemas for Progress resources RESTful API
 ----------------------------------------------------
 """
 
-from flask_marshmallow import base_fields
-
 from flask_restx_patched import ModelSchema
 
 from .models import Progress
@@ -28,9 +26,6 @@ class DetailedProgressSchema(BaseProgressSchema):
     Detailed Progress schema exposes all useful fields.
     """
 
-    parent = base_fields.Nested('DetailedProgressSchema', many=False)
-    steps = base_fields.Nested('DetailedProgressSchema', many=True)
-
     class Meta(BaseProgressSchema.Meta):
         fields = BaseProgressSchema.Meta.fields + (
             Progress.description.key,
@@ -45,8 +40,7 @@ class DetailedProgressSchema(BaseProgressSchema):
             'idle',
             'inactive',
             'ahead',
-            'parent',
-            'steps',
+            Progress.parent_guid.key,
             Progress.celery_guid.key,
             Progress.sage_guid.key,
             Progress.eta.key,

--- a/app/modules/progress/schemas.py
+++ b/app/modules/progress/schemas.py
@@ -4,6 +4,8 @@ Serialization schemas for Progress resources RESTful API
 ----------------------------------------------------
 """
 
+from flask_marshmallow import base_fields
+
 from flask_restx_patched import ModelSchema
 
 from .models import Progress
@@ -26,15 +28,27 @@ class DetailedProgressSchema(BaseProgressSchema):
     Detailed Progress schema exposes all useful fields.
     """
 
+    parent = base_fields.Nested('DetailedProgressSchema', many=False)
+    steps = base_fields.Nested('DetailedProgressSchema', many=True)
+
     class Meta(BaseProgressSchema.Meta):
         fields = BaseProgressSchema.Meta.fields + (
             Progress.description.key,
             Progress.percentage.key,
             Progress.status.key,
             Progress.message.key,
+            'skipped',
+            'cancelled',
+            'failed',
             'complete',
+            'active',
+            'idle',
+            'inactive',
             'ahead',
-            Progress.parent_guid.key,
+            'parent',
+            'steps',
+            Progress.celery_guid.key,
+            Progress.sage_guid.key,
             Progress.eta.key,
             Progress.created.key,
             Progress.updated.key,

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -242,7 +242,7 @@ class Sighting(db.Model, FeatherModel):
     def init_progress_identification(self, overwrite=False):
         from app.modules.progress.models import Progress
 
-        if self.progress_identification is not None:
+        if self.progress_identification:
             if not overwrite:
                 log.warning(
                     'Sighting %r already has a progress identification %r'
@@ -1483,12 +1483,12 @@ class Sighting(db.Model, FeatherModel):
                     log, f'annotation {annot_guid} for {job_id_str} not found'
                 )
 
-            if annotation.progress_identification is not None:
+            if annotation.progress_identification:
                 annotation.progress_identification.set(90)
 
             status, result = self._parse_id_response(job_id_str, data)
 
-            if annotation.progress_identification is not None:
+            if annotation.progress_identification:
                 annotation.progress_identification.set(91)
 
             description = ''
@@ -1504,7 +1504,7 @@ class Sighting(db.Model, FeatherModel):
             except KeyError:
                 log.warning(f'{debug_context} failed to find {algorithm},')
 
-            if annotation.progress_identification is not None:
+            if annotation.progress_identification:
                 annotation.progress_identification.set(92)
 
             log.info(
@@ -1528,16 +1528,16 @@ class Sighting(db.Model, FeatherModel):
                 self.jobs = self.jobs
                 db.session.merge(self)
 
-            if annotation.progress_identification is not None:
+            if annotation.progress_identification:
                 annotation.progress_identification.set(95)
 
             # Ensure that the ID result is readable
             self.get_id_result()
 
-            if annotation is not None and annotation.progress_identification is not None:
+            if annotation and annotation.progress_identification:
                 annotation.progress_identification.set(100)
         except Exception as ex:
-            if annotation is not None and annotation.progress_identification is not None:
+            if annotation and annotation.progress_identification:
                 annotation.progress_identification.fail(str(ex))
             raise
 

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -317,7 +317,6 @@ class Sightings(Resource):
                     owner,
                     transaction_id,
                     paths=all_arefs[transaction_id],
-                    foreground=True,
                 )
             except Exception as ex:
                 cleanup.asset_group = asset_group

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -317,6 +317,7 @@ class Sightings(Resource):
                     owner,
                     transaction_id,
                     paths=all_arefs[transaction_id],
+                    foreground=True,
                 )
             except Exception as ex:
                 cleanup.asset_group = asset_group

--- a/app/modules/sightings/schemas.py
+++ b/app/modules/sightings/schemas.py
@@ -113,7 +113,7 @@ class TimedSightingSchema(CreateSightingSchema):
     review_time = base_fields.Function(Sighting.get_review_time)
 
     progress_identification = base_fields.Nested(
-        'BaseProgressSchema',
+        'DetailedProgressSchema',
         many=False,
     )
 

--- a/migrations/versions/1cdb69cbdcaa_.py
+++ b/migrations/versions/1cdb69cbdcaa_.py
@@ -9,8 +9,6 @@ Create Date: 2022-05-30 19:25:21.207058
 import sqlalchemy as sa
 from alembic import op
 
-import app
-
 # revision identifiers, used by Alembic.
 revision = '1cdb69cbdcaa'
 down_revision = 'afedda6596b9'

--- a/tasks/codex/asset_groups.py
+++ b/tasks/codex/asset_groups.py
@@ -64,7 +64,9 @@ def create_asset_group_from_path(
     asset_group.git_copy_path(absolute_path)
 
     hostname = socket.gethostname()
-    asset_group.git_commit('Initial commit via CLI on host {!r}'.format(hostname))
+    asset_group.git_commit(
+        'Initial commit via CLI on host {!r}'.format(hostname), update=True, commit=True
+    )
 
     git_push(str(asset_group.guid))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -566,6 +566,7 @@ def ensure_asset_group_repo(flask_app, db, asset_group, file_data=[]):
 
     asset_group.ensure_repository()
     # Call ensure_remote without .delay in tests to do it in the foreground
+
     try:
         ensure_remote(str(asset_group.guid), additional_tags=['type:pytest-required'])
     except GitlabInitializationError:

--- a/tests/modules/asset_groups/test_models.py
+++ b/tests/modules/asset_groups/test_models.py
@@ -30,7 +30,6 @@ def test_asset_group_sightings_jobs(flask_app, db, admin_user, test_root, reques
         admin_user,
         transaction_id,
         paths=[input_filename],
-        foreground=True,
     )
     asset_group.config['speciesDetectionModel'] = test_utils.dummy_detection_info()
     # Make sure config changes are saved

--- a/tests/modules/asset_groups/test_tus_creation.py
+++ b/tests/modules/asset_groups/test_tus_creation.py
@@ -37,9 +37,7 @@ def test_create_asset_group_from_tus(flask_app, db, researcher_1, test_root):
 
     # test with explicit paths (should succeed)
     tid, valid_file = tus_utils.prep_tus_dir(test_root)
-    sub, _ = AssetGroup.create_from_tus(
-        'PYTEST', researcher_1, tid, paths=[valid_file], foreground=True
-    )
+    sub, _ = AssetGroup.create_from_tus('PYTEST', researcher_1, tid, paths=[valid_file])
     assert len(sub.assets) == 1
     assert sub.assets[0].path == valid_file
     if os.path.exists(sub.get_absolute_path()):
@@ -48,7 +46,7 @@ def test_create_asset_group_from_tus(flask_app, db, researcher_1, test_root):
 
     # test with no paths (should succeed same as above)
     tid, valid_file = tus_utils.prep_tus_dir(test_root)
-    sub, _ = AssetGroup.create_from_tus('PYTEST', researcher_1, tid, foreground=True)
+    sub, _ = AssetGroup.create_from_tus('PYTEST', researcher_1, tid)
     assert len(sub.assets) == 1
     assert sub.assets[0].path == valid_file
     if os.path.exists(sub.get_absolute_path()):

--- a/tests/modules/assets/test_models.py
+++ b/tests/modules/assets/test_models.py
@@ -36,7 +36,7 @@ def set_up_assets(flask_app, db, test_root, admin_user, request):
     with mock.patch('app.modules.asset_groups.metadata.current_user', new=admin_user):
         metadata.process_request()
     assert metadata.owner == admin_user
-    asset_group, _ = AssetGroup.create_from_metadata(metadata, foreground=True)
+    asset_group, _ = AssetGroup.create_from_metadata(metadata)
 
     cleanup(request, lambda: db.session.delete(asset_group))
 

--- a/tests/modules/job_control/test_models.py
+++ b/tests/modules/job_control/test_models.py
@@ -31,7 +31,6 @@ def test_job_control(flask_app, researcher_1, test_root, db):
             researcher_1,
             transaction_id,
             paths=[input_filename],
-            foreground=True,
         )
 
         with db.session.begin():

--- a/tests/modules/missions/resources/test_modify_collection.py
+++ b/tests/modules/missions/resources/test_modify_collection.py
@@ -51,7 +51,6 @@ def test_create_patch_mission_collection(
             tid,
             mission=temp_mission,
             paths={valid_file},
-            foreground=True,
         )
         assert len(temp_mission_collection.assets) == 1
         assert temp_mission_collection.assets[0].path == valid_file

--- a/tests/modules/missions/test_collection_tus_creation.py
+++ b/tests/modules/missions/test_collection_tus_creation.py
@@ -51,7 +51,6 @@ def test_create_mission_collection_from_tus(flask_app, db, data_manager_1, test_
         tid,
         mission=temp_mission,
         paths={valid_file},
-        foreground=True,
     )
     assert len(sub.assets) == 1
     assert sub.assets[0].path == valid_file
@@ -62,7 +61,7 @@ def test_create_mission_collection_from_tus(flask_app, db, data_manager_1, test_
     # test with no paths (should succeed same as above)
     tid, valid_file = tus_utils.prep_tus_dir(test_root)
     sub, _ = MissionCollection.create_from_tus(
-        'PYTEST', data_manager_1, tid, mission=temp_mission, foreground=True
+        'PYTEST', data_manager_1, tid, mission=temp_mission
     )
     assert len(sub.assets) == 1
     assert sub.assets[0].path == valid_file

--- a/tests/tasks/app/test_asset_groups.py
+++ b/tests/tasks/app/test_asset_groups.py
@@ -55,7 +55,14 @@ def test_create_asset_group_from_path(flask_app, test_root, admin_user, request)
     request.addfinalizer(asset_group.delete)
 
     assert asset_group.owner == admin_user
-    dir_files = sorted(f.name for f in pathlib.Path(test_root).glob('*'))
+    duplicate_paths = [
+        'zebra-named-Sigurður.jpg',
+        'zebra.jpg',
+        'zebra2.jpg',
+    ]
+    dir_files = sorted(
+        f.name for f in pathlib.Path(test_root).glob('*') if f.name not in duplicate_paths
+    )
     asset_paths = sorted(a.path for a in asset_group.assets)
     assert dir_files == asset_paths
     assert asset_group.description == 'AssetGroup creation test'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -747,12 +747,15 @@ def wait_for_progress(flask_app, progress_guids=None):
     while True:
         try:
             # Fetch the detection results from Sage
-            flask_app.sage.sync_jobs()
+            pending = flask_app.sage.sync_jobs()
+            if pending == 0:
+                break
 
             for progress_guid in progress_guids:
                 progress = Progress.query.get(progress_guid)
-                assert not progress.active
-                assert progress.complete
+                if progress:
+                    assert not progress.active
+                    assert progress.complete
 
             break
         except AssertionError:


### PR DESCRIPTION
Some fix-ups from the Tus, Detection, and ID hardening PRs that have been merged

---

* Remove the hardening hack where preparation is performed in the foreground
* Fix bugs in Sage status display calculation
* Disable hourly Sage sync with Celery (for now)
* Add better sync failure recovery and messaging for Annotations: missing or incorrect annotation bounds
* Add better sync failure recovery and messaging for Assets: file failure to load or send to Sage (e.g., not an image file)
* Add progress tracking percentages for detection in `AssetGroupSighting`
* Add progress tracking percentages for identification in `Sighting`
* Add progress skip messages for identification in `Sighting`
* Move `detection_attempts` back to the relevant section after the Sage request is completed
* Upgrade `BaseProgressSchema` to `DetailedProgressSchema` in `AssetGroupSighting` and `Sighting` schemas, also add more attributes to the Progress schema
* Add the ability to disable `JobControl` task by setting `JOB_CONTROL_CHECK_FREQUENCY=None`