### PR TITLE
DEX-1114: matching set annots must have encounter

### DIFF
--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -393,6 +393,9 @@ class Annotation(db.Model, HoustonModel, SageModel):
         if tx_guid:
             parts['filter'].append({'match': {'taxonomy_guid': tx_guid}})
 
+        # requiring an encounter is equivalent to requiring a sighting, which seems reasonable (see DEX-1027)
+        parts['filter'].append({'exists': {'field': 'encounter_guid'}})
+
         if self.encounter_guid:
             parts['must_not'] = {'match': {'encounter_guid': str(self.encounter_guid)}}
 
@@ -425,6 +428,8 @@ class Annotation(db.Model, HoustonModel, SageModel):
         # (going with the theory that if these are *redundant* its not a big deal to ES.)
         # we MUST have a content_guid
         query['bool']['filter'].append({'exists': {'field': 'content_guid'}})
+        # requiring an encounter is equivalent to requiring a sighting, which seems reasonable (see DEX-1027)
+        query['bool']['filter'].append({'exists': {'field': 'encounter_guid'}})
         return query
 
     # first tries encounter fields, but will use field on sighting if none on encounter,

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -425,9 +425,6 @@ class Annotation(db.Model, HoustonModel, SageModel):
             query['bool']['must_not'] = {
                 'match': {'encounter_guid': str(self.encounter_guid)}
             }
-        # (going with the theory that if these are *redundant* its not a big deal to ES.)
-        # we MUST have a content_guid
-        query['bool']['filter'].append({'exists': {'field': 'content_guid'}})
         # requiring an encounter is equivalent to requiring a sighting, which seems reasonable (see DEX-1027)
         query['bool']['filter'].append({'exists': {'field': 'encounter_guid'}})
         return query


### PR DESCRIPTION
## Pull Request Overview

- Matching set (queries) should not include Annotations without Encounters
- Also includes a removal of requirement of `content_guid` on Annotation _for **custom** matching-set queries_.  This is based on the fact that [the same filter was removed](https://github.com/WildMeOrg/houston/commit/161cc6d8f147db5e9d9fea205e5e4c963a4204c4#diff-0c1cb11ddca500b44b617bfde7e2ffc02441c1352948ba3aba96d8aba4e9eb04R363-R369) by @bluemellophone for the _default_ matching-set query.