### PR TITLE
DEX-798 Include individuals count in merge complete email

### DIFF
--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -740,7 +740,9 @@ class Individual(db.Model, FeatherModel):
             'merge_outcome': 'deadline',
         }
         Individual.merge_notify(
-            [target_individual], request_data, NotificationType.individual_merge_complete
+            [target_individual] + all_individuals,
+            request_data,
+            NotificationType.individual_merge_complete,
         )
 
     # note: this will destructively remove names from source_individuals

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -745,7 +745,9 @@ class IndividualMergeRequestByTaskId(Resource):
             'merge_outcome': 'unanimous',
         }
         Individual.merge_notify(
-            [target_individual], request_data, NotificationType.individual_merge_complete
+            [target_individual] + all_individuals,
+            request_data,
+            NotificationType.individual_merge_complete,
         )
         return {'vote': vote, 'merge_completed': True}
 

--- a/app/modules/notifications/models.py
+++ b/app/modules/notifications/models.py
@@ -237,13 +237,28 @@ class NotificationBuilder(object):
                 self.data['target_individual_name'] = indiv.get_primary_name()
             else:
                 source_names.append(indiv.get_primary_name())
-        self.data['source_names_list'] = ', '.join(source_names)
         self.data['other_individuals'] = []
 
         for indiv in other_individuals:
             ind_data = {'guid': indiv.guid, 'primaryName': indiv.get_primary_name()}
             self.data['other_individuals'].append(ind_data)
+            source_names.append(indiv.get_primary_name())
         self.data['request_id'] = request_data.get('id')
+        uuid_names = []
+        for source_name in source_names:
+            try:
+                uuid_names.append(uuid.UUID(source_name))
+            except ValueError:
+                pass
+        if uuid_names:
+            # If any individuals have a uuid name, skip the name listing and
+            # just use number of individuals
+            if len(source_names) == 1:
+                self.data['source_names_list'] = f'{len(source_names)} individual'
+            else:
+                self.data['source_names_list'] = f'{len(source_names)} individuals'
+        else:
+            self.data['source_names_list'] = ', '.join(source_names)
         deadline_datetime = request_data.get('deadline')
         if deadline_datetime:
             self.data['deadline'] = deadline_datetime.isoformat() + 'Z'


### PR DESCRIPTION
The individual merge complete email subject looked like "Archibald and
have been merged".  The `source_names_list` which should contain the
other individuals names was empty.

After individuals have been merged, the other individuals appear to lose
their primary names so we can't use their names, instead we'll say
"Archibald and 1 individual have been merged".

