### PR TITLE
DEX-1174 Return sighting time if encounter time is missing in BaseEncounterSchema

### DIFF
--- a/app/modules/encounters/models.py
+++ b/app/modules/encounters/models.py
@@ -165,12 +165,9 @@ class Encounter(db.Model, FeatherModel):
             taxonomy_guid = self.sighting.get_taxonomy_guid()
         return taxonomy_guid
 
-    def get_time_isoformat_in_timezone(self, sighting_fallback=False):
-        if self.time:
-            return self.time.isoformat_in_timezone()
-        if self.sighting and sighting_fallback:
-            return self.sighting.get_time_isoformat_in_timezone()
-        return None
+    def get_time_isoformat_in_timezone(self, sighting_fallback=True):
+        time = self.get_time(sighting_fallback=sighting_fallback)
+        return time.isoformat_in_timezone() if time else None
 
     def get_time(self, sighting_fallback=True):
         if self.time:
@@ -179,8 +176,9 @@ class Encounter(db.Model, FeatherModel):
             return self.sighting.time
         return None
 
-    def get_time_specificity(self):
-        return self.time.specificity if self.time else None
+    def get_time_specificity(self, sighting_fallback=True):
+        time = self.get_time(sighting_fallback=sighting_fallback)
+        return time.specificity if time else None
 
     # this does the heavy lifting of trying to set time from user-provided data
     def set_time_from_data(self, data):

--- a/app/modules/encounters/schemas.py
+++ b/app/modules/encounters/schemas.py
@@ -21,8 +21,8 @@ class BaseEncounterSchema(ModelSchema):
     owner = base_fields.Nested('PublicUserSchema', many=False)
     hasView = base_fields.Function(Encounter.current_user_has_view_permission)
     hasEdit = base_fields.Function(Encounter.current_user_has_edit_permission)
-    time = base_fields.Function(Encounter.get_time_isoformat_in_timezone)
-    timeSpecificity = base_fields.Function(Encounter.get_time_specificity)
+    time = base_fields.Function(lambda enc: enc.get_time_isoformat_in_timezone())
+    timeSpecificity = base_fields.Function(lambda enc: enc.get_time_specificity())
 
     class Meta:
         # pylint: disable=missing-docstring

--- a/tests/modules/encounters/resources/test_modify_encounter.py
+++ b/tests/modules/encounters/resources/test_modify_encounter.py
@@ -540,6 +540,7 @@ def test_create_encounter_time_test(
 def test_mix_edm_houston_patch(
     flask_app, flask_app_client, researcher_1, request, test_root
 ):
+    sighting_time = '2000-01-01T01:01:01+00:00'
     uuids = enc_utils.create_encounter(flask_app_client, researcher_1, request, test_root)
     encounter_guid = uuids['encounters'][0]
 
@@ -563,6 +564,7 @@ def test_mix_edm_houston_patch(
         == 'org.ecocean.api.ApiValueException: invalid longitude value'
     )
     assert 'decimalLatitude' not in read_resp.json.keys()
+    assert read_resp.json['time'] == sighting_time
 
     # Houston only patch
     new_time = datetime.datetime.now().isoformat() + '+00:00'
@@ -578,7 +580,7 @@ def test_mix_edm_houston_patch(
     )
     read_resp = enc_utils.read_encounter(flask_app_client, researcher_1, encounter_guid)
     assert 'Failed to update Encounter details.' in patch_resp.json['message']
-    assert read_resp.json['time'] is None
+    assert read_resp.json['time'] == sighting_time
 
     # Houston and EDM patch
     lat = utils.random_decimal_latitude()
@@ -613,3 +615,4 @@ def test_mix_edm_houston_patch(
     ]
     assert read_resp.json['decimalLatitude'] == str(lat)
     assert read_resp.json['decimalLongitude'] == str(long)
+    assert read_resp.json['time'] == sighting_time

--- a/tests/modules/individuals/resources/test_individual_crud.py
+++ b/tests/modules/individuals/resources/test_individual_crud.py
@@ -227,6 +227,15 @@ def test_add_remove_encounters(db, flask_app_client, researcher_1, request, test
         str(encounter.guid) for encounter in individual_1.get_encounters()
     ]
 
+    # Check individual encounters times (which are null and should
+    # return the sighting time)
+    individual_json = individual_utils.read_individual(
+        flask_app_client, researcher_1, individual_1.guid
+    ).json
+    for encounter in individual_json['encounters']:
+        assert encounter['timeSpecificity'] == 'time'
+        assert encounter['time'] == test_time
+
     # removing all encounters will trigger delete cascade and clean up EDM
     # hack because sighting patch only takes one ID for remove. another PR for another day.
     enc_guids = [str(enc_2.guid), str(enc_3.guid), str(enc_4.guid)]


### PR DESCRIPTION
When the encounter time is null, we are supposed to return the sighting
time. But that wasn't the case in the individual API.

The individual API uses `AugmentedEdmEncounterSchema` which uses
`Encounter.get_time_isoformat_in_timezone` and
`Encounter.get_time_specificity` for the time and time specificity.
Those methods should use `Encounter.get_time` with
`sighting_fallback=True` in order to fix this.

The change from:

```
time = base_fields.Function(Encounter.get_time_isoformat_in_timezone)
```

to

```
time = base_fields.Function(lambda enc: enc.get_time_isoformat_in_timezone())
```

is necessary because in the first case, `sighting_fallback` is `{}` for
some reason, in the second case, `sighting_fallback` is `True` as
expected.

