### PR TITLE
DEX-1191: admin role mapping

### DIFF
--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -97,6 +97,11 @@ if is_extension_enabled('edm'):
                 log.info('manager role found, setting is_user_manager, is_data_manager')
                 self.is_user_manager = True
                 self.is_data_manager = True
+            if 'admin' in roles:
+                log.info('admin role found, setting is_user_manager, is_admin')
+                self.is_user_manager = True
+                self.is_admin = True
+
 
 else:
     UserEDMMixin = object


### PR DESCRIPTION
## Pull Request Overview

- additional old-to-new-world mapping of roles during user-migration, per DEX-1191: `admin` -> `is_user_manager` + `is_admin`
