### PR TITLE
DEX-1279: no email verification for first admin user

### DIFF
--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -102,6 +102,7 @@ if is_extension_enabled('edm'):
                 self.is_user_manager = True
                 self.is_admin = True
 
+
 else:
     UserEDMMixin = object
 
@@ -579,6 +580,15 @@ class User(db.Model, FeatherModel, UserEDMMixin):
         if code is None:
             return False
         return code.is_resolved
+
+    # creates email code and resolves it so above returns true
+    def bypass_email_confirmation(self):
+        import datetime
+
+        code = self.get_email_confirmation_code()
+        code.response = datetime.datetime.now()
+        with db.session.begin():
+            db.session.merge(code)
 
     @property
     def owned_missions(self):

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -583,12 +583,10 @@ class User(db.Model, FeatherModel, UserEDMMixin):
 
     # creates email code and resolves it so above returns true
     def bypass_email_confirmation(self):
-        import datetime
+        from app.modules.auth.models import CodeDecisions
 
         code = self.get_email_confirmation_code()
-        code.response = datetime.datetime.now()
-        with db.session.begin():
-            db.session.merge(code)
+        code.record(CodeDecisions.accept)
 
     @property
     def owned_missions(self):

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -321,7 +321,9 @@ class AdminUserInitialized(Resource):
                 in_beta=True,
                 in_alpha=True,
                 update=True,
+                send_verification=False,
             )
+            admin.bypass_email_confirmation()
             log.info(
                 'Success creating startup (houston) admin user via API: {!r}.'.format(
                     admin


### PR DESCRIPTION
When new codex is initialized and new admin user is created, this bypasses the requirement of this first user needing to verify their email address before logging in.