### PR TITLE
Sage sync with MIME type filtering

### DIFF
--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -175,7 +175,7 @@ class Annotation(db.Model, HoustonModel, SageModel):
             'SAGE_MIME_TYPE_WHITELIST_EXTENSIONS', []
         ):
             log.info(
-                'Cannot sync Annotation %r with unsupported SAGE MIME type %d on Asset, skipping'
+                'Cannot sync Annotation %r with unsupported SAGE MIME type %r on Asset, skipping'
                 % (
                     self,
                     self.asset.mime_type,

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -171,6 +171,18 @@ class Annotation(db.Model, HoustonModel, SageModel):
 
             return
 
+        if self.asset.mime_type not in current_app.config.get(
+            'SAGE_MIME_TYPE_WHITELIST_EXTENSIONS', []
+        ):
+            log.info(
+                'Cannot sync Annotation %r with unsupported SAGE MIME type %d on Asset, skipping'
+                % (
+                    self,
+                    self.asset.mime_type,
+                )
+            )
+            return
+
         # First, ensure that the annotation's asset has been synced with Sage
         if not skip_asset:
             self.asset.sync_with_sage(

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -284,6 +284,18 @@ class Asset(db.Model, HoustonModel, SageModel):
     def sync_with_sage(self, ensure=False, force=False, bulk_sage_uuids=None, **kwargs):
         from app.extensions.sage import from_sage_uuid
 
+        if self.mime_type not in current_app.config.get(
+            'SAGE_MIME_TYPE_WHITELIST_EXTENSIONS', []
+        ):
+            log.info(
+                'Cannot sync Asset %r with unsupported SAGE MIME type %d, skipping'
+                % (
+                    self,
+                    self.mime_type,
+                )
+            )
+            return
+
         if force:
             with db.session.begin(subtransactions=True):
                 self.content_guid = None

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -288,7 +288,7 @@ class Asset(db.Model, HoustonModel, SageModel):
             'SAGE_MIME_TYPE_WHITELIST_EXTENSIONS', []
         ):
             log.info(
-                'Cannot sync Asset %r with unsupported SAGE MIME type %d, skipping'
+                'Cannot sync Asset %r with unsupported SAGE MIME type %r, skipping'
                 % (
                     self,
                     self.mime_type,

--- a/config/base.py
+++ b/config/base.py
@@ -118,6 +118,14 @@ class BaseConfig(FlaskConfigOverrides, RedisConfig):
         'video/webm': 'webm',
     }
 
+    SAGE_MIME_TYPE_WHITELIST_EXTENSIONS = [
+        'image/bmp',
+        'image/jpeg',
+        'image/png',
+        'image/tiff',
+        'image/webp',
+    ]
+
     # specifically this is where tus "temporary" files go
     UPLOADS_DATABASE_PATH = str(DATA_ROOT / 'uploads')
     UPLOADS_TTL_SECONDS = 60 * 60 * 1


### PR DESCRIPTION
Remove Assets and Annotations from the Sage sync when they have the wrong MIME type, as specified in the base config.