### PR TITLE
Make sentryDsn site setting read only

### DIFF
--- a/app/modules/site_settings/models.py
+++ b/app/modules/site_settings/models.py
@@ -138,6 +138,15 @@ class SiteSetting(db.Model, Timestamp):
             'type': str,
             'public': True,
             'default': lambda: current_app.config.get('SENTRY_DSN'),
+            # sentry is only initialized once in
+            # app/extensions/sentry/__init__.py so changing the sentryDsn site
+            # setting wouldn't change where the errors are sent... For now,
+            # make sentryDsn read only
+            'read_only': True,
+            'edm_definition': {
+                'readOnly': True,
+                'settable': False,
+            },
         },
         'flatfileKey': {
             'type': str,

--- a/tests/modules/site_settings/resources/test_bundles.py
+++ b/tests/modules/site_settings/resources/test_bundles.py
@@ -97,7 +97,7 @@ def test_bundle_read(
             200,
             True,
         ),
-        ({'sentryDsn': 'sentryDsnKey'}, 200, False),
+        ({'recaptchaPublicKey': 'recaptcha-public-key'}, 200, False),
     ),
 )
 def test_bundle_modify(


### PR DESCRIPTION
  Sentry is set up in `app/extensions/sentry/__init__.py` at the beginning
  of the app initialization.  Even if the user changes the `sentryDsn`
  setting, it won't be used until the server restarts, so let's just make
  it not editable for now.
