### PR TITLE
1088 curation status

### DIFF
--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -575,7 +575,7 @@ class Sighting(db.Model, FeatherModel):
                 status['skipped'] = True
 
             # The curation stage starts when manual annotation OR detection adds the first annotation to the asset group sighting.
-            annotations = self.get_all_annotations()
+            annotations = self.get_annotations()
             if annotations and len(annotations) > 1:
                 times = [ann.created for ann in annotations]
                 first_time = min(times)

--- a/tests/modules/asset_groups/test_models.py
+++ b/tests/modules/asset_groups/test_models.py
@@ -8,8 +8,6 @@ import tests.utils as test_utils
 from app.utils import HoustonException
 from tests.utils import extension_unavailable, module_unavailable
 
-import dateutil
-
 
 @pytest.mark.skipif(
     module_unavailable('asset_groups'), reason='AssetGroups module disabled'
@@ -97,15 +95,16 @@ def test_asset_group_sightings_jobs(flask_app, db, admin_user, test_root, reques
     assert not ps['detection']['inProgress']
     assert not ps['detection']['failed']
 
-    # As long as it's an AGS (and not committed to sighting)
-    # curation is ongoing
-    assert ps['curation']
-    assert ps['curation']['inProgress']
-    assert not ps['curation']['complete']
-    assert not ps['curation']['skipped']
-    assert ps['curation']['progress'] == 0.5
-    curation_start = dateutil.parser.parse(ps['curation']['start'])
-    assert curation_start
+    curation_progress = {
+        'skipped': False,
+        'start': ags1.get_curation_start_time(),
+        'end': None,
+        'inProgress': True,
+        'complete': False,
+        'failed': False,
+        'progress': 0.5,
+    }
+    assert ps['curation'] == curation_progress
 
     ags1.jobs = None
     ags1.detection_attempts = ps['detection']['numAttemptsMax'] + 9

--- a/tests/modules/sightings/test_models.py
+++ b/tests/modules/sightings/test_models.py
@@ -5,14 +5,13 @@ import logging
 import pytest
 
 import tests.utils as test_utils
+from app.modules.sightings.models import Sighting, SightingStage
 from app.modules.users.models import User
 from tests.utils import module_unavailable
 
 
 @pytest.mark.skipif(module_unavailable('sightings'), reason='Sightings module disabled')
 def test_sighting_create_and_add_encounters(db):
-
-    from app.modules.sightings.models import Sighting, SightingStage
 
     test_sighting = Sighting(stage=SightingStage.processed)
     test_sighting.time = test_utils.complex_date_time_now()
@@ -59,9 +58,31 @@ def test_sighting_create_and_add_encounters(db):
 
 
 @pytest.mark.skipif(module_unavailable('sightings'), reason='Sightings module disabled')
-def test_sighting_ensure_no_duplicate_encounters(db):
-    from app.modules.sightings.models import Sighting, SightingStage
+def test_basic_pipeline_status(db):
+    sighting = Sighting(stage=SightingStage.processed)
+    sighting.time = test_utils.complex_date_time_now()
 
+    with db.session.begin():
+        db.session.add(sighting)
+
+    pipeline_status = sighting.get_pipeline_status()
+
+    curation_status = {
+        '_note': 'migrated sighting; curation status fabricated',
+        'skipped': True,
+        'start': sighting.created.isoformat() + 'Z',
+        'end': sighting.created.isoformat() + 'Z',
+        'inProgress': False,
+        'complete': True,
+        'failed': False,
+        'progress': 1.0,
+    }
+    assert pipeline_status['curation'] == curation_status
+    sighting.delete()
+
+
+@pytest.mark.skipif(module_unavailable('sightings'), reason='Sightings module disabled')
+def test_sighting_ensure_no_duplicate_encounters(db):
     test_sighting = Sighting(stage=SightingStage.processed)
     test_sighting.time = test_utils.complex_date_time_now()
     owner = User.get_public_user()

--- a/tests/modules/sightings/test_models.py
+++ b/tests/modules/sightings/test_models.py
@@ -5,13 +5,13 @@ import logging
 import pytest
 
 import tests.utils as test_utils
-from app.modules.sightings.models import Sighting, SightingStage
 from app.modules.users.models import User
 from tests.utils import module_unavailable
 
 
 @pytest.mark.skipif(module_unavailable('sightings'), reason='Sightings module disabled')
 def test_sighting_create_and_add_encounters(db):
+    from app.modules.sightings.models import Sighting, SightingStage
 
     test_sighting = Sighting(stage=SightingStage.processed)
     test_sighting.time = test_utils.complex_date_time_now()
@@ -59,6 +59,8 @@ def test_sighting_create_and_add_encounters(db):
 
 @pytest.mark.skipif(module_unavailable('sightings'), reason='Sightings module disabled')
 def test_basic_pipeline_status(db):
+    from app.modules.sightings.models import Sighting, SightingStage
+
     sighting = Sighting(stage=SightingStage.processed)
     sighting.time = test_utils.complex_date_time_now()
 
@@ -83,6 +85,8 @@ def test_basic_pipeline_status(db):
 
 @pytest.mark.skipif(module_unavailable('sightings'), reason='Sightings module disabled')
 def test_sighting_ensure_no_duplicate_encounters(db):
+    from app.modules.sightings.models import Sighting, SightingStage
+
     test_sighting = Sighting(stage=SightingStage.processed)
     test_sighting.time = test_utils.complex_date_time_now()
     owner = User.get_public_user()


### PR DESCRIPTION
Adds a curation top-level object to AGS and sighting pipeline_status. Curation is the stage after detection in the four-part pipeline: Preparation -> Detection -> Curation -> (AGS is committed becoming a Sighting) -> Identification. Curation is when a user might add manual annotation boxes, and also when they assign annotations from detection or manual annotation to the encounters/individuals in the submission.

For an AGS, curation is considered to have begun once the `AssetGroupSighting.creation_start_time` has been set, which is done when detection is finished / skipped. Curation is done when the AGS is committed to a Sighting.

Curation is always considered done on the Sighting object, and it inherits stuff like curation start time from the AGS.