### PR TITLE
Fix a broken template url name reference

### DIFF
--- a/app/modules/app_ui.py
+++ b/app/modules/app_ui.py
@@ -178,7 +178,7 @@ def user_logout_frontend(refer=None, *args, **kwargs):
     return user_logout_shared('frontend.user_login', refer=refer, *args, **kwargs)
 
 
-@backend_blueprint.route('/logout', methods=['GET', 'POST'])
+@backend_blueprint.route('/logout', methods=['GET', 'POST'], endpoint='user_logout')
 @login_required
 def user_logout_backend(refer=None, *args, **kwargs):
     # pylint: disable=unused-argument

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -409,6 +409,7 @@ def admin_user(temp_db_instance_helper):
     for _ in temp_db_instance_helper(
         utils.generate_user_instance(
             email='admin@localhost',
+            password='Pas$w0rd',
             is_admin=True,
         )
     ):

--- a/tests/modules/app_ui/resources/test_general_access.py
+++ b/tests/modules/app_ui/resources/test_general_access.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
+import re
+from urllib.parse import urlparse
+
 import pytest
+from flask import url_for
 
 
 @pytest.mark.parametrize(
@@ -16,3 +20,25 @@ def test_frontend_page_loads(http_method, http_path, flask_app_client):
     response = flask_app_client.open(method=http_method, path=http_path)
     print(response)
     assert response.status_code == 200
+
+
+def test_login_logout(flask_app, admin_user):
+    client = flask_app.test_client()
+    resp = client.get(url_for('backend.home'))
+    content = resp.get_data().decode('utf-8')
+
+    login_form_url = re.search('action="([^"]*)"', content).group(1)
+    resp = client.post(
+        login_form_url, data={'email': admin_user.email, 'password': 'Pas$w0rd'}
+    )
+    assert resp.status_code == 302
+    assert resp.headers['Location'] == url_for('backend.home')
+
+    resp = client.get(url_for('backend.home'))
+    content = resp.get_data().decode('utf-8')
+    assert 'Hello, First Middle Last' in content
+    assert urlparse(url_for('backend.user_logout')).path in content
+
+    resp = client.get(url_for('backend.user_logout'))
+    assert resp.status_code == 302
+    assert resp.headers['Location'] == url_for('backend.user_login')


### PR DESCRIPTION
Fixes the reference to
`app/templates/home.logout.jinja2:7:    <a href="{{ url_for('backend.user_logout') }}">`.

This likely went unnoticed when changes to add the frontend endpoints
where added, which would have changed the name of this function from
`user_logout` to `user_logout_backend`.

Resolves https://sentry.dyn.wildme.io/organizations/wildme/issues/510/?project=8, which is seen in both staging and production.