### PR TITLE
DEX-1052 Add TUS_MAX_FILES_PER_TRANSACTION and TUS_MAX_TIME_PER_TRANSACTION settings

### DIFF
--- a/app/extensions/tus/__init__.py
+++ b/app/extensions/tus/__init__.py
@@ -413,7 +413,7 @@ def tus_cleanup():
                 log.info(
                     'Deleting too old (%s seconds) Tus pending file: %r'
                     % (
-                        delta,
+                        int(delta),
                         tus_path,
                     )
                 )
@@ -428,7 +428,7 @@ def tus_cleanup():
                     'Skipping Tus pending file (Age: %s, Remaining: %s): %r'
                     % (
                         humanize.naturaldelta(datetime.timedelta(seconds=age)),
-                        humanize.naturaldelta(datetime.timedelta(seconds=delta)),
+                        humanize.naturaldelta(datetime.timedelta(seconds=-delta)),
                         tus_path,
                     )
                 )

--- a/app/extensions/tus/flask_tus_cont.py
+++ b/app/extensions/tus/flask_tus_cont.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import base64
+import json
 import os
 import uuid
 
@@ -359,6 +360,10 @@ class TusManager(object):
                         request,
                         self.app,
                     )
+            except Exception as e:
+                response.status_code = 400
+                response.content_type = 'application/json'
+                response.set_data(json.dumps({'status': 400, 'message': str(e)}))
             finally:
                 self._remove_resources(resource_id)
 

--- a/config/base.py
+++ b/config/base.py
@@ -219,6 +219,9 @@ class BaseConfig(FlaskConfigOverrides, RedisConfig):
     }
 
     TUS_MAX_FILES_PER_TRANSACTION = int(_getenv('TUS_MAX_FILES_PER_TRANSACTION', 5000))
+    TUS_MAX_TIME_PER_TRANSACTION = int(
+        _getenv('TUS_MAX_TIME_PER_TRANSACTION', 24 * 60 * 60)
+    )
 
 
 class EmailConfig(object):

--- a/config/base.py
+++ b/config/base.py
@@ -218,6 +218,8 @@ class BaseConfig(FlaskConfigOverrides, RedisConfig):
         'client_secret': _getenv('OAUTH_CLIENT_SECRET'),
     }
 
+    TUS_MAX_FILES_PER_TRANSACTION = int(_getenv('TUS_MAX_FILES_PER_TRANSACTION', 5000))
+
 
 class EmailConfig(object):
     MAIL_SERVER = _getenv('MAIL_SERVER', 'smtp.gmail.com')

--- a/tests/extensions/tus/test_tus.py
+++ b/tests/extensions/tus/test_tus.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import pathlib
+import time
+import uuid
+from unittest import mock
+
+from app.extensions import tus
+
+from . import utils
+
+
+def test_tus_cleanup(flask_app, test_root, request):
+    log_patcher = mock.patch('app.extensions.tus.log')
+    log = log_patcher.start()
+    request.addfinalizer(log_patcher.stop)
+
+    # Create some files in tus dir
+    tid = str(uuid.uuid4())
+    utils.prep_tus_dir(test_root, transaction_id=tid)
+    request.addfinalizer(lambda: utils.cleanup_tus_dir(tid))
+    tus_dir = tus.tus_upload_dir(flask_app, transaction_id=tid)
+
+    # Try tus_cleanup (should not clean up anything)
+    tus.tus_cleanup()
+    assert log.info.call_args_list[0] == mock.call(
+        'Using clean-up TTL seconds (config UPLOADS_TTL_SECONDS) of 3600'
+    )
+    assert log.info.call_args_list[1] in [
+        mock.call(
+            f'Skipping Tus pending file (Age: a moment, Remaining: an hour): {repr(tus_dir)}'
+        ),
+        mock.call(
+            f'Skipping Tus pending file (Age: a moment, Remaining: 59 minutes): {repr(tus_dir)}'
+        ),
+    ]
+    assert pathlib.Path(tus_dir).exists()
+    log.reset_mock()
+
+    # Mock time to add 4000 seconds to the current time and
+    # tus_cleanup should delete the directory
+    current_time = time.time()
+    with mock.patch('time.time') as mock_time:
+        mock_time.return_value = current_time + 4000
+        tus.tus_cleanup()
+    assert log.info.call_args_list == [
+        mock.call('Using clean-up TTL seconds (config UPLOADS_TTL_SECONDS) of 3600'),
+        mock.call(f'Deleting too old (399 seconds) Tus pending file: {repr(tus_dir)}'),
+    ]
+    assert not pathlib.Path(tus_dir).exists()

--- a/tests/test_tus.py
+++ b/tests/test_tus.py
@@ -7,6 +7,7 @@ import uuid
 
 import pytest
 
+from tests.extensions.tus import utils
 from tests.utils import get_stored_path, redis_unavailable
 
 
@@ -31,10 +32,12 @@ def test_tus_options(flask_app_client):
 
 
 @pytest.mark.skipif(redis_unavailable(), reason='Redis unavailable')
-def test_tus_upload_protocol(flask_app, flask_app_client):
+def test_tus_upload_protocol(flask_app, flask_app_client, request):
     resource_id = str(uuid.uuid4())
     transaction_id = str(uuid.uuid4())
     file_upload_path = get_file_upload_path(flask_app, transaction_id)
+    file_upload_dir = file_upload_path.parent
+    request.addfinalizer(lambda: shutil.rmtree(file_upload_dir))
 
     # Initialize file upload
     a_txt = 'abcd\n'
@@ -93,6 +96,10 @@ def test_tus_upload_protocol(flask_app, flask_app_client):
     assert response.headers['Upload-Length'] == str(len(a_txt))
     assert response.data == b''
 
+    # Set maximum number of files per transaction to 3
+    flask_app.config['TUS_MAX_FILES_PER_TRANSACTION'] = 3
+    request.addfinalizer(lambda: flask_app.config.pop('TUS_MAX_FILES_PER_TRANSACTION'))
+
     # Upload the rest of the file
     response = flask_app_client.patch(
         path,
@@ -120,8 +127,38 @@ def test_tus_upload_protocol(flask_app, flask_app_client):
     )
     assert response.status_code == 404
 
-    if file_upload_path.parent.exists():
-        shutil.rmtree(file_upload_path.parent)
+    # Upload more files
+    for response in utils.upload_files_to_tus(
+        flask_app_client,
+        transaction_id,
+        (
+            ('xyz.txt', 'xyz\n'),
+            ('stu.txt', 'stu\n'),
+        ),
+    ):
+        assert response.status_code == 204
+    file_content = []
+    for path in file_upload_dir.glob('[0-9a-f]*'):
+        with path.open() as f:
+            file_content.append(f.read())
+    file_content.sort()
+    assert file_content == ['abcd\n', 'stu\n', 'xyz\n']
+
+    # After 3 files, file number limit is reached
+    for response in utils.upload_files_to_tus(
+        flask_app_client, transaction_id, (('ghi.txt', 'ghi\n'),)
+    ):
+        assert response.status_code == 400
+        assert response.json == {
+            'status': 400,
+            'message': 'Exceeded maximum number of files in one transaction: 3',
+        }
+    file_content = []
+    for path in file_upload_dir.glob('[0-9a-f]*'):
+        with path.open() as f:
+            file_content.append(f.read())
+    file_content.sort()
+    assert file_content == ['abcd\n', 'stu\n', 'xyz\n']
 
 
 @pytest.mark.skipif(redis_unavailable(), reason='Redis unavailable')


### PR DESCRIPTION
- Add tests for tus_cleanup and small fixes for log messages

  The original log messages were:
  
  ```
  Deleting too old (706.4403812885284 seconds) Tus pending file: '/data/var/uploads/trans-a292db28-dd7c-4d2b-afd3-8430a81c5cff'
  ```
  
  and
  
  ```
  Skipping Tus pending file (Age: 56 minutes, Remaining: a day): '/data/var/uploads/trans-a292db28-dd7c-4d2b-afd3-8430a81c5cff'
  ```
  
  The "Remaining: a day" part is definitely wrong.  The reason is this bit
  of code `humanize.naturaldelta(datetime.timedelta(seconds=-500))`
  returns "a day".  It seems the delta needs to be a positive number.
  
  The updated log messages are:
  
  ```
  Deleting too old (706 seconds) Tus pending file: '/data/var/uploads/trans-a292db28-dd7c-4d2b-afd3-8430a81c5cff'
  ```
  
  and
  
  ```
  Skipping Tus pending file (Age: 56 minutes, Remaining: 3 minutes): '/data/var/uploads/trans-a292db28-dd7c-4d2b-afd3-8430a81c5cff'
  ```

- DEX-1052 Add TUS_MAX_FILES_PER_TRANSACTION setting

  Error is raised if number of files in one transaction exceeds
  TUS_MAX_FILES_PER_TRANSACTION (default 5000)

- DEX-1052 Add TUS_MAX_TIME_PER_TRANSACTION setting

  Error is raised if the time between the first file is uploaded and the
  last file is more than TUS_MAX_TIME_PER_TRANSACTION seconds (default 24
  hours).
