### PR TITLE
DEX-1132: Sage ID Result Asset Access Permissions

### DIFF
--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -10,6 +10,7 @@ import uuid
 from functools import total_ordering
 
 from flask import current_app, url_for
+from flask_login import current_user
 from PIL import Image
 
 import app.extensions.logging as AuditLog
@@ -404,10 +405,13 @@ class Asset(db.Model, HoustonModel, SageModel):
         return user.is_internal
 
     # This relates to if the user can access to viewing an asset if it was specifically in a sighting's ID result that the user has access to view
-    def user_can_access(self, user):
+    def user_can_access(self, user=None):
         from app.modules.annotations.models import Annotation
         from app.modules.users.permissions.rules import ObjectActionRule
         from app.modules.users.permissions.types import AccessOperation
+
+        if user is None:
+            user = current_user
 
         users = []
         users.append(user)

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -403,6 +403,40 @@ class Asset(db.Model, HoustonModel, SageModel):
         # return self.is_detection() and user.is_internal
         return user.is_internal
 
+    # This relates to if the user can access to viewing an asset if it was specifically in a sighting's ID result that the user has access to view
+    def user_can_access(self, user):
+        from app.modules.annotations.models import Annotation
+        from app.modules.users.permissions.rules import ObjectActionRule
+        from app.modules.users.permissions.types import AccessOperation
+
+        users = []
+        users.append(user)
+        for collaboration in user.get_collaboration_associations():
+            users.append(collaboration.get_other_user())
+
+        sightings = []
+        for user in users:
+            sightings += user.get_sightings()
+
+        annotation_guids = []
+        for sighting in sightings:
+            rule = ObjectActionRule(sighting, AccessOperation.READ, user)
+            if rule.check():
+                annotation_guids += sighting.get_matched_annotation_guids()
+
+        annotation_guids = sorted(set(annotation_guids))
+
+        cls = Annotation
+        asset_guids = (
+            cls.query.filter(cls.guid.in_(annotation_guids))
+            .with_entities(cls.asset_guid)
+            .all()
+        )
+        asset_guids = [val[0] for val in asset_guids]
+        asset_guids = sorted(set(asset_guids))
+
+        return self.guid in asset_guids
+
     # will only set .meta values that can be derived automatically from file
     # (will not overwrite any manual/other values); silently fails if unknown type for deriving
     #

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -71,6 +71,12 @@ MODULE_USER_MAP = {
 OBJECT_USER_MAP = {
     ('SiteSetting', AccessOperation.WRITE): ['is_admin'],
     ('SiteSetting', AccessOperation.DELETE): ['is_admin'],
+    ('Asset', AccessOperation.READ): [
+        'is_staff',
+        'is_admin',
+        'is_data_manager',
+        'is_researcher',
+    ],
     ('AssetGroup', AccessOperation.READ_PRIVILEGED): ['is_staff'],
     ('AssetGroupSighting', AccessOperation.READ): [
         'is_admin',
@@ -136,6 +142,7 @@ OBJECT_USER_METHOD_MAP = {
     ('Sighting', AccessOperation.READ): ['user_is_owner'],
     ('Sighting', AccessOperation.WRITE): ['user_owns_all_encounters'],
     ('Sighting', AccessOperation.DELETE): ['user_can_edit_all_encounters'],
+    ('Asset', AccessOperation.READ): ['user_can_access'],
     ('Asset', AccessOperation.READ_INTERNAL): ['user_raw_read'],
     ('Asset', AccessOperation.WRITE): ['user_is_owner'],
     ('AssetGroupSighting', AccessOperation.READ): ['user_can_access'],
@@ -309,7 +316,7 @@ class ObjectActionRule(DenyAbortMixin, Rule):
     Ensure that the current_user has has permission to perform the action on the object passed.
     """
 
-    def __init__(self, obj=None, action=AccessOperation.READ, **kwargs):
+    def __init__(self, obj=None, action=AccessOperation.READ, user=None, **kwargs):
         """
         Args:
         obj (object) - any object can be passed here, which this functionality will
@@ -319,6 +326,9 @@ class ObjectActionRule(DenyAbortMixin, Rule):
         """
         self._obj = obj
         self._action = action
+        if user is None:
+            user = current_user
+        self._user = user
         super().__init__(**kwargs)
 
     def any_table_driven_permission(self):
@@ -333,9 +343,9 @@ class ObjectActionRule(DenyAbortMixin, Rule):
 
         if roles is not None:
             for role in roles:
-                if not hasattr(current_user, role):
+                if not hasattr(self._user, role):
                     log.warning(f'user object does not have accessor {role}')
-                elif getattr(current_user, role):
+                elif getattr(self._user, role):
                     return True, True
 
         if object_user_methods is not None:
@@ -344,12 +354,12 @@ class ObjectActionRule(DenyAbortMixin, Rule):
                     log.warning(
                         f'{self._obj.__class__.__name__} object does not have accessor {method}'
                     )
-                elif getattr(self._obj, method)(current_user):
+                elif getattr(self._obj, method)(self._user):
                     return True, True
 
         return True, False
 
-    def elevated_permission(self, user):
+    def elevated_permission(self):
         # internal access cannot be achieved by elevated permission
         if (
             self._action == AccessOperation.READ_INTERNAL
@@ -358,42 +368,43 @@ class ObjectActionRule(DenyAbortMixin, Rule):
             return False
         elif self._action == AccessOperation.READ_DEBUG:
             # Only staff can read debug info, not owners
-            return user.is_privileged
+            return self._user.is_privileged
         else:
             # Specifically also includes READ_PRIVILEGED
-            return owner_or_privileged(user, self._obj)
+            return owner_or_privileged(self._user, self._obj)
 
     def check(self):
         # This Rule is for checking permissions on objects, so there must be one, Use the ModuleActionRule for
         # permissions checking without objects
         assert self._obj is not None
+
         # Anyone can read public data, even anonymous and inactive users
         has_permission = self._action == AccessOperation.READ and self._obj.is_public()
 
-        if current_user and not current_user.is_anonymous and current_user.is_active:
+        if self._user and not self._user.is_anonymous and self._user.is_active:
             if not has_permission:
                 was_table_driven, has_permission = self.any_table_driven_permission()
 
             if not has_permission:
-                has_permission = self.elevated_permission(current_user) | (
-                    self._permitted_via_collaboration(current_user)
-                    # | self._permitted_via_org(current_user)
-                    # | self._permitted_via_project(current_user)
+                has_permission = self.elevated_permission() | (
+                    self._permitted_via_collaboration()
+                    # | self._permitted_via_org()
+                    # | self._permitted_via_project()
                 )
 
         if not has_permission:
             log.info(
                 'Access permission denied for %r, %r by %r'
-                % (self._action, self._obj, current_user)
+                % (self._action, self._obj, self._user)
             )
         return has_permission
 
-    # def _permitted_via_org(self, user):
+    # def _permitted_via_org(self):
     #     has_permission = False
     #     # Orgs not supported fully yet, but allow read if user is in it
     #     if self._action == AccessOperation.READ:
     #         org_index = 0
-    #         orgs = user.get_org_memberships()
+    #         orgs = self._user.get_org_memberships()
     #         while not has_permission and org_index < len(orgs):
     #             org = orgs[org_index]
     #             member_index = 0
@@ -405,13 +416,13 @@ class ObjectActionRule(DenyAbortMixin, Rule):
     #
     #     return has_permission
 
-    # def _permitted_via_project(self, user):
+    # def _permitted_via_project(self):
     #     from app.modules.encounters.models import Encounter
     #     from app.modules.assets.models import Asset
     #
     #     has_permission = False
     #     project_index = 0
-    #     projects = user.get_projects()
+    #     projects = self._user.get_projects()
     #     # For MVP, Project ownership/membership is the driving factor for access to data within the project,
     #     # not the Role. If Role specific access is later required, it would be added here.
     #     # A user may read an object via permission granted via the project. The user may not update or

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -441,18 +441,18 @@ class ObjectActionRule(DenyAbortMixin, Rule):
     #             project_index = project_index + 1
 
     @module_required('collaborations', resolve='warn', default=False)
-    def _permitted_via_collaboration(self, user):
+    def _permitted_via_collaboration(self):
         from app.modules.collaborations.models import Collaboration
 
-        tried_users = [user]
+        tried_users = [self._user]
         object_user_methods = OBJECT_USER_METHOD_MAP.get(
             (self._obj.__class__.__name__, self._action)
         )
 
         if self._action == AccessOperation.READ:
-            collab_users = Collaboration.get_users_for_read(user)
+            collab_users = Collaboration.get_users_for_read(self._user)
         elif self._action == AccessOperation.WRITE:
-            collab_users = Collaboration.get_users_for_write(user)
+            collab_users = Collaboration.get_users_for_write(self._user)
         else:
             collab_users = []
 

--- a/tests/modules/users/test_permissions.py
+++ b/tests/modules/users/test_permissions.py
@@ -501,14 +501,16 @@ def test_ObjectAccessPermission_contributor_user(
     # object that is not a project, encounter or asset
     mock_other = Mock(is_public=lambda: False)
     projects = [project1, project2, project3]
+
     with patch.object(contributor_1_login, 'owns_object', return_value=False):
         with patch.object(contributor_1_login, 'get_projects', return_value=projects):
-            # Project access disabled for MVP, the first 3 should be _can_read checks when restored
-            validate_cannot_read_object(project1)
-            validate_cannot_read_object(owned_encounter)
-            validate_cannot_read_object(mock_asset)
-            # object that is not a project, encounter or asset
-            validate_cannot_read_object(mock_other)
+            with patch.object(mock_asset, 'user_can_access', return_value=False):
+                # Project access disabled for MVP, the first 3 should be _can_read checks when restored
+                validate_cannot_read_object(project1)
+                validate_cannot_read_object(owned_encounter)
+                validate_cannot_read_object(mock_asset)
+                # object that is not a project, encounter or asset
+                validate_cannot_read_object(mock_other)
 
     my_encounter = test_utils.generate_owned_encounter(contributor_1_login)
     with db.session.begin():


### PR DESCRIPTION
This PR fixes the access control for ID results.  We should always show a user the asset for ID results when they are returned from Sage, regardless of who owns the image.  