### PR TITLE
1099 Houston Exceptions on objects create audit logs for the correct …

### DIFF
--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -534,6 +534,7 @@ class FeatherModel(CommonHoustonModel):
             raise HoustonException(
                 log,
                 f'Only one None encounters value between {class_name} edm/feather objects!',
+                obj=self,
             )
         for encounter in edm_json.get('encounters') or []:
             # EDM returns strings for decimalLatitude and decimalLongitude
@@ -550,7 +551,7 @@ class FeatherModel(CommonHoustonModel):
                 error_msg += (
                     f', locally:{len(self.encounters)}, EDM:{len(guid_to_encounter)} !'
                 )
-                raise HoustonException(log, error_msg)
+                raise HoustonException(log, error_msg, obj=self)
 
             for encounter in self.encounters:  # now we augment each encounter
                 found_edm = guid_to_encounter[str(encounter.guid)]

--- a/app/extensions/git_store/__init__.py
+++ b/app/extensions/git_store/__init__.py
@@ -794,7 +794,9 @@ class GitStore(db.Model, HoustonModel):
                 filename for filename in uploaded_files if filename not in paths
             ]
             if unprocessed_files:
-                raise HoustonException(log, f'Asset(s) {unprocessed_files} are not used')
+                raise HoustonException(
+                    log, f'Asset(s) {unprocessed_files} are not used', obj=self
+                )
 
         paths_added = []
         original_filenames = []

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -133,7 +133,7 @@ class Annotation(db.Model, HoustonModel, SageModel):
             return self.encounter.sighting.get_job_debug(self.guid, verbose)
         else:
             raise HoustonException(
-                log, f'Annotation {self.guid} not connected to an encounter'
+                log, f'Annotation {self.guid} not connected to an encounter', obj=self
             )
 
     @classmethod
@@ -569,7 +569,9 @@ class Annotation(db.Model, HoustonModel, SageModel):
         sighting = self.get_sighting()
         if not sighting:
             raise HoustonException(
-                log, f'{self} requires a sighting to run send_to_identification()'
+                log,
+                f'{self} requires a sighting to run send_to_identification()',
+                obj=self,
             )
         sighting.validate_id_configs()
         job_count = sighting.send_annotation_for_identification(self, matching_set_query)

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -533,7 +533,9 @@ class Asset(db.Model, HoustonModel, SageModel):
         format = Image.registered_extensions().get(f'.{self.extension}', None)
         if not format:
             raise HoustonException(
-                log, f'Unable to find valid format to save modified Asset {self.guid}'
+                log,
+                f'Unable to find valid format to save modified Asset {self.guid}',
+                obj=self,
             )
         image_object.save(symlink.resolve(), format=format)
         self.reset_derived_images()
@@ -551,6 +553,7 @@ class Asset(db.Model, HoustonModel, SageModel):
             raise HoustonException(
                 log,
                 'Asset does not have a valid path, needs to be within an AssetGroup',
+                obj=self,
             )
         target_path = self.get_derived_path('master')
         target_path.parent.mkdir(parents=True, exist_ok=True)

--- a/app/modules/collaborations/models.py
+++ b/app/modules/collaborations/models.py
@@ -508,7 +508,7 @@ class Collaboration(db.Model, HoustonModel):
                     db.session.merge(other_assoc)
         else:
             raise HoustonException(
-                log, 'Unable to start edit on unapproved collaboration'
+                log, 'Unable to start edit on unapproved collaboration', obj=self
             )
 
     # This relates to if the user can access the collaboration itself, not the data

--- a/app/modules/encounters/parameters.py
+++ b/app/modules/encounters/parameters.py
@@ -85,7 +85,7 @@ class PatchEncounterDetailsParameters(PatchJSONParameters):
                 )
             if annot.encounter and not annot.encounter.current_user_has_edit_permission():
                 raise HoustonException(
-                    log, f'annotation {value} owned by a different user'
+                    log, f'annotation {value} owned by a different user', obj=annot
                 )
             annot.encounter = obj
 

--- a/app/modules/individuals/parameters.py
+++ b/app/modules/individuals/parameters.py
@@ -77,6 +77,7 @@ class PatchIndividualDetailsParameters(PatchJSONParameters):
                     log,
                     f'invalid name guid {value}',
                     status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                    obj=obj,
                 )
             try:
                 obj.remove_name(name)
@@ -85,6 +86,7 @@ class PatchIndividualDetailsParameters(PatchJSONParameters):
                     log,
                     f'{name} could not be removed from {obj}: {str(ve)}',
                     status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                    obj=obj,
                 )
             ret_val = True
 
@@ -116,6 +118,7 @@ class PatchIndividualDetailsParameters(PatchJSONParameters):
                     log,
                     f"invalid user guid {value['preferring_user']}",
                     status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                    obj=obj,
                 )
             found = name.remove_preferring_user(user)
             return found
@@ -136,6 +139,7 @@ class PatchIndividualDetailsParameters(PatchJSONParameters):
                     log,
                     'value must contain keys ("context", "value") or ("guid", "preferring_user")',
                     status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                    obj=obj,
                 )
             from flask_login import current_user
 
@@ -156,6 +160,7 @@ class PatchIndividualDetailsParameters(PatchJSONParameters):
                                 log,
                                 f'invalid user guid {user_guid}',
                                 status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                                obj=obj,
                             )
                         preferring_users.append(user)
                 obj.add_name(
@@ -169,6 +174,7 @@ class PatchIndividualDetailsParameters(PatchJSONParameters):
                         log,
                         f"invalid name guid {value['guid']}",
                         status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                        obj=obj,
                     )
                 user = User.query.get(value['preferring_user'])
                 # see above decree from 2021-12-08
@@ -177,6 +183,7 @@ class PatchIndividualDetailsParameters(PatchJSONParameters):
                         log,
                         f"invalid user guid {value['preferring_user']}",
                         status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                        obj=obj,
                     )
                 name.add_preferring_user(user)
                 return True
@@ -210,6 +217,7 @@ class PatchIndividualDetailsParameters(PatchJSONParameters):
                     log,
                     'value must contain keys "guid" and at least one of: "context", "value"',
                     status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                    obj=obj,
                 )
             name = Name.query.get(value['guid'])
             if not name or name.individual_guid != obj.guid:
@@ -217,6 +225,7 @@ class PatchIndividualDetailsParameters(PatchJSONParameters):
                     log,
                     f"invalid name guid {value['guid']}",
                     status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                    obj=obj,
                 )
             if 'context' in value:
                 name.context = value['context']

--- a/app/utils.py
+++ b/app/utils.py
@@ -17,7 +17,12 @@ log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 class HoustonException(Exception):
     def __init__(
-        self, logger, log_message, fault=AuditLog.AuditType.FrontEndFault, **kwargs
+        self,
+        logger,
+        log_message,
+        fault=AuditLog.AuditType.FrontEndFault,
+        obj=None,
+        **kwargs,
     ):
         self.message = kwargs.get('message', log_message)
         self.status_code = kwargs.get('status_code', 400)
@@ -27,7 +32,12 @@ class HoustonException(Exception):
         if log_message == '' and self.message != '':
             log_message = self.message
 
-        AuditLog.audit_log(logger, f'Failed: {log_message} {self.status_code}', fault)
+        if obj:
+            AuditLog.audit_log_object(
+                logger, obj, f'Failed: {log_message} {self.status_code}', fault
+            )
+        else:
+            AuditLog.audit_log(logger, f'Failed: {log_message} {self.status_code}', fault)
 
     def __str__(self):
         # something, somewhere was setting this as a tuple, hence this possibly redudant str()


### PR DESCRIPTION
…objects

<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Audit logs for HoustonExceptions had no associated objects so did not appear in the audit log for the object
- HoustonException now takes an optional obj parameter, which if present creates an audit log for the associated object

