### PR TITLE
Store houston logs in the filesystem DEX-1064

### DIFF
--- a/.dockerfiles/docker-entrypoint.sh
+++ b/.dockerfiles/docker-entrypoint.sh
@@ -121,6 +121,15 @@ _main() {
 			# check dir permissions to reduce likelihood of half-initialized database
 			ls ${DATA_ROOT}/ > /dev/null
 
+			# Ensure the log file directory has the correct permissions
+			if [ -n "${LOG_FILE}" ]; then
+				LOG_DIR=$(dirname ${LOG_FILE})
+			else
+				LOG_DIR="./logs"
+			fi
+			mkdir -p $LOG_DIR
+			chown -R nobody:nogroup ${LOG_DIR}
+
 			# Have the application initialize the data location and database
 			# FIXME: `--no-backup` is necessary because this apparently has the side-effect
 			#        of doing doing a backup for a database it may not know how to backup.

--- a/.dockerignore
+++ b/.dockerignore
@@ -42,3 +42,5 @@ __pycache__
 cookie.jar
 pip-wheel-metadata/
 local_config.py.template
+
+logs/*

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ __pycache__/
 pip-log.txt
 pip-delete-this-directory.txt
 
+# Application logs
+logs/*
+
 # Unit test / coverage reports
 htmlcov/
 .tox/

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -102,7 +102,6 @@ if is_extension_enabled('edm'):
                 self.is_user_manager = True
                 self.is_admin = True
 
-
 else:
     UserEDMMixin = object
 

--- a/docker-compose.codex.yml
+++ b/docker-compose.codex.yml
@@ -263,6 +263,7 @@ services:
       - "83:5000"
     environment: &houston-environment
       HOUSTON_APP_CONTEXT: codex
+      LOG_FILE: "/data/var/logs/houston.codex.log"
       # exposed service is 'localhost' using port 84
       SERVER_NAME: "${SERVER_NAME}"
       PREFERRED_URL_SCHEME: "${PREFERRED_URL_SCHEME}"

--- a/docker-compose.mws.yml
+++ b/docker-compose.mws.yml
@@ -230,6 +230,7 @@ services:
       - "83:5000"
     environment: &houston-environment
       HOUSTON_APP_CONTEXT: mws
+      LOG_FILE: "/data/var/logs/houston.mws.log"
       # exposed service is 'localhost' using port 84
       SERVER_NAME: "${SERVER_NAME}"
       PREFERRED_URL_SCHEME: "${PREFERRED_URL_SCHEME}"

--- a/docs/docker_compose_debugging.md
+++ b/docs/docker_compose_debugging.md
@@ -1,10 +1,10 @@
 # Docker compose debugging
 
-## Installing Docker 
+## Installing Docker
 
 One way to install Docker along with all the necessary tools (such as docker-compose) is to install [Docker Desktop](https://www.docker.com/products/docker-desktop/). This will also give you a user interface that will prove helpful for debugging, especially if you are not experienced with Docker.
 
-## Resource requirements 
+## Resource requirements
 
 You must ensure that Docker has sufficient resources to run Codex. The default resource allocations are probably not sufficient - you can update the them in Docker Desktop under Settings -> Resources. The following minimum resource allocations are known to work:
 
@@ -15,15 +15,15 @@ Disk image size - 60GB
 
 Note that on Windows resource allocations cannot be set from the Docker Desktop UI, please see the Windows section below for more details.
 
-## Elasticsearch container crashing 
+## Elasticsearch container crashing
 
 There is a known issue that might be causing your ES container to crash. Read more about it in our [Elasticsearch Docs](https://docs.wildme.org/docs/developers/elasticsearch#1--sysctl-resource-limits).
 
-## Windows 
+## Windows
 
 The best way to run docker-compose on Windows is using WSL2. Use the [official documentation](https://docs.microsoft.com/en-us/windows/wsl/install) to install WSL2 and one of the Linux distributions. The latest stable release of Ubuntu is known to work.
 
-Tip: clone houston and codex-frontend (if using) into a folder on the Linux subsystem. While it may seem like you can interact with files and folders outside of the subsystem normally, issues will arise when Docker attempts to use them. 
+Tip: clone houston and codex-frontend (if using) into a folder on the Linux subsystem. While it may seem like you can interact with files and folders outside of the subsystem normally, issues will arise when Docker attempts to use them.
 
 When using WSL2, resource allocations are set for the Linux subsystem and inherited by Docker. These can be set using a `.wslconfig` file stored in the home directory. The following file contents will work, but you can also browse [Microsoft's wslconfig documentation](https://docs.microsoft.com/en-us/windows/wsl/wsl-config) for more configuration options.
 

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -5,8 +5,20 @@ The starting point of Invoke tasks for Houston.
 """
 
 import logging
+import logging.handlers
 import os
 import platform
+
+FORMAT = '[%(name)s] %(message)s'
+logging_config = {'level': logging.DEBUG, 'format': FORMAT, 'datefmt': '[%X]'}
+handlers = [
+    logging.handlers.TimedRotatingFileHandler(
+        filename=os.getenv('LOG_FILE', 'logs/houston.log'),
+        when='midnight',
+        backupCount=int(os.getenv('LOG_FILE_BACKUP_COUNT', 30)),
+    ),
+]
+
 
 try:
     import rich
@@ -46,15 +58,11 @@ try:
         console_kwargs['soft_wrap'] = True
 
     rich.reconfigure(**console_kwargs)
-    handler = RichHandler(**handler_kwargs)
-
-    FORMAT = '[%(name)s] %(message)s'
-    logging.basicConfig(
-        level=logging.DEBUG, format=FORMAT, datefmt='[%X]', handlers=[handler]
-    )
+    handlers.append(RichHandler(**handler_kwargs))
 except ImportError:  # pragma: no cover
-    logging.basicConfig()
+    print('Unable to load Rich for logging')
 
+logging.basicConfig(handlers=handlers, **logging_config)
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 # logging.getLogger('app').setLevel(logging.DEBUG)

--- a/tests/modules/individuals/resources/test_individual_elasticsearch.py
+++ b/tests/modules/individuals/resources/test_individual_elasticsearch.py
@@ -75,7 +75,7 @@ def test_search_with_elasticsearch(
         'bool': {
             'minimum_should_match': 1,
             'should': [
-                {'term': {'guid':  searchTerm}},
+                {'term': {'guid': searchTerm}},
                 {
                     'query_string': {
                         'query': '*{}*'.format(searchTerm),
@@ -136,7 +136,7 @@ def test_search_with_elasticsearch(
         'bool': {
             'minimum_should_match': 1,
             'should': [
-                {'term': {'guid':  searchTerm}},
+                {'term': {'guid': searchTerm}},
                 {
                     'query_string': {
                         'query': '*{}*'.format(searchTerm),


### PR DESCRIPTION
By default, store logs in `logs/houston.log`, at midnight, move to
`logs/houston.log.<year>-<month>-<day>`, and 30 log files are stored.

