### PR TITLE
dex 1169 - clean up codex apiKeys.js

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -45,11 +45,6 @@ jobs:
         run: |
           ./scripts/swagger/build.sh
 
-      - name: Create apiKeys.js for frontend
-        run: |
-          cd _frontend.codex
-          cp src/constants/apiKeysTemplate.js src/constants/apiKeys.js
-
       # - name: Add 1GB of Swap
       #   uses: pierotofy/set-swap-space@master
       #   with:

--- a/scripts/codex/build.frontend.sh
+++ b/scripts/codex/build.frontend.sh
@@ -73,14 +73,6 @@ function build() {
     # Install dependencies fresh
     npm install
 
-    # Create API file, if it doesn't exist
-    if [[ ! -f src/constants/apiKeys.js ]]
-    then
-        echo "Copying apiKeysTemplate.js to apiKeys.js..."
-        echo "You will need to edit _frontend.codex/src/constants/apiKeys.js file to get the Codex frontend to run properly."
-        cp src/constants/apiKeysTemplate.js src/constants/apiKeys.js
-    fi
-
     # Build dist of the Codex frontend UI
     #  you can alter houston url here if desired
     npm run build -- --env=houston=relative


### PR DESCRIPTION
## Pull Request Overview

- Removes the reference to `apiKeys.js` in `scripts/codex/build.frontend.sh` to prevent the Nightly frontend build from failing: https://github.com/WildMeOrg/houston/runs/6865149205?check_suite_focus=true
- Removes the reference to codex's `apiKeys.js` in the integration tests workflow to prevent integration test failure.
---

**Review Notes**
- This is another piece of the transition from the front-end config file, `apiKeys.js` to houston provided site settings: #645 , #665, WildmeOrg/codex-frontend#370