### PR TITLE
1203 rerun ID takes a config

### DIFF
--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -793,6 +793,19 @@ class SightingRerunId(Resource):
     )
     def post(self, sighting):
         try:
+            req = json.loads(request.data)
+            from app.modules.asset_groups.metadata import (
+                AssetGroupMetadata,
+                AssetGroupMetadataError,
+            )
+
+            log.warning(req)
+            if isinstance(req, list) and len(req) > 0:
+                try:
+                    AssetGroupMetadata.validate_id_configs(req, 'id_configs')
+                except AssetGroupMetadataError as error:
+                    abort(error.status_code, error.message)
+                sighting.id_configs = req
             sighting.stage = SightingStage.identification
             sighting.ia_pipeline()
             return sighting.get_detailed_json()

--- a/tests/modules/sightings/resources/test_identify_sighting.py
+++ b/tests/modules/sightings/resources/test_identify_sighting.py
@@ -161,3 +161,38 @@ def test_sighting_identification(
                 progress_guids.append(str(annotation.progress_identification.guid))
 
     test_utils.wait_for_progress(flask_app, progress_guids)
+
+    # This is what the FE sends and it is process (now) by the BE but is not yet a valid test as this does not
+    # result in ID being rerun.
+    rerun_id_data = [
+        {
+            'algorithms': ['hotspotter_nosv'],
+            'matching_set': {
+                'bool': {
+                    'filter': [
+                        {
+                            'bool': {
+                                'minimum_should_match': 1,
+                                'should': [
+                                    {
+                                        'match_phrase': {
+                                            'locationId': 'c74ff3e3-d0f5-4930-8c3a-68f2b172b655'
+                                        }
+                                    }
+                                ],
+                            }
+                        },
+                        {'bool': '_MACRO_annotation_neighboring_viewpoints_clause'},
+                        {'exists': {'field': 'encounter_guid'}},
+                    ],
+                    'must_not': {
+                        'match': {'encounter_guid': '_MACRO_annotation_encounter_guid'}
+                    },
+                }
+            },
+        }
+    ]
+
+    sighting_utils.write_sighting_path(
+        flask_app_client, researcher_1, f'{sighting_uuid}/rerun_id', rerun_id_data
+    )


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Now takes the config from the user and reruns ID with that config 
- Issues:
    - Current test was based on what FE sends but this does not result in any annots found in the matching set
    - FE currently sends this id_config as a list of length 1. The BE replaces the sighting ID configs list. 
        - It would be much better in this case if the FE sent a single ID Config. That way the BE could just add one more ID config and rerun ID with that.
        - To keep this change as low risk as possible this close to release, this has not been implemented.

