### PR TITLE
Add custom Elasticsearch mappings with automatic patching

### DIFF
--- a/app/extensions/api/namespace.py
+++ b/app/extensions/api/namespace.py
@@ -125,6 +125,8 @@ class Namespace(BaseNamespace):
         def decorator(func):
             @wraps(func)
             def wrapper(self_, parameters_args, *args, **kwargs):
+                from app.extensions.elasticsearch import ELASTICSEARCH_SORTING_PREFIX
+
                 offset = parameters_args['offset']
                 limit = parameters_args['limit']
                 sort = parameters_args['sort']
@@ -155,7 +157,19 @@ class Namespace(BaseNamespace):
                         )
                         default_column = cls.guid
 
+                    if sort.startswith(ELASTICSEARCH_SORTING_PREFIX):
+                        log.error(
+                            'Unable to sort listing APIs with Elasticsearch property {!r}'.format(
+                                sort
+                            )
+                        )
+
+                        # Remove ES-specific prefix from sort
+                        # This will also try to use local columns as a backup, if found
+                        sort = sort.replace(ELASTICSEARCH_SORTING_PREFIX, '')
+
                     sort = sort.lower()
+
                     outerjoin_cls = None
 
                     if sort in ['default', 'primary']:

--- a/app/extensions/celery.py
+++ b/app/extensions/celery.py
@@ -44,9 +44,6 @@ if is_extension_enabled('sage'):
 if is_module_enabled('asset_groups'):
     import app.modules.asset_groups.tasks  # noqa
 
-if is_module_enabled('elasticsearch'):
-    import app.modules.elasticsearch.tasks  # noqa
-
 if is_module_enabled('individuals'):
     import app.modules.individuals.tasks  # noqa
 

--- a/app/extensions/elasticsearch/__init__.py
+++ b/app/extensions/elasticsearch/__init__.py
@@ -4,6 +4,7 @@ import datetime
 import enum
 import json
 import logging
+import pprint
 import time
 import types
 import uuid
@@ -33,6 +34,7 @@ REGISTERED_MODELS = {}
 CELERY_VERIFY_TIMEOUT = 60.0
 CELERY_ASYNC_PROMISES = []
 
+ELASTICSEARCH_SORTING_PREFIX = 'elasticsearch.'
 
 log = logging.getLogger('elasticsearch')  # pylint: disable=invalid-name
 
@@ -46,6 +48,36 @@ class ElasticsearchModel(object):
     @classmethod
     def get_elasticsearch_schema(cls):
         return None
+
+    @classmethod
+    def get_elasticsearch_settings(cls):
+        return None
+
+    @classmethod
+    def patch_elasticsearch_mappings(cls, mappings):
+        # Check all fields that are GUIDs or "IDs"
+        for key in mappings:
+            # Ensure all GUIDs and the _schema
+            if (
+                key in ['guid', '_schema', 'email']
+                or key.endswith('_guid')
+                or key.endswith('Id')
+                or key.endswith('ID')
+                or key.endswith('_id')
+            ):
+                mappings[key] = {
+                    'type': 'keyword',
+                }
+            # # Convert all text types to keywords by default
+            # if mappings[key].get('type', None) in ['text']:
+            #     mappings[key] = {
+            #         'type': 'keyword',
+            #     }
+            if key in ['properties']:
+                # Recursively catch all properties of a field as well
+                mappings[key] = cls.patch_elasticsearch_mappings(mappings[key])
+
+        return mappings
 
     @classmethod
     def index_hook_cls(cls, *args, **kwargs):
@@ -62,6 +94,8 @@ class ElasticsearchModel(object):
     @classmethod
     def index_all(cls, app=None, prune=True, pit=False, update=True, force=False):
         index = cls._index()
+
+        es_index_mappings_patch(cls, app=app)
 
         session_forced = session.in_forced_mode()
 
@@ -305,7 +339,7 @@ class ElasticSearchBulkOperation(object):
         if app is None:
             app = self.app
 
-        index = es_index_name(cls)
+        index = es_index_name(cls, app=app)
 
         if index is None:
             return exists
@@ -348,7 +382,7 @@ class ElasticSearchBulkOperation(object):
         if app is None:
             app = self.app
 
-        index = es_index_name(cls)
+        index = es_index_name(cls, app=app)
 
         if index is None:
             return 0
@@ -382,6 +416,10 @@ class ElasticSearchBulkOperation(object):
         if len(pending) == 0:
             return len(skipped)
 
+        # Check schema mappings first
+        es_index_mappings_patch(cls, app=app)
+
+        # Continue to serialize and send
         level_str = '' if level == 0 else ' [retry=%d]' % (level,)
         desc = 'Serializing (Bulk) {}{}'.format(
             cls.__name__,
@@ -473,7 +511,7 @@ class ElasticSearchBulkOperation(object):
         if app is None:
             app = self.app
 
-        index = es_index_name(cls)
+        index = es_index_name(cls, app=app)
 
         if index is None:
             return 0
@@ -968,17 +1006,17 @@ def es_validate(obj):
                 )
 
 
-def es_index(obj, app=None, force=False, quiet=False):
+def es_index(obj, app=None, force=False, quiet=False, recover=True):
     from flask import current_app
-
-    cls = obj.__class__
-    index = es_index_name(cls, quiet=quiet)
-
-    if index is None:
-        return None
 
     if app is None:
         app = current_app
+
+    cls = obj.__class__
+    index = es_index_name(cls, app=app, quiet=quiet)
+
+    if index is None:
+        return None
 
     if session.in_bulk_mode():
         return session.track_bulk_action('index', obj, force=force)
@@ -986,9 +1024,26 @@ def es_index(obj, app=None, force=False, quiet=False):
     try:
         index, id_, body = obj.serialize()
         resp = app.es.index(index=index, id=id_, body=body)
-    except (elasticsearch.exceptions.RequestError, TypeError):  # pragma: no cover
-        log.error('Error indexing {!r}'.format(obj))
-        raise
+
+        _seq_no = resp.get('_seq_no', None)
+        if _seq_no is not None and _seq_no == 0:
+            # We have indexed our very first object, let's check the mappings
+            es_index_mappings_patch(cls, app=app)
+            cls.pit(app=app)
+    except (
+        elasticsearch.exceptions.RequestError,
+        TypeError,
+    ) as exception:  # pragma: no cover
+        if not recover:
+            raise
+
+        try:
+            # We want to try to recover by checking the index's mappings and try re-indexing
+            es_index_mappings_patch(cls, app=app)
+            es_index(obj, app=app, force=force, quiet=quiet, recover=False)
+        except Exception:
+            log.error('Error indexing {!r}, likely bad schema'.format(obj))
+            raise exception  # Raise original exception
 
     # Update the object's indexed timestamp
     assert resp['_id'] == str(obj.guid)
@@ -1024,6 +1079,45 @@ def es_all_indices(app=None):
             response.append(index)
 
     return response
+
+
+def es_create_index(cls, app=None, mappings=None):
+    from flask import current_app
+
+    if is_disabled():
+        return False
+
+    if app is None:
+        app = current_app
+
+    index = es_index_name(cls, app=app)
+
+    if index is None:
+        return None
+
+    if es_index_exists(index, app=app):
+        return 'exists'
+
+    body = {}
+
+    settings = cls.get_elasticsearch_settings()
+    if settings is not None:
+        body['settings'] = settings
+
+    if mappings is not None:
+        body['mappings'] = {'_doc': {'properties': mappings}}
+        include_type_name = True
+    else:
+        include_type_name = False
+
+    response = app.es.indices.create(
+        index, body=body, include_type_name=include_type_name
+    )
+    acknowledged = response.get('acknowledged', False)
+
+    cls.pit(app=app)
+
+    return acknowledged
 
 
 def es_delete_index(index, app=None):
@@ -1078,16 +1172,16 @@ def es_update(*args, **kwargs):
 def es_exists(obj, app=None):
     from flask import current_app
 
+    if app is None:
+        app = current_app
+
     id_ = str(obj.guid)
     cls = obj.__class__
-    index = es_index_name(cls)
+    index = es_index_name(cls, app=app)
 
     if index is None:
         obj.invalidate()
         return False
-
-    if app is None:
-        app = current_app
 
     exists = app.es.exists(index, id=id_)
 
@@ -1127,18 +1221,83 @@ def es_index_mappings(index, app=None):
     return mappings
 
 
-def es_get(obj, app=None):
+def es_index_mappings_patch(cls, app=None, quiet=False):
+    from copy import deepcopy
+
+    from deepdiff import DeepDiff
     from flask import current_app
-
-    id_ = str(obj.guid)
-    cls = obj.__class__
-    index = es_index_name(cls)
-
-    if index is None:
-        return None
 
     if app is None:
         app = current_app
+
+    if is_disabled():
+        return None
+
+    if cls not in REGISTERED_MODELS:
+        if not quiet:
+            log.error('Model ({!r}) is not in Elasticsearch'.format(cls))
+        return None
+
+    if not hasattr(cls, 'patch_elasticsearch_mappings'):
+        return None
+
+    index = es_index_name(cls, app=app)
+
+    if not es_index_exists(index, app=app):
+        return None
+
+    mappings = es_index_mappings(index)
+    if len(mappings) == 0:
+        # We don't have a useful "starting" mapping from the auto-parsing, skip
+        return None
+
+    # We want to give the developer of `patch_elasticsearch_mappings` the most freedom,
+    # can use by-reference updates or returned value
+
+    patched_mappings = deepcopy(mappings)
+    patched_mappings = cls.patch_elasticsearch_mappings(patched_mappings)
+
+    diff = DeepDiff(mappings, patched_mappings)
+    if len(diff) > 0:
+        log.error('Index ({!r}) has an incorrect mapping, rebuilding'.format(index))
+        log.error(pprint.pformat(diff))
+
+        # Get all of the GUIDs that have been indexed for this class
+        es_refresh_index(index, app=app)
+        existsing_guids = cls.elasticsearch(None, load=False)
+
+        # Delete the current idnex
+        es_delete_index(index)
+
+        # Recreate the index with the correct mappings
+        es_create_index(cls, app=app, mappings=patched_mappings)
+
+        # Restore the msissing GUIDs (in the background)
+        with session.begin(forced=True):
+            objs = cls.query.filter(cls.guid.in_(existsing_guids)).all()
+            desc = 'Restoring {}'.format(cls.__name__)
+            for obj in tqdm.tqdm(objs, desc=desc, disable=quiet):
+                obj.index(app=app)
+
+        es_refresh_index(index, app=app)
+
+        return 'patched'
+
+    return 'up-to-date'
+
+
+def es_get(obj, app=None):
+    from flask import current_app
+
+    if app is None:
+        app = current_app
+
+    id_ = str(obj.guid)
+    cls = obj.__class__
+    index = es_index_name(cls, app=app)
+
+    if index is None:
+        return None
 
     if not app.es.exists(index, id=id_):
         return None
@@ -1159,7 +1318,11 @@ def es_search(index, body, app=None):
     if not es_index_exists(index, app=app):
         return None
 
-    resp = list(helpers.scan(app.es, query=body, index=index, scroll='1d', size=10000))
+    resp = list(
+        helpers.scan(
+            app.es, query=body, index=index, scroll='1d', preserve_order=True, size=10000
+        )
+    )
 
     return resp
 
@@ -1172,10 +1335,10 @@ def es_delete(obj, app=None):
 def es_delete_guid(cls, guid, app=None):
     from flask import current_app
 
-    index = es_index_name(cls)
-
     if app is None:
         app = current_app
+
+    index = es_index_name(cls, app=app)
 
     if session.in_bulk_mode():
         return session.track_bulk_action('delete', (cls, guid))
@@ -1219,24 +1382,27 @@ def es_pit(cls, app=None):
 
     global REGISTERED_MODELS
 
-    index = es_index_name(cls)
+    if app is None:
+        app = current_app
+
+    index = es_index_name(cls, app=app)
 
     if index is None:
         return None
 
-    if app is None:
-        app = current_app
+    if not es_index_exists(index, app=app):
+        return None
 
     pit_id = REGISTERED_MODELS.get(cls, {}).get('pit', None)
     if pit_id is not None:
         body = {
             'id': pit_id,
         }
-        resp = app.es.close_point_in_time(body)
-        assert resp['succeeded']
-
-    if not es_index_exists(index, app=app):
-        app.es.indices.create(index)
+        try:
+            resp = app.es.close_point_in_time(body)
+            assert resp['succeeded']
+        except elasticsearch.exceptions.NotFoundError:
+            pass
 
     resp = app.es.open_point_in_time(index, keep_alive='1d')
     pit_id = resp.get('id', None)
@@ -1255,7 +1421,7 @@ def es_status(app=None, outdated=True, missing=False, active=True, health=True):
 
     if outdated:
         for cls in REGISTERED_MODELS:
-            index = es_index_name(cls)
+            index = es_index_name(cls, app=app)
             if index is None:
                 continue
 
@@ -1267,7 +1433,7 @@ def es_status(app=None, outdated=True, missing=False, active=True, health=True):
 
     if missing:
         for cls in REGISTERED_MODELS:
-            index = es_index_name(cls)
+            index = es_index_name(cls, app=app)
             if index is None:
                 continue
 
@@ -1589,9 +1755,43 @@ def es_elasticsearch(
 
     # Don't return anything about the hits
     assert isinstance(body, dict)
+    assert sort.count('.') <= 1
     body['_source'] = False
 
-    hits = es_search(index, body, app=app)
+    pre_sorted = sort.startswith(ELASTICSEARCH_SORTING_PREFIX)
+
+    if pre_sorted:
+        es_sort_term = sort.replace(ELASTICSEARCH_SORTING_PREFIX, '')
+        es_sort_order = 'desc' if reverse else 'asc'
+        body['sort'] = [
+            {
+                es_sort_term: {'order': es_sort_order},
+            },
+            {
+                'guid': {'order': es_sort_order},
+            },
+        ]
+
+    try:
+        hits = es_search(index, body, app=app)
+    except (elasticsearch.exceptions.RequestError, TypeError):  # pragma: no cover
+        if 'sort' in body:
+            # Try again without any sort field in the body
+            es_sort = body.pop('sort')
+            log.error(
+                'Unable to sort within Elasticsearch using {!r}, retrying without sort'.format(
+                    es_sort
+                )
+            )
+
+            # Remove ES-specific prefix from sort
+            # This will also try to use local columns as a backup, if found
+            sort = sort.replace(ELASTICSEARCH_SORTING_PREFIX, '')
+            pre_sorted = False
+
+            hits = es_search(index, body, app=app)
+        else:
+            raise
 
     if hits is None or len(hits) == 0:
         if total:
@@ -1652,7 +1852,11 @@ def es_elasticsearch(
     sort = sort.lower()
     outerjoin_cls = None
 
-    if sort in ['default', 'primary']:
+    if pre_sorted:
+        # The results we pre-sorted by Elasticsearch during the query, just fetch them
+        # We will re-order them after load
+        sort_column = default_column
+    elif sort in ['default', 'primary']:
         sort_column = default_column
     else:
         # First, check for columns in the table
@@ -1690,26 +1894,58 @@ def es_elasticsearch(
     if outerjoin_cls is not None:
         query = query.outerjoin(outerjoin_cls)
 
-    query = (
-        query.filter(cls.guid.in_(search_guids))
-        .order_by(sort_func_1(), sort_func_2())
-        .offset(offset)
-        .limit(limit)
-    )
+    query = query.filter(cls.guid.in_(search_guids))
 
-    if reverse_after:
-        after_sort_func_1 = sort_column.asc if reverse else sort_column.desc
-        after_sort_func_2 = default_column.asc if reverse else default_column.desc
-        query = query.from_self().order_by(after_sort_func_1(), after_sort_func_2())
-
-    if not load:
+    if pre_sorted:
+        # We pre-sorted, so let's do all filtering on the GUIDs here since the query is being broken up here
         query = query.with_entities(cls.guid)
 
-    results = query.all()
+        houston_guids = query.all()
+        houston_guids = {local_result[0] for local_result in houston_guids}
 
-    if not load:
-        # Strip column 0
-        results = [result[0] for result in results]
+        elasticsearch_guids = []
+        for search_guid in search_guids:
+            if search_guid in houston_guids:
+                elasticsearch_guids.append(search_guid)
+
+        if offset is not None:
+            offset = max(0, min(offset, len(elasticsearch_guids)))
+            elasticsearch_guids = elasticsearch_guids[offset:]
+
+        if limit is not None:
+            offset = max(0, min(limit, len(elasticsearch_guids)))
+            elasticsearch_guids = elasticsearch_guids[:limit]
+
+        if reverse_after:
+            elasticsearch_guids = elasticsearch_guids[::-1]
+
+        if load:
+            results = []
+            for elasticsearch_guid in elasticsearch_guids:
+                obj = cls.query.get(elasticsearch_guid)
+                if (
+                    obj
+                ):  # This should always be True since we have already filtered on the DB
+                    results.append(obj)
+        else:
+            results = elasticsearch_guids
+    else:
+        # We are performing a Houston-forward SQL query, so let's stay within SQLalchemy for as long as possible
+        query = query.order_by(sort_func_1(), sort_func_2()).offset(offset).limit(limit)
+
+        if reverse_after:
+            after_sort_func_1 = sort_column.asc if reverse else sort_column.desc
+            after_sort_func_2 = default_column.asc if reverse else default_column.desc
+            query = query.from_self().order_by(after_sort_func_1(), after_sort_func_2())
+
+        if not load:
+            query = query.with_entities(cls.guid)
+
+        results = query.all()
+
+        if not load:
+            # Strip column 0
+            results = [result[0] for result in results]
 
     if total:
         return total_hits, results

--- a/app/extensions/elasticsearch/__init__.py
+++ b/app/extensions/elasticsearch/__init__.py
@@ -279,7 +279,7 @@ class ElasticSearchBulkOperation(object):
         if self.in_bulk_mode():
             top_config = self.depth[0]
             if top_config is not None:
-                forced = top_config.get('forced', False)
+                forced = top_config.get('forced', top_config.get('force', False))
         return forced
 
     def track_bulk_action(self, action, item, force=False):
@@ -655,10 +655,10 @@ class ElasticSearchBulkOperation(object):
             if config is None:
                 config = {}
 
-            blocking = config.get('blocking', self.blocking)
-            verify = config.get('verify', False)
+            blocking = config.get('blocking', config.get('foreground', self.blocking))
+            verify = config.get('verified', config.get('verify', False))
             disabled = config.get('disabled', not config.get('enabled', True))
-            forced = config.get('forced', False)
+            forced = config.get('forced', config.get('force', False))
 
             keys = self.bulk_actions.keys()
             log.debug('ES exit block with {!r} keys'.format(keys))

--- a/app/modules/encounters/models.py
+++ b/app/modules/encounters/models.py
@@ -98,6 +98,16 @@ class Encounter(db.Model, FeatherModel):
 
         return ElasticsearchEncounterSchema
 
+    @classmethod
+    def patch_elasticsearch_mappings(cls, mappings):
+        mappings = super(Encounter, cls).patch_elasticsearch_mappings(mappings)
+
+        mappings['point'] = {
+            'type': 'geo_point',
+        }
+
+        return mappings
+
     # index of encounter must trigger index of its annotations (so they can update)
     def index_hook_obj(self, *args, **kwargs):
         for annot in self.annotations:

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -9,6 +9,8 @@ blinker
 
 celery
 
+deepdiff
+
 elasticsearch>=7.0.0,<7.14.0
 
 etaprogress

--- a/tasks/app/elasticsearch.py
+++ b/tasks/app/elasticsearch.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+import tqdm
+
 from tasks.utils import app_context_task
 
 
@@ -191,3 +193,136 @@ def delete_index(context, model=None):
         for index in indices:
             print('Deleting ES index {!r}'.format(index))
             es.es_delete_index(index)
+
+
+@app_context_task(
+    help={
+        'model': 'The name of the model to index',
+    }
+)
+def patch(context, model=None):
+    """
+    Check the mappings patch for a given model, if specified, otherwise all models
+    """
+    from app.extensions import elasticsearch as es
+
+    models = []
+
+    available = _get_available_model_mappings()
+
+    if model is None:
+        models += [available[key] for key in sorted(available.keys())]
+    else:
+        model = model.strip()
+        model_cls = available.get(model, None)
+
+        if model_cls is None:
+            print('Model must be one of {!r}'.format(set(available.keys())))
+        else:
+            models.append(model_cls)
+
+    custom_schema_mappings = {
+        'app.modules.individuals.models.individual.adoptionName': 'get_adoption_name',
+        'app.modules.names.models.name.preferring_users': 'get_preferring_users',
+        # 'app.modules.sightings.models.sighting.verbatimLocality': 'get_locality',
+        # 'app.modules.sightings.models.sighting.taxonomy_guid': 'get_taxonomy_guid',
+    }
+
+    if len(models) > 0:
+        missing = {}
+        for model_cls in models:
+            model_index = model_cls._index()
+            print('Patching ES model {!r}'.format(model_cls))
+
+            obj = model_cls.query.first()
+            if obj is None:
+                continue
+
+            with es.session.begin(blocking=True, forced=True):
+                obj.index()
+            with es.session.begin(blocking=True, forced=True):
+                es.es_index_mappings_patch(model_cls)
+            with es.session.begin(blocking=True, forced=True):
+                obj.index()
+            es.es_refresh_index(model_index)
+
+            document = sorted(obj.fetch().get('_source').keys())
+            mappings = sorted(es.es_index_mappings(model_index).keys())
+            miss_document = set(mappings) - set(document)
+            miss_mappings = set(document) - set(mappings)
+
+            if len(miss_document) > 0 or len(miss_mappings) > 0:
+                missing[model_cls] = {
+                    'obj': obj,
+                }
+            if len(miss_document) > 0:
+                missing[model_cls]['miss_document'] = miss_document
+            if len(miss_mappings) > 0:
+                missing[model_cls]['miss_mappings'] = miss_mappings
+
+        for model_cls in missing:
+            print(model_cls)
+            model_index = model_cls._index()
+
+            obj = missing[model_cls].get('obj', None)
+            miss_document = missing[model_cls].get('miss_document', None)
+            miss_mappings = missing[model_cls].get('miss_mappings', None)
+
+            if miss_document:
+                print('\tmissing in document = {!r}'.format(miss_document))
+
+            if miss_mappings:
+                print('\tmissing in mappings = {!r}'.format(miss_mappings))
+                for miss_mapping in miss_mappings:
+                    print(
+                        '\t\t{!r}'.format(miss_mapping),
+                    )
+
+                    if obj is None:
+                        continue
+
+                    custom_mapping = None
+                    miss_mapping_str = '{}.{}'.format(model_index, miss_mapping)
+                    if miss_mapping_str in custom_schema_mappings:
+                        custom_mapping = custom_schema_mappings.get(miss_mapping_str)
+                        if not hasattr(obj, custom_mapping):
+                            custom_mapping = None
+
+                    if custom_mapping is not None:
+                        value_func = getattr(obj, custom_mapping)
+                        value = value_func()
+                        setattr(obj, miss_mapping, value)
+
+                    if hasattr(obj, miss_mapping):
+                        value = getattr(obj, miss_mapping)
+                        if value is None or (isinstance(value, list) and len(value) == 0):
+                            candidates = model_cls.query.all()
+                            for candidate in tqdm.tqdm(candidates, desc='Searching'):
+                                if candidate is None:
+                                    continue
+
+                                if custom_mapping is not None:
+                                    value_func = getattr(candidate, custom_mapping)
+                                    value = value_func()
+                                    setattr(candidate, miss_mapping, value)
+
+                                if hasattr(candidate, miss_mapping):
+                                    value_ = getattr(candidate, miss_mapping)
+                                    if value != value_:
+                                        print(
+                                            '\t\tfound non-empty candidate for attribute {!r}: {!r}, indexing now'.format(
+                                                miss_mapping, value_
+                                            )
+                                        )
+                                        with es.session.begin(blocking=True, forced=True):
+                                            candidate.index()
+                                        with es.session.begin(blocking=True, forced=True):
+                                            es.es_index_mappings_patch(model_cls)
+                                        with es.session.begin(blocking=True, forced=True):
+                                            candidate.index()
+                                        es.es_refresh_index(model_index)
+                                        break
+                        else:
+                            print('search: unprocessable value: {!r}'.format(value))
+                    else:
+                        print('search: unmappable value: {!r}'.format(value))

--- a/tests/extensions/test_elasticsearch.py
+++ b/tests/extensions/test_elasticsearch.py
@@ -270,7 +270,7 @@ def test_elasticsearch_utilities(
                         None,
                         'guid',
                         'indexed',
-                        'full_name',
+                        # 'full_name',
                         'elasticsearch.guid',
                     ]:
                         for reverse in [True, False]:
@@ -323,10 +323,10 @@ def test_elasticsearch_utilities(
                 compare.sort(key=lambda user: user.guid, reverse=reverse)
             elif sort == 'indexed':
                 compare.sort(key=lambda user: (user.indexed, user.guid), reverse=reverse)
-            elif sort == 'full_name':
-                compare.sort(
-                    key=lambda user: (user.full_name, user.guid), reverse=reverse
-                )
+            # elif sort == 'full_name':
+            #     compare.sort(
+            #         key=lambda user: (user.full_name, user.guid), reverse=reverse
+            #     )
             elif sort == 'elasticsearch.guid':
                 values = []
                 for user in compare:
@@ -359,7 +359,7 @@ def test_elasticsearch_utilities(
     configs = []
     for limit in [None, 1, 5, 100]:
         for offset in [None, 0, 5, 100]:
-            for sort in [None, 'guid', 'indexed', 'full_name', 'elasticsearch.guid']:
+            for sort in [None, 'guid', 'indexed', 'elasticsearch.guid']:
                 for reverse in [True, False]:
                     for reverse_after in [True, False]:
                         config = (limit, offset, sort, reverse, reverse_after)
@@ -399,10 +399,10 @@ def test_elasticsearch_utilities(
                 compare.sort(key=lambda user: user.guid, reverse=reverse)
             elif sort == 'indexed':
                 compare.sort(key=lambda user: (user.indexed, user.guid), reverse=reverse)
-            elif sort == 'full_name':
-                compare.sort(
-                    key=lambda user: (user.full_name, user.guid), reverse=reverse
-                )
+            # elif sort == 'full_name':
+            #     compare.sort(
+            #         key=lambda user: (user.full_name, user.guid), reverse=reverse
+            #     )
             else:
                 raise ValueError()
 

--- a/tests/extensions/test_elasticsearch.py
+++ b/tests/extensions/test_elasticsearch.py
@@ -252,6 +252,11 @@ def test_elasticsearch_utilities(
     assert total1 == total2 and total2 == total3
     assert set(users1) == set(users2) and set(users1) == set(users3)
 
+    with es.session.begin(blocking=True, forced=True):
+        es.es_index_mappings_patch(User)
+    with es.session.begin(blocking=True, forced=True):
+        User.index_all()
+
     # Check pagination
     reference = User.elasticsearch(body)
 

--- a/tests/extensions/test_elasticsearch.py
+++ b/tests/extensions/test_elasticsearch.py
@@ -29,7 +29,7 @@ def test_indexing_with_elasticsearch():
 
 
 @pytest.mark.skipif(
-    extension_unavailable('elasticsearch') or module_unavailable('elasticsearch'),
+    extension_unavailable('elasticsearch'),
     reason='Elasticsearch extension or module disabled',
 )
 def test_index_cls_conversion():
@@ -49,9 +49,7 @@ def test_index_cls_conversion():
 
 
 @pytest.mark.skipif(
-    extension_unavailable('elasticsearch')
-    or module_unavailable('elasticsearch')
-    or module_unavailable('asset_groups'),
+    extension_unavailable('elasticsearch') or module_unavailable('asset_groups'),
     reason='Elasticsearch extension or module disabled, or Asset Groups module is disabled',
 )
 def test_elasticsearch_utilities(
@@ -142,7 +140,9 @@ def test_elasticsearch_utilities(
     assert admin_user.available() == es.es_exists(admin_user)
     assert not admin_user.elasticsearchable
 
-    assert admin_user.index().get('result', None) == 'created'
+    with es.session.begin(blocking=True):
+        assert admin_user.index() == 'tracked'
+    assert admin_user.fetch().get('found', True)
     assert admin_user.index().get('result', None) == 'updated'
     assert admin_user.elasticsearchable
     assert admin_user.available()
@@ -261,7 +261,13 @@ def test_elasticsearch_utilities(
         for total in [True, False]:
             for limit in [None, 1, 5, 100]:
                 for offset in [None, 0, 5, 100]:
-                    for sort in [None, 'guid', 'indexed', 'full_name']:
+                    for sort in [
+                        None,
+                        'guid',
+                        'indexed',
+                        'full_name',
+                        'elasticsearch.guid',
+                    ]:
                         for reverse in [True, False]:
                             for reverse_after in [True, False]:
                                 config = (
@@ -316,6 +322,13 @@ def test_elasticsearch_utilities(
                 compare.sort(
                     key=lambda user: (user.full_name, user.guid), reverse=reverse
                 )
+            elif sort == 'elasticsearch.guid':
+                values = []
+                for user in compare:
+                    es_guid = user.fetch().get('_source', {}).get('guid')
+                    values.append((es_guid, user))
+                values.sort(reverse=reverse)
+                compare = [value[1] for value in values]
             else:
                 raise ValueError()
 
@@ -341,7 +354,7 @@ def test_elasticsearch_utilities(
     configs = []
     for limit in [None, 1, 5, 100]:
         for offset in [None, 0, 5, 100]:
-            for sort in [None, 'guid', 'indexed', 'full_name']:
+            for sort in [None, 'guid', 'indexed', 'full_name', 'elasticsearch.guid']:
                 for reverse in [True, False]:
                     for reverse_after in [True, False]:
                         config = (limit, offset, sort, reverse, reverse_after)
@@ -377,7 +390,7 @@ def test_elasticsearch_utilities(
 
             compare = reference[:]
 
-            if sort in [None, 'guid']:
+            if sort in [None, 'guid', 'elasticsearch.guid']:
                 compare.sort(key=lambda user: user.guid, reverse=reverse)
             elif sort == 'indexed':
                 compare.sort(key=lambda user: (user.indexed, user.guid), reverse=reverse)
@@ -420,7 +433,12 @@ def test_elasticsearch_utilities(
         for total in [True, False]:
             for limit in [None, 1, 10]:
                 for offset in [None, 0, 1, 10]:
-                    for sort in [None, 'magic_signature', 'path']:
+                    for sort in [
+                        None,
+                        'magic_signature',
+                        'path',
+                        'elasticsearch.annotation_count',
+                    ]:
                         for reverse in [True, False]:
                             for reverse_after in [True, False]:
                                 config = (
@@ -475,6 +493,13 @@ def test_elasticsearch_utilities(
                 )
             elif sort == 'path':
                 compare.sort(key=lambda asset: (asset.path, asset.guid), reverse=reverse)
+            elif sort == 'elasticsearch.annotation_count':
+                values = []
+                for asset in compare:
+                    es_guid = asset.fetch().get('_source', {}).get('annotation_count')
+                    values.append((es_guid, asset))
+                values.sort(reverse=reverse)
+                compare = [value[1] for value in values]
             else:
                 raise ValueError()
 
@@ -500,7 +525,12 @@ def test_elasticsearch_utilities(
     configs = []
     for limit in [None, 1, 10]:
         for offset in [None, 0, 1, 10]:
-            for sort in [None, 'magic_signature', 'path']:
+            for sort in [
+                None,
+                'magic_signature',
+                'path',
+                'elasticsearch.annotation_count',
+            ]:
                 for reverse in [True, False]:
                     for reverse_after in [True, False]:
                         config = (limit, offset, sort, reverse, reverse_after)
@@ -536,7 +566,7 @@ def test_elasticsearch_utilities(
 
             compare = reference[:]
 
-            if sort in [None, 'guid']:
+            if sort in [None, 'guid', 'elasticsearch.annotation_count']:
                 compare.sort(key=lambda asset: asset.guid, reverse=reverse)
             elif sort == 'magic_signature':
                 compare.sort(
@@ -683,7 +713,7 @@ def test_elasticsearch_utilities(
 
 
 @pytest.mark.skipif(
-    extension_unavailable('elasticsearch') or module_unavailable('elasticsearch'),
+    extension_unavailable('elasticsearch'),
     reason='Elasticsearch extension or module disabled',
 )
 def test_model_search(flask_app_client, staff_user):

--- a/tests/modules/annotations/resources/test_matching_set.py
+++ b/tests/modules/annotations/resources/test_matching_set.py
@@ -56,7 +56,7 @@ def test_annotation_matching_set(
     assert tx
     assert 'id' in tx
     taxonomy_guid = tx['id']
-    locationId = 'erehwon'
+    locationId = str(uuid.uuid4())
     patch_data = [
         utils.patch_replace_op('taxonomy', taxonomy_guid),
         utils.patch_replace_op('locationId', locationId),
@@ -201,7 +201,7 @@ def test_annotation_elasticsearch(
     assert tx
     assert 'id' in tx
     taxonomy_guid = tx['id']
-    locationId = 'erehwon'
+    locationId = str(uuid.uuid4())
     patch_data = [
         utils.patch_replace_op('taxonomy', taxonomy_guid),
         utils.patch_replace_op('locationId', locationId),
@@ -277,7 +277,7 @@ def test_annotation_matching_set_macros(
     assert tx
     assert 'id' in tx
     taxonomy_guid = tx['id']
-    locationId = 'erehwon'
+    locationId = str(uuid.uuid4())
     patch_data = [
         utils.patch_replace_op('taxonomy', taxonomy_guid),
         utils.patch_replace_op('locationId', locationId),
@@ -354,7 +354,7 @@ def test_search_with_elasticsearch(
     assert tx
     assert 'id' in tx
     taxonomy_guid = tx['id']
-    locationId = 'erehwon'
+    locationId = str(uuid.uuid4())
     patch_data = [
         utils.patch_replace_op('taxonomy', taxonomy_guid),
         utils.patch_replace_op('locationId', locationId),
@@ -380,7 +380,7 @@ def test_search_with_elasticsearch(
     request.addfinalizer(annotation.delete)
     annotation.content_guid = uuid.uuid4()
 
-    # Index all users
+    # Index all annotations
     with es.session.begin(blocking=True):
         Annotation.index_all(force=True)
 

--- a/tests/modules/asset_groups/resources/utils.py
+++ b/tests/modules/asset_groups/resources/utils.py
@@ -72,15 +72,16 @@ def create_simple_asset_group_uuids(flask_app_client, user, request, test_root):
 
 # Helper that does what the above method does but for multiple files and multiple encounters in the sighting
 def create_large_asset_group_uuids(flask_app_client, user, request, test_root):
+    import uuid
+
     import tests.extensions.tus.utils as tus_utils
     from tests import utils as test_utils
 
     transaction_id, filenames = create_bulk_tus_transaction(test_root)
     uuids = {'transaction': transaction_id}
     request.addfinalizer(lambda: tus_utils.cleanup_tus_dir(transaction_id))
-    import random
 
-    locationId = random.randrange(10000)
+    locationId = str(uuid.uuid4())
     sighting_data = {
         'time': '2000-01-01T01:01:01+00:00',
         'timeSpecificity': 'time',

--- a/tests/modules/individuals/resources/test_individual_elasticsearch.py
+++ b/tests/modules/individuals/resources/test_individual_elasticsearch.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=missing-docstring
+
+import pytest
+
+from tests.modules.individuals.resources import utils as individual_utils
+from tests.utils import (
+    elasticsearch,
+    extension_unavailable,
+    module_unavailable,
+    wait_for_elasticsearch_status,
+)
+
+
+@pytest.mark.skipif(
+    module_unavailable('individuals'), reason='Individuals module disabled'
+)
+@pytest.mark.skipif(
+    extension_unavailable('elasticsearch'),
+    reason='Elasticsearch extension or module disabled',
+)
+def test_search_with_elasticsearch(
+    db, flask_app_client, researcher_1, request, test_root
+):
+    from app.extensions import elasticsearch as es
+    from app.modules.individuals.models import Individual
+    from app.modules.names.models import DEFAULT_NAME_CONTEXT
+
+    individual_1_id = individual_utils.create_individual_and_sighting(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root,
+        individual_data={
+            'names': [
+                {'context': DEFAULT_NAME_CONTEXT, 'value': 'Zebra 1'},
+                {'context': 'nickname', 'value': 'Nick'},
+            ],
+        },
+    )['individual']
+    individual_utils.create_individual_and_sighting(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root,
+        individual_data={
+            'names': [
+                {'context': 'nickname', 'value': 'Nick'},
+            ],
+        },
+    )
+    individual_utils.create_individual_and_sighting(
+        flask_app_client,
+        researcher_1,
+        request,
+        test_root,
+        individual_data={
+            'names': [
+                {'context': 'nickname', 'value': 'Nick Jr.'},
+            ],
+        },
+    )
+
+    # Index all users
+    with es.session.begin(blocking=True):
+        Individual.index_all(force=True)
+
+    # Wait for elasticsearch to catch up
+    wait_for_elasticsearch_status(flask_app_client, researcher_1)
+    assert len(Individual.elasticsearch(None, load=False)) == 3
+
+    # Search individuals (matching GUID first)
+    searchTerm = individual_1_id
+    search = {
+        'bool': {
+            'minimum_should_match': 1,
+            'should': [
+                {'match_phrase': {'guid': {'query': searchTerm}}},
+                {
+                    'query_string': {
+                        'query': '*{}*'.format(searchTerm),
+                        'fields': ['adoptionName', 'firstName'],
+                    },
+                },
+            ],
+        },
+    }
+    result_api = Individual.elasticsearch(search, load=False)
+    response = elasticsearch(flask_app_client, researcher_1, 'individuals', search)
+    result_rest = response.json
+    assert len(result_api) == 1
+    assert len(result_api) == len(result_rest)
+    assert str(result_api[0]) == result_rest[0].get('guid')
+
+    # Search individuals (matching GUID only)
+    searchTerm = individual_1_id
+    search = {
+        'bool': {
+            'minimum_should_match': 1,
+            'should': [
+                {'match_phrase': {'guid': {'query': searchTerm}}},
+            ],
+        },
+    }
+    result_api = Individual.elasticsearch(search, load=False)
+    response = elasticsearch(flask_app_client, researcher_1, 'individuals', search)
+    result_rest = response.json
+    assert len(result_api) == 1
+    assert len(result_api) == len(result_rest)
+    assert str(result_api[0]) == result_rest[0].get('guid')
+
+    # Search individuals (shouldn't match anything)
+    searchTerm = individual_1_id
+    search = {
+        'bool': {
+            'minimum_should_match': 1,
+            'should': [
+                {
+                    'query_string': {
+                        'query': '*{}*'.format(searchTerm),
+                        'fields': ['adoptionName', 'firstName'],
+                    },
+                },
+            ],
+        },
+    }
+    result_api = Individual.elasticsearch(search, load=False)
+    response = elasticsearch(flask_app_client, researcher_1, 'individuals', search)
+    result_rest = response.json
+    assert len(result_api) == 0
+    assert len(result_api) == len(result_rest)
+
+    # Search individuals (matching first name)
+    searchTerm = 'Zebra'
+    search = {
+        'bool': {
+            'minimum_should_match': 1,
+            'should': [
+                {'match_phrase': {'guid': {'query': searchTerm}}},
+                {
+                    'query_string': {
+                        'query': '*{}*'.format(searchTerm),
+                        'fields': ['adoptionName', 'firstName'],
+                    },
+                },
+            ],
+        },
+    }
+    result_api = Individual.elasticsearch(search, load=False)
+    response = elasticsearch(flask_app_client, researcher_1, 'individuals', search)
+    result_rest = response.json
+    assert len(result_api) == 1
+    assert len(result_api) == len(result_rest)
+    assert str(result_api[0]) == result_rest[0].get('guid')
+
+    # Search individuals (matching first name only)
+    searchTerm = 'Zebra'
+    search = {
+        'bool': {
+            'minimum_should_match': 1,
+            'should': [
+                {
+                    'query_string': {
+                        'query': '*{}*'.format(searchTerm),
+                        'fields': ['adoptionName', 'firstName'],
+                    },
+                },
+            ],
+        },
+    }
+    result_api = Individual.elasticsearch(search, load=False)
+    response = elasticsearch(flask_app_client, researcher_1, 'individuals', search)
+    result_rest = response.json
+    assert len(result_api) == 1
+    assert len(result_api) == len(result_rest)
+    assert str(result_api[0]) == result_rest[0].get('guid')
+
+    # Search individuals (matching GUID first)
+    searchTerm = individual_1_id
+    search = {
+        'bool': {
+            'minimum_should_match': 1,
+            'should': [
+                {
+                    'term': {
+                        'guid': searchTerm,
+                    }
+                },
+            ],
+        },
+    }
+    result_api = Individual.elasticsearch(search, load=False)
+    response = elasticsearch(flask_app_client, researcher_1, 'individuals', search)
+    result_rest = response.json
+    assert len(result_api) == 1
+    assert len(result_api) == len(result_rest)
+    assert str(result_api[0]) == result_rest[0].get('guid')

--- a/tests/modules/individuals/resources/test_individual_elasticsearch.py
+++ b/tests/modules/individuals/resources/test_individual_elasticsearch.py
@@ -61,7 +61,7 @@ def test_search_with_elasticsearch(
         },
     )
 
-    # Index all users
+    # Index all individuals
     with es.session.begin(blocking=True):
         Individual.index_all(force=True)
 

--- a/tests/modules/sightings/resources/test_sighting_elasticsearch.py
+++ b/tests/modules/sightings/resources/test_sighting_elasticsearch.py
@@ -114,7 +114,7 @@ def test_search_with_elasticsearch(
         },
     )
 
-    # Index all users
+    # Index all sightings
     with es.session.begin(blocking=True):
         Sighting.index_all(force=True)
 


### PR DESCRIPTION
This PR adds the ability to update the automatically parsed Elasticsearch schemas after creation.  The function `cls.patch_elasticsearch_mappings(mappings )` gives an indexed `HoustonModel` the ability to override the existing mappings.  The new mappings may be updated by reference or returned by the function.

```python
@classmethod
def patch_elasticsearch_mappings(cls, mappings):
    # global GUID mapping patch
    mappings = super(Encounter, cls).patch_elasticsearch_mappings(mappings)

    mappings['point'] = {
        'type': 'geo_point',
    }

    return mappings
```

This PR also gives the user the ability to sort based on Elasticsearch attributes, for example:

```python
from app.extensions import elasticsearch as es
from app.modules.users.models import User

with es.session.begin(blocking=True, forced=True):
    User.index_all()

users = User.elasticsearch(None, sort='elasticsearch.guid')
```


---

* added global schema mapping patchings for any reference of the following (converting them to the `keyword` type), including recursive replacement for nested schemas:
  * `guid`
  * `email`
  * `_schema`
  * ending with `_guid`
  * ending with `_id`
  * ending with `_Id`
  * ending with `_ID`
* added `Encoutner.point` schema mapping patchings for `geo_point`
* automatic schema patching on indexing error (assumed during the first failure to be due to a schema conflict), with automatic restoring of the documents that were in the old schema.
* adds new `es.es_create_index(cls)` and `es.es_create_index(cls)` functions to the Elasticsearch extension
* adds ability to sort Elasticsearch queries directly using the built-in Elasticsearch feature.  The `sort` property must be specified as `elasticsearch.<property>` where `<property>` is a key in the mapping for a given index.
* added testing for Elasticsearch sorting via `elasticsearch.<property>`, which will not work for listing APIs
  * when sorting on an Elasticsearch field with the listing APIs, we will default to the `<property>` attribute if it exists within Houston, else the class's default sort will be used
* added testing for `Individual`, `Sighting`, and `Annotation` matching query set ES queries as used by the frontend
* re-enabled some tests that were being skipped due to `module_unavailable('elasticsearch')`
* remove reference to `is_module_enabled('elasticsearch')` in Celery
* added `invoke app.elasticsearch.patch` to apply the ES mappings patches on an existing database
* add `deepdiff` to compare the schemas as two dictionaries