### PR TITLE
1126 researcher can see others pending sightings

### DIFF
--- a/app/modules/asset_groups/metadata.py
+++ b/app/modules/asset_groups/metadata.py
@@ -483,6 +483,11 @@ class AssetGroupMetadata(object):
                         'Invalid submitter data',
                         403,
                     )
+        elif not current_user.is_researcher:
+            if self.bulk_upload:
+                raise AssetGroupMetadataError(log, 'User not permitted to do bulk upload')
+            if self.owner_assignment:
+                raise AssetGroupMetadataError(log, 'User not permitted to assign owners')
         elif self.bulk_upload:
             for group in current_user.get_asset_groups():
                 if group.bulk_upload and not group.is_processed():

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -16,6 +16,7 @@ from flask_login import current_user
 import app.extensions.logging as AuditLog
 from app.extensions import db
 from app.extensions.api import Namespace, abort
+from app.extensions.api.parameters import PaginationParameters
 from app.modules.auth.utils import recaptcha_required
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
@@ -454,8 +455,8 @@ class ContributorPendingAssetGroupSightings(Resource):
             'action': AccessOperation.READ_BY_ROLE,
         },
     )
+    @api.parameters(PaginationParameters())
     @api.response(schemas.BaseAssetGroupSightingSchema(many=True))
-    @api.paginate()
     def get(self, args):
         """
         List of Pending Contributor submitted Asset_group Sightings for a researcher to process

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -455,7 +455,8 @@ class ContributorPendingAssetGroupSightings(Resource):
         },
     )
     @api.response(schemas.BaseAssetGroupSightingSchema(many=True))
-    def get(self):
+    @api.paginate()
+    def get(self, args):
         """
         List of Pending Contributor submitted Asset_group Sightings for a researcher to process
         """
@@ -473,7 +474,10 @@ class ContributorPendingAssetGroupSightings(Resource):
                     and not ags.asset_group.owner.is_researcher
                 ):
                     response.append(ags)
-            return response
+            # Manually apply offset and limit after the list is created
+            offset = args['offset']
+            limit = args['limit']
+            return response[offset : offset + limit]
         return []
 
 

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -26,6 +26,10 @@ MODULE_USER_MAP = {
     ('AssetGroup', AccessOperation.READ): ['is_admin'],
     ('AssetGroup', AccessOperation.WRITE): ['is_active'],
     ('AssetGroupSighting', AccessOperation.READ): ['is_admin'],
+    ('AssetGroupSighting', AccessOperation.READ_MULTI_USER): [
+        'is_admin',
+        'is_researcher',
+    ],
     ('Encounter', AccessOperation.READ): ['is_researcher'],
     ('Encounter', AccessOperation.WRITE): ['is_active'],  # TODO is this still correct
     ('Sighting', AccessOperation.READ): ['is_researcher'],

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -26,7 +26,7 @@ MODULE_USER_MAP = {
     ('AssetGroup', AccessOperation.READ): ['is_admin'],
     ('AssetGroup', AccessOperation.WRITE): ['is_active'],
     ('AssetGroupSighting', AccessOperation.READ): ['is_admin'],
-    ('AssetGroupSighting', AccessOperation.READ_MULTI_USER): [
+    ('AssetGroupSighting', AccessOperation.READ_BY_ROLE): [
         'is_admin',
         'is_researcher',
     ],

--- a/app/modules/users/permissions/types.py
+++ b/app/modules/users/permissions/types.py
@@ -18,7 +18,7 @@ class AccessOperation(enum.Enum):
     # internal operations only (only Sage, no wetware users)
     READ_INTERNAL = 4
     # Read where different users see different things, eg lists where admin sees all but researcher sees a limited set
-    READ_MULTI_USER = 5
+    READ_BY_ROLE = 5
     WRITE = 6
     # internal operations only (only Sage, no wetware users)
     WRITE_INTERNAL = 7

--- a/app/modules/users/permissions/types.py
+++ b/app/modules/users/permissions/types.py
@@ -17,7 +17,9 @@ class AccessOperation(enum.Enum):
     READ_PRIVILEGED = 3
     # internal operations only (only Sage, no wetware users)
     READ_INTERNAL = 4
-    WRITE = 5
+    # Read where different users see different things, eg lists where admin sees all but researcher sees a limited set
+    READ_MULTI_USER = 5
+    WRITE = 6
     # internal operations only (only Sage, no wetware users)
-    WRITE_INTERNAL = 6
-    DELETE = 7
+    WRITE_INTERNAL = 7
+    DELETE = 8

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -347,6 +347,18 @@ def read_all_asset_group_sightings(flask_app_client, user, expected_status_code=
     )
 
 
+def read_pending_asset_group_sightings(
+    flask_app_client, user, group, expected_status_code=200
+):
+    return test_utils.get_list_via_flask(
+        flask_app_client,
+        user,
+        scopes='asset_groups:read',
+        path=f'{PATH}sighting/pending/{group}',
+        expected_status_code=expected_status_code,
+    )
+
+
 def read_asset_group_sighting(
     flask_app_client, user, asset_group_sighting_guid, expected_status_code=200
 ):

--- a/tests/modules/test_ia_pipeline.py
+++ b/tests/modules/test_ia_pipeline.py
@@ -130,8 +130,8 @@ def test_ia_pipeline_sim_detect_response(
         if len(annot_guids) > 0:
             annot_debug = annot_utils.read_debug(
                 flask_app_client, staff_user, annot_guids[0]
-            )
-            assert annot_debug.json['guid'] == sighting_uuid
+            ).json
+            assert annot_debug['sighting']['guid'] == sighting_uuid
 
         asset_guids = [asset['guid'] for asset in ag_resp.json['assets']]
         asset_debug = asset_utils.read_asset(


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- New API(s) where users can see pending public sightings and all contributor owned pending sightings
- Involved a new READ_BY_ROLE access permission check for any APIs which may have different access for different users
- Contributor can no longer submit a bulk upload or assign ownership, bugs found in testing contributor AGS creation

/api/v1/asset_groups/sighting/pending/public returns the Pending Public AssetGroupSightings.
/api/v1/asset_groups/sighting/pending/contributor returns the Pending Contributor owned AssetGroupSightings.
The output format is the same as for /api/v1/users/{user guid}/asset_group_sightings which should make it easy for the FE.
