### PR TITLE
1182 seal ia config

### DIFF
--- a/app/modules/ia_config_reader.py
+++ b/app/modules/ia_config_reader.py
@@ -20,6 +20,13 @@ def _link_destination(link_str):
     return destination
 
 
+# gets the lookup key for a taxonomy string
+def _get_species_key(genus_species):
+    # only replace first space, because additional spaces indicate 'species subspecies' which is a single key with a space. This allows us to distinguish between a subspecies and an ia class under a species.
+    key = genus_species.replace(' ', '.', 1)
+    return key
+
+
 class IaConfig:
     def __init__(self, name='zebra'):
         self.name = name
@@ -56,7 +63,7 @@ class IaConfig:
         return detector_config
 
     def get_detectors_with_links(self, genus_species):
-        species_key = genus_species.replace(' ', '.')
+        species_key = _get_species_key(genus_species)
         detectors_key = f'{species_key}._detectors'
         detectors = self.get(detectors_key)
         return detectors
@@ -72,7 +79,7 @@ class IaConfig:
         return detectors_dict
 
     def get_identifiers_with_links(self, genus_species, ia_class):
-        species_key = genus_species.replace(' ', '.')
+        species_key = _get_species_key(genus_species)
         identifiers_key = f'{species_key}.{ia_class}._identifiers'
         identifiers = self.get(identifiers_key)
         return identifiers
@@ -119,7 +126,7 @@ class IaConfig:
         return species
 
     def get_supported_ia_classes(self, genus_species):
-        species_key = genus_species.replace(' ', '.')
+        species_key = _get_species_key(genus_species)
         ia_classes = [key for key in self.get(species_key) if not key.startswith('_')]
         return ia_classes
 
@@ -147,7 +154,7 @@ class IaConfig:
     # if an itis-id is missing? Current thinking is, if we're using those fields
     # on the frontend they are required, so this would error if they are missing.
     def get_frontend_species_summary(self, genus_species):
-        species_key = genus_species.replace(' ', '.')
+        species_key = _get_species_key(genus_species)
         id_algos = self.get_supported_id_algos(genus_species)
         for algo in id_algos:
             id_algos[algo] = id_algos[algo]['frontend']

--- a/ia-configs/IA.seal.json
+++ b/ia-configs/IA.seal.json
@@ -1,9 +1,9 @@
 {
-  "_README": "A value starting with '@' indicates an absolute path from the top of this config file, and parsing that @-link results in the value of that absolute path. The first half of this file (top-level _detectors and _identifiers) defines the various algorithms we use, including the configs we send to SAGE and some metadata about each config. Each algo config is under a name-key, e.g. the african_terrestrial detector.  \n The second half of the file defines the pipeline for each species by referencing the previously-defined algorithms, in the hierachy genus->species->detectors, and genus->species->iaClass->identifiers. The values of these species configurations should be @-links but literals are also supported by the parser.",
+  "_README": "A value starting with '@' indicates an absolute path from the top of this config file, and parsing that @-link results in the value of that absolute path. The first half of this file (top-level _detectors and _identifiers) defines the various algorithms we use, including the configs we send to SAGE and some metadata about each config. Each algo config is under a name-key, e.g. the african_terrestrial detector.  \n The second half of the file defines the pipeline for each species by referencing the previously-defined algorithms, in the hierachy genus->species->detectors, and genus->species->iaClass->identifiers. Subspecies are included in a single species key with a space, eg Genus->species subspecies-><content>, in order to distinguish subspecies from ia classes. The values of these species configurations should be @-links but literals are also supported by the parser.",
   "Halichoerus": {
     "grypus": {
       "_common_name": "gray seal",
-      "_default": "@Halichoerus.grypus.seal",
+      "_default": "@Halichoerus.grypus.grey_seal_unknown",
       "_detectors": [
         "@_detectors.seals_v0"
       ],
@@ -24,7 +24,7 @@
   "Monachus": {
     "monachus": {
       "_common_name": "Mediterranean monk seal",
-      "_default": "@Monachus.monachus.seal",
+      "_default": "@Monachus.monachus.mediterranean_monk_seal",
       "_detectors": [
         "@_detectors.seals_v0"
       ],
@@ -66,7 +66,7 @@
   "Phoca": {
     "vitulina": {
       "_common_name": "harbor seal",
-      "_default": "@Phoca.vitulina.seal",
+      "_default": "@Phoca.vitulina.harbour_seal",
       "_detectors": [
         "@_detectors.seals_v0"
       ],
@@ -117,8 +117,7 @@
         "sensitivity": 0.63,
         "use_labeler_species": true
       },
-      "description": "Trained on grey seals, hawaiian monk seals, and mediterranean monk seals, giraffes, lions, hyenas, leopards, cheetahs, and wild dogs.",
-      "name": "Seal detector"
+      "description": "Trained on grey seals, harbor seals, hawaiian monk seals, and mediterranean monk seals"
     }
   },
   "_identifiers": {

--- a/ia-configs/IA.seal.json
+++ b/ia-configs/IA.seal.json
@@ -1,0 +1,136 @@
+{
+  "_README": "A value starting with '@' indicates an absolute path from the top of this config file, and parsing that @-link results in the value of that absolute path. The first half of this file (top-level _detectors and _identifiers) defines the various algorithms we use, including the configs we send to SAGE and some metadata about each config. Each algo config is under a name-key, e.g. the african_terrestrial detector.  \n The second half of the file defines the pipeline for each species by referencing the previously-defined algorithms, in the hierachy genus->species->detectors, and genus->species->iaClass->identifiers. The values of these species configurations should be @-links but literals are also supported by the parser.",
+  "Halichoerus": {
+    "grypus": {
+      "_common_name": "gray seal",
+      "_default": "@Halichoerus.grypus.seal",
+      "_detectors": [
+        "@_detectors.seals_v0"
+      ],
+      "_itis_id": 180653,
+      "grey_seal_femaleyoung": "@Halichoerus.grypus.grey_seal_unknown",
+      "grey_seal_male": "@Halichoerus.grypus.grey_seal_unknown",
+      "grey_seal_pup": "@Halichoerus.grypus.grey_seal_unknown",
+      "grey_seal_unknown": {
+        "_identifiers": [
+          "@_identifiers.hotspotter"
+        ]
+      },
+      "harbour_seal": "@Halichoerus.grypus.grey_seal_unknown",
+      "hawaiian_monk_seal": "@Halichoerus.grypus.grey_seal_unknown",
+      "mediterranean_monk_seal": "@Halichoerus.grypus.grey_seal_unknown"
+    }
+  },
+  "Monachus": {
+    "monachus": {
+      "_common_name": "Mediterranean monk seal",
+      "_default": "@Monachus.monachus.seal",
+      "_detectors": [
+        "@_detectors.seals_v0"
+      ],
+      "_itis_id": 180659,
+      "grey_seal_femaleyoung": "@Monachus.monachus.mediterranean_monk_seal",
+      "grey_seal_male": "@Monachus.monachus.mediterranean_monk_seal",
+      "grey_seal_pup": "@Monachus.monachus.mediterranean_monk_seal",
+      "grey_seal_unknown": "@Monachus.monachus.mediterranean_monk_seal",
+      "harbour_seal": "@Monachus.monachus.mediterranean_monk_seal",
+      "hawaiian_monk_seal": "@Monachus.monachus.mediterranean_monk_seal",
+      "mediterranean_monk_seal": {
+        "_identifiers": [
+          "@_identifiers.hotspotter"
+        ]
+      }
+    }
+  },
+  "Neomonachus": {
+    "schauinslandi": {
+      "_common_name": "Hawaiian monk seal",
+      "_default": "@Neomonachus.schauinslandi.hawaiian_monk_seal",
+      "_detectors": [
+        "@_detectors.seals_v0"
+      ],
+      "_itis_id": 1133135,
+      "grey_seal_femaleyoung": "@Neomonachus.schauinslandi.hawaiian_monk_seal",
+      "grey_seal_male": "@Neomonachus.schauinslandi.hawaiian_monk_seal",
+      "grey_seal_pup": "@Neomonachus.schauinslandi.hawaiian_monk_seal",
+      "grey_seal_unknown": "@Neomonachus.schauinslandi.hawaiian_monk_seal",
+      "harbour_seal": "@Neomonachus.schauinslandi.hawaiian_monk_seal",
+      "hawaiian_monk_seal": {
+        "_identifiers": [
+          "@_identifiers.hotspotter"
+        ]
+      },
+      "mediterranean_monk_seal": "@Neomonachus.schauinslandi.hawaiian_monk_seal"
+    }
+  },
+  "Phoca": {
+    "vitulina": {
+      "_common_name": "harbor seal",
+      "_default": "@Phoca.vitulina.seal",
+      "_detectors": [
+        "@_detectors.seals_v0"
+      ],
+      "_itis_id": 180649,
+      "grey_seal_femaleyoung": "@Phoca.vitulina.harbour_seal",
+      "grey_seal_male": "@Phoca.vitulina.harbour_seal",
+      "grey_seal_pup": "@Phoca.vitulina.harbour_seal",
+      "grey_seal_unknown": "@Phoca.vitulina.harbour_seal",
+      "harbour_seal": {
+        "_identifiers": [
+          "@_identifiers.hotspotter"
+        ]
+      },
+      "hawaiian_monk_seal": "@Phoca.vitulina.harbour_seal",
+      "mediterranean_monk_seal": "@Phoca.vitulina.harbour_seal"
+    }
+  },
+  "Pusa": {
+    "hispida saimensis": {
+      "_common_name": "Saimaa seal",
+      "_default": "@Pusa.hispida saimensis.seal",
+      "_detectors": [
+        "@_detectors.seals_v0"
+      ],
+      "_itis_id": 622064,
+      "grey_seal_femaleyoung": "@Pusa.hispida saimensis.seal",
+      "grey_seal_male": "@Pusa.hispida saimensis.seal",
+      "grey_seal_pup": "@Pusa.hispida saimensis.seal",
+      "grey_seal_unknown": "@Pusa.hispida saimensis.seal",
+      "harbour_seal": "@Pusa.hispida saimensis.seal",
+      "hawaiian_monk_seal": "@Pusa.hispida saimensis.seal",
+      "mediterranean_monk_seal": "@Pusa.hispida saimensis.seal",
+      "seal": {
+        "_identifiers": [
+          "@_identifiers.hotspotter"
+        ]
+      }
+    }
+  },
+  "_detectors": {
+    "seals_v0": {
+      "config_dict": {
+        "labeler_algo": "densenet",
+        "labeler_model_tag": "seals_v0",
+        "model_tag": "seals_v0",
+        "nms_aware": null,
+        "nms_thresh": 0.4,
+        "sensitivity": 0.63,
+        "use_labeler_species": true
+      },
+      "description": "Trained on grey seals, hawaiian monk seals, and mediterranean monk seals, giraffes, lions, hyenas, leopards, cheetahs, and wild dogs.",
+      "name": "Seal detector"
+    }
+  },
+  "_identifiers": {
+    "hotspotter": {
+      "frontend": {
+        "description": "HotSpotter pattern-matcher"
+      },
+      "sage": {
+        "query_config_dict": {
+          "sv_on": true
+        }
+      }
+    }
+  }
+}

--- a/tests/modules/test_ia_config.py
+++ b/tests/modules/test_ia_config.py
@@ -150,3 +150,55 @@ def test_get_detect_model_frontend_data(flask_app_client):
     }
     frontend_data = ia_config_reader.get_detect_model_frontend_data()
     assert frontend_data == desired_frontend_data
+
+
+def test_get_seal_species(flask_app_client):
+    ia_config_reader = IaConfig('seal')
+    species = ia_config_reader.get_configured_species()
+    desired_species = [
+        'Halichoerus grypus',
+        'Monachus monachus',
+        'Neomonachus schauinslandi',
+        'Phoca vitulina',
+        'Pusa hispida saimensis',
+    ]
+    assert set(species) == set(desired_species)
+
+
+def test_get_seal_detectors(flask_app_client):
+    ia_config_reader = IaConfig('seal')
+    specieses = ia_config_reader.get_configured_species()
+    desired_detector_config = {
+        '_detectors.seals_v0': {
+            'config_dict': {
+                'labeler_algo': 'densenet',
+                'labeler_model_tag': 'seals_v0',
+                'model_tag': 'seals_v0',
+                'nms_aware': None,
+                'nms_thresh': 0.4,
+                'sensitivity': 0.63,
+                'use_labeler_species': True,
+            },
+            'description': 'Trained on grey seals, harbor seals, hawaiian monk seals, and mediterranean monk seals',
+        }
+    }
+    for species in specieses:
+        detector = ia_config_reader.get_detectors_dict(species)
+        assert detector == desired_detector_config
+
+
+def test_get_seal_identifiers(flask_app_client):
+    ia_config_reader = IaConfig('seal')
+    specieses = ia_config_reader.get_configured_species()
+    desired_identifier_config = {
+        'hotspotter': {
+            'frontend': {'description': 'HotSpotter pattern-matcher'},
+            'sage': {'query_config_dict': {'sv_on': True}},
+        }
+    }
+    # each seal species, for each supported ia_class, should use the same hotspotter config
+    for species in specieses:
+        ia_classes = ia_config_reader.get_supported_ia_classes(species)
+        for ia_class in ia_classes:
+            identifiers = ia_config_reader.get_identifiers_dict(species, ia_class)
+            assert identifiers == desired_identifier_config


### PR DESCRIPTION
IA config for seals plus some tests to validate it. While submitting this PR, I went through and double-checked all the ITIS id's and binomial names, so don't worry about that unless you have a masochistic love for really slow government websites.

Note, I have not fully QA'd/validated this to the extent of actually running seal IA jobs against Sage. I have just made the config and validated its format, parsing, and the relevant getters used by houston.

The one potentially controversial move I've done here is decided how we'll treat subspecies in the config format, necessary because Saimaa seals are _Pusa hispida saimensis_. **The config/parser treats species+subspecies like a species name that happens to have a space in it**, eg 'hispida saimensis' is the species-level key for Saima seals. The alternative, storing subspecies at a deeper json level under species, would require we treat ia_class differently, because that's where ia_classes are now. This update required basically one line in the config format and doesn't break any existing logic we use to populate ia_class and species options.