### PR TITLE
DEX-1096: pipeline_status bugfixes

### DIFF
--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -585,13 +585,10 @@ class Sighting(db.Model, FeatherModel):
             'progress': None,
         }
 
-        if self.asset_group_sighting:
-            status['idConfigs'] = self.asset_group_sighting.get_id_configs()
-            if status['idConfigs']:
-                # TODO not entirely true... i think.  as this can be passed via api (single annot)
-                status['matchingSetQueryPassed'] = status['idConfigs'][0].get(
-                    'matching_set'
-                )
+        status['idConfigs'] = self.get_id_configs()
+        if status['idConfigs']:
+            # TODO not entirely true... i think.  as this can be passed via api (single annot)
+            status['matchingSetQueryPassed'] = status['idConfigs'][0].get('matching_set')
 
         if not self.is_migrated_data():
             # seems irrelevant for migrated

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -650,7 +650,9 @@ class Sighting(db.Model, FeatherModel):
                 # we sh/could toggle active if this shows failure
                 ss = None
                 try:
-                    ss = self.get_sage_job_status(job_id)
+                    # disabling for now as we are going to start using Progress soon
+                    # ss = self.get_sage_job_status(job_id)
+                    pass
                 except Exception as ex:
                     status[f'_debug_{job_id}'] = 'failed getting sage job status'
                     job_info['_get_sage_status_exception'] = str(ex)

--- a/app/utils.py
+++ b/app/utils.py
@@ -122,10 +122,16 @@ def normalized_timezone_string(dt):
 
 # converts string like 'Wed, 25 May 2022 00:16:42 GMT' which is what datetime is stringified as
 def datetime_string_to_isoformat(dts):
+    import re
     from datetime import datetime
 
     if not isinstance(dts, str):
         return None
+
+    # if are already in isoformat, just return
+    if re.match(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}', dts):
+        return dts
+
     try:
         d = datetime.strptime(dts, '%a, %d %b %Y %H:%M:%S %Z')
     except ValueError as err:

--- a/tests/modules/annotations/test_basic.py
+++ b/tests/modules/annotations/test_basic.py
@@ -63,6 +63,10 @@ def test_misc():
     res = datetime_string_to_isoformat(None)
     assert not res
 
+    thru = '2000-01-02T03:04:05Z'
+    res = datetime_string_to_isoformat(thru)
+    assert res == thru
+
     res = datetime_string_to_isoformat('Wed, 25 May 2022 00:16:42 GMT')
     assert res == '2022-05-25T00:16:42Z'
 


### PR DESCRIPTION
## Pull Request Overview

- datetime format fixer was failing when datetime format was _already correct_
- disabling sage-job-status-checker in `pipeline_status` since it had a bug and will be replaced with Progress soon
- use Sighting `id_configs`, not AGS