### PR TITLE
Fix Sort Ordering with Empty Data

### DIFF
--- a/app/extensions/elasticsearch/__init__.py
+++ b/app/extensions/elasticsearch/__init__.py
@@ -5,6 +5,7 @@ import enum
 import json
 import logging
 import pprint
+import sys
 import time
 import types
 import uuid
@@ -35,6 +36,8 @@ CELERY_VERIFY_TIMEOUT = 60.0
 CELERY_ASYNC_PROMISES = []
 
 ELASTICSEARCH_SORTING_PREFIX = 'elasticsearch.'
+
+MAX_UNICODE_CODE_POINT_CHAR = chr(int(hex(sys.maxunicode), 16))
 
 log = logging.getLogger('elasticsearch')  # pylint: disable=invalid-name
 

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -256,9 +256,11 @@ class Individual(db.Model, FeatherModel):
         return first_name
 
     def get_first_name_keyword(self):
+        from app.extensions.elasticsearch import MAX_UNICODE_CODE_POINT_CHAR
+
         first_name = self.get_first_name()
         if first_name is None:
-            first_name = ''
+            first_name = MAX_UNICODE_CODE_POINT_CHAR
         first_name_keyword = first_name.strip().lower()
         return first_name_keyword
 

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -229,9 +229,11 @@ class Sighting(db.Model, FeatherModel):
         return location_id_value
 
     def get_location_id_keyword(self):
+        from app.extensions.elasticsearch import MAX_UNICODE_CODE_POINT_CHAR
+
         location_id_value = self.get_location_id_value()
         if location_id_value is None:
-            location_id_value = ''
+            location_id_value = MAX_UNICODE_CODE_POINT_CHAR
         location_id_keyword = location_id_value.strip().lower()
         return location_id_keyword
 


### PR DESCRIPTION
Use maximum Unicode code point as the default sort value for empty values in Elasticsearch, replacing empty string.  The change in this PR will move empty data from the start to the end of a sorted list

I have verified that the sort ordering works as expected after indexing these tables.

```python
In [2]: import sys
   ...: MAX_UNICODE_CODE_POINT_CHAR = chr(int(hex(sys.maxunicode), 16))

In [3]: MAX_UNICODE_CODE_POINT_CHAR
Out[3]: '\U0010ffff'

In [4]: MAX_UNICODE_CODE_POINT_CHAR.lower()
Out[4]: '\U0010ffff'
```