### PR TITLE
Remove Path Check on Release Action

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -2,13 +2,9 @@ name: Docker
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/nightly.yml'
-      - 'scripts/**'
+    branches:
+      - main
   push:
-    paths:
-      - '.github/workflows/nightly.yml'
-      - 'scripts/**'
     branches:
       - main
     tags:


### PR DESCRIPTION
Updates the Docker release action's triggers

```yaml
on:
  pull_request:
    branches:
      - main
  push:
    branches:
      - main
    tags:
      - v*
  schedule:
    - cron: '0 16 * * *' # Every day at 16:00 UTC (~09:00 PT)
```