### PR TITLE
Always run data directories creation code in docker-entrypoint.sh

### DIFF
--- a/.dockerfiles/docker-entrypoint.sh
+++ b/.dockerfiles/docker-entrypoint.sh
@@ -113,23 +113,24 @@ _main() {
 		if [ _is_development_env ]; then
 			set_up_development_mode
 		fi
+
+		mkdir -p ${DATA_ROOT}
+		# fix permissions on the data directory
+		chown -R nobody:nogroup ${DATA_ROOT}
+		# check dir permissions to reduce likelihood of half-initialized database
+		ls ${DATA_ROOT}/ > /dev/null
+
+		# Ensure the log file directory has the correct permissions
+		if [ -n "${LOG_FILE}" ]; then
+			LOG_DIR=$(dirname ${LOG_FILE})
+		else
+			LOG_DIR="./logs"
+		fi
+		mkdir -p $LOG_DIR
+		chown -R nobody:nogroup ${LOG_DIR}
+
 		# only run initialization on an empty data directory
 		if [ -z "$ALREADY_INITIALIZED" ]; then
-			mkdir -p ${DATA_ROOT}
-			# fix permissions on the data directory
-			chown -R nobody:nogroup ${DATA_ROOT}
-			# check dir permissions to reduce likelihood of half-initialized database
-			ls ${DATA_ROOT}/ > /dev/null
-
-			# Ensure the log file directory has the correct permissions
-			if [ -n "${LOG_FILE}" ]; then
-				LOG_DIR=$(dirname ${LOG_FILE})
-			else
-				LOG_DIR="./logs"
-			fi
-			mkdir -p $LOG_DIR
-			chown -R nobody:nogroup ${LOG_DIR}
-
 			# Have the application initialize the data location and database
 			# FIXME: `--no-backup` is necessary because this apparently has the side-effect
 			#        of doing doing a backup for a database it may not know how to backup.


### PR DESCRIPTION
The original problem was log files directory was created only if the
houston volume was not initialized, which means people have to clear
their houston volume for the log files directory to be created.  I've
changed it so the log files directory creation code is run whether the
houston volume is initialized or not.

The code includes changing the owner of the data directories to nobody
so the app can write to it.  The code used to be inside the "not already
initialized" block, but really it can run every time.

