### PR TITLE
DEX-1172 Fix base_fields.Function in schemas

### DIFF
--- a/app/modules/annotations/schemas.py
+++ b/app/modules/annotations/schemas.py
@@ -43,7 +43,7 @@ class DetailedAnnotationSchema(BaseAnnotationSchema):
         'BaseKeywordSchema',
         many=True,
     )
-    asset_src = base_fields.Function(Annotation.get_asset_src)
+    asset_src = base_fields.Function(lambda ann: ann.get_asset_src())
 
     class Meta(BaseAnnotationSchema.Meta):
         fields = BaseAnnotationSchema.Meta.fields + (
@@ -68,13 +68,13 @@ class AnnotationElasticsearchSchema(BaseAnnotationSchema):
     for purposes other than ES indexing.
     """
 
-    keywords = base_fields.Function(Annotation.get_keyword_values)
-    locationId = base_fields.Function(Annotation.get_location_id)
-    taxonomy_guid = base_fields.Function(Annotation.get_taxonomy_guid)
-    owner_guid = base_fields.Function(Annotation.get_owner_guid_str)
-    encounter_guid = base_fields.Function(Annotation.get_encounter_guid_str)
-    sighting_guid = base_fields.Function(Annotation.get_sighting_guid_str)
-    time = base_fields.Function(Annotation.get_time_isoformat_in_timezone)
+    keywords = base_fields.Function(lambda ann: ann.get_keyword_values())
+    locationId = base_fields.Function(lambda ann: ann.get_location_id())
+    taxonomy_guid = base_fields.Function(lambda ann: ann.get_taxonomy_guid())
+    owner_guid = base_fields.Function(lambda ann: ann.get_owner_guid_str())
+    encounter_guid = base_fields.Function(lambda ann: ann.get_encounter_guid_str())
+    sighting_guid = base_fields.Function(lambda ann: ann.get_sighting_guid_str())
+    time = base_fields.Function(lambda ann: ann.get_time_isoformat_in_timezone())
 
     class Meta(BaseAnnotationSchema.Meta):
         fields = BaseAnnotationSchema.Meta.fields + (

--- a/app/modules/asset_groups/schemas.py
+++ b/app/modules/asset_groups/schemas.py
@@ -76,7 +76,7 @@ class DetailedAssetGroupSchema(DetailedGitStoreSchema):
         many=False,
     )
 
-    pipeline_status = base_fields.Function(AssetGroup.get_pipeline_status)
+    pipeline_status = base_fields.Function(lambda ag: ag.get_pipeline_status())
 
     class Meta(DetailedGitStoreSchema.Meta):
         fields = DetailedGitStoreSchema.Meta.fields + (
@@ -101,9 +101,7 @@ class BaseAssetGroupSightingSchema(ModelSchema):
     locationId = base_fields.Function(
         AssetGroupSighting.config_field_getter('locationId')
     )
-    submissionTime = base_fields.Function(
-        AssetGroupSighting.get_submission_time_isoformat
-    )
+    submissionTime = base_fields.Function(lambda ags: ags.get_submission_time_isoformat())
 
     class Meta:
         # pylint: disable=missing-docstring
@@ -144,15 +142,15 @@ class DetailedAssetGroupSightingSchema(BaseAssetGroupSightingSchema):
         many=True,
     )
 
-    sighting_guid = base_fields.Function(AssetGroupSighting.get_sighting_guid)
+    sighting_guid = base_fields.Function(lambda ags: ags.get_sighting_guid())
     detection_start_time = base_fields.Function(
-        AssetGroupSighting.get_detection_start_time
+        lambda ags: ags.get_detection_start_time()
     )
-    curation_start_time = base_fields.Function(AssetGroupSighting.get_curation_start_time)
+    curation_start_time = base_fields.Function(lambda ags: ags.get_curation_start_time())
 
     creator = base_fields.Nested('PublicUserSchema', attribute='get_owner', many=False)
 
-    jobs = base_fields.Function(AssetGroupSighting.get_detailed_jobs_json)
+    jobs = base_fields.Function(lambda ags: ags.get_detailed_jobs_json())
 
     progress_preparation = base_fields.Nested(
         'DetailedProgressSchema',
@@ -225,9 +223,9 @@ class AssetGroupSightingAsSightingSchema(ModelSchema):
     updatedHouston = base_fields.DateTime(attribute='updated')
     creator = base_fields.Nested('PublicUserSchema', attribute='get_owner', many=False)
     detection_start_time = base_fields.Function(
-        AssetGroupSighting.get_detection_start_time
+        lambda ags: ags.get_detection_start_time()
     )
-    curation_start_time = base_fields.Function(AssetGroupSighting.get_curation_start_time)
+    curation_start_time = base_fields.Function(lambda ags: ags.get_curation_start_time())
 
     # Note: these config_field_getter vars should conform to SIGHTING_FIELDS_IN_AGS_CONFIG
     # at the top of this file
@@ -284,12 +282,10 @@ class AssetGroupSightingAsSightingSchema(ModelSchema):
     identification_start_time = base_fields.String(default=None)
     unreviewed_start_time = base_fields.String(default=None)
     review_time = base_fields.String(default=None)
-    submissionTime = base_fields.Function(
-        AssetGroupSighting.get_submission_time_isoformat
-    )
+    submissionTime = base_fields.Function(lambda ags: ags.get_submission_time_isoformat())
 
-    hasEdit = base_fields.Function(AssetGroupSighting.current_user_has_edit_permission)
-    hasView = base_fields.Function(AssetGroupSighting.current_user_has_view_permission)
+    hasEdit = base_fields.Function(lambda ags: ags.current_user_has_edit_permission())
+    hasView = base_fields.Function(lambda ags: ags.current_user_has_view_permission())
 
     progress_preparation = base_fields.Nested(
         'DetailedProgressSchema',
@@ -324,12 +320,12 @@ class AssetGroupSightingAsSightingSchema(ModelSchema):
 class AssetGroupSightingAsSightingWithPipelineStatusSchema(
     AssetGroupSightingAsSightingSchema
 ):
-    pipeline_status = base_fields.Function(AssetGroupSighting.get_pipeline_status)
+    pipeline_status = base_fields.Function(lambda ags: ags.get_pipeline_status())
 
 
 class DebugAssetGroupSightingSchema(DetailedAssetGroupSightingSchema):
-    detection_attempts = base_fields.Function(lambda ags: ags.detection_attempts)
-    jobs = base_fields.Function(AssetGroupSighting.get_debug_jobs_json)
+    detection_attempts = base_fields.Function(lambda ags: ags.detection_attempts())
+    jobs = base_fields.Function(lambda ags: ags.get_debug_jobs_json())
 
 
 class DebugAssetGroupSchema(CreateAssetGroupSchema):

--- a/app/modules/assets/schemas.py
+++ b/app/modules/assets/schemas.py
@@ -20,7 +20,7 @@ class BaseAssetSchema(ModelSchema):
     Base Asset schema exposes only the most general fields.
     """
 
-    dimensions = base_fields.Function(Asset.get_dimensions)
+    dimensions = base_fields.Function(lambda asset: asset.get_dimensions())
 
     class Meta:
         # pylint: disable=missing-docstring
@@ -129,7 +129,7 @@ class ExtendedAssetDetailedAnnotationsSchema(BaseAssetSchema):
 
 
 class DebugAssetSchema(DetailedAssetSchema):
-    jobs = base_fields.Function(Asset.get_jobs_debug)
+    jobs = base_fields.Function(lambda asset: asset.get_jobs_debug())
 
     class Meta(DetailedAssetSchema.Meta):
         fields = DetailedAssetSchema.Meta.fields + ('jobs',)

--- a/app/modules/collaborations/schemas.py
+++ b/app/modules/collaborations/schemas.py
@@ -17,7 +17,7 @@ class BaseCollaborationSchema(ModelSchema):
     Base Collaboration schema exposes only the most general fields.
     """
 
-    members = base_fields.Function(Collaboration.get_user_data_as_json)
+    members = base_fields.Function(lambda collab: collab.get_user_data_as_json())
 
     class Meta:
         # pylint: disable=missing-docstring

--- a/app/modules/complex_date_time/schemas.py
+++ b/app/modules/complex_date_time/schemas.py
@@ -16,8 +16,8 @@ class BaseComplexDateTimeSchema(ModelSchema):
     Base ComplexDateTime schema exposes only the most general fields.
     """
 
-    timezoneNormalized = base_fields.Function(ComplexDateTime.get_timezone_normalized)
-    timeInTimezone = base_fields.Function(ComplexDateTime.isoformat_in_timezone)
+    timezoneNormalized = base_fields.Function(lambda cdt: cdt.get_timezone_normalized())
+    timeInTimezone = base_fields.Function(lambda cdt: cdt.isoformat_in_timezone())
 
     class Meta:
         # pylint: disable=missing-docstring

--- a/app/modules/encounters/schemas.py
+++ b/app/modules/encounters/schemas.py
@@ -19,8 +19,8 @@ class BaseEncounterSchema(ModelSchema):
     annotations = base_fields.Nested('BaseAnnotationSchema', many=True)
     submitter = base_fields.Nested('PublicUserSchema', many=False)
     owner = base_fields.Nested('PublicUserSchema', many=False)
-    hasView = base_fields.Function(Encounter.current_user_has_view_permission)
-    hasEdit = base_fields.Function(Encounter.current_user_has_edit_permission)
+    hasView = base_fields.Function(lambda enc: enc.current_user_has_view_permission())
+    hasEdit = base_fields.Function(lambda enc: enc.current_user_has_edit_permission())
     time = base_fields.Function(lambda enc: enc.get_time_isoformat_in_timezone())
     timeSpecificity = base_fields.Function(lambda enc: enc.get_time_specificity())
 
@@ -37,16 +37,16 @@ class ElasticsearchEncounterSchema(ModelSchema):
     """
 
     annotations = base_fields.Nested('AnnotationElasticsearchSchema', many=True)
-    hasView = base_fields.Function(Encounter.current_user_has_view_permission)
-    hasEdit = base_fields.Function(Encounter.current_user_has_edit_permission)
-    time = base_fields.Function(Encounter.get_time_isoformat_in_timezone)
-    timeSpecificity = base_fields.Function(Encounter.get_time_specificity)
-    owner_guid = base_fields.Function(Encounter.get_owner_guid_str)
-    sighting_guid = base_fields.Function(Encounter.get_sighting_guid_str)
-    locationId = base_fields.Function(Encounter.get_location_id)
-    taxonomy_guid = base_fields.Function(Encounter.get_taxonomy_guid)
-    point = base_fields.Function(Encounter.get_point)
-    customFields = base_fields.Function(Encounter.get_custom_fields)
+    hasView = base_fields.Function(lambda enc: enc.current_user_has_view_permission())
+    hasEdit = base_fields.Function(lambda enc: enc.current_user_has_edit_permission())
+    time = base_fields.Function(lambda enc: enc.get_time_isoformat_in_timezone())
+    timeSpecificity = base_fields.Function(lambda enc: enc.get_time_specificity())
+    owner_guid = base_fields.Function(lambda enc: enc.get_owner_guid_str())
+    sighting_guid = base_fields.Function(lambda enc: enc.get_sighting_guid_str())
+    locationId = base_fields.Function(lambda enc: enc.get_location_id())
+    taxonomy_guid = base_fields.Function(lambda enc: enc.get_taxonomy_guid())
+    point = base_fields.Function(lambda enc: enc.get_point())
+    customFields = base_fields.Function(lambda enc: enc.get_custom_fields())
 
     class Meta:
         # pylint: disable=missing-docstring

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -25,8 +25,8 @@ class BaseIndividualSchema(ModelSchema):
     Base Individual schema exposes only the most general fields.
     """
 
-    hasView = base_fields.Function(Individual.current_user_has_view_permission)
-    hasEdit = base_fields.Function(Individual.current_user_has_edit_permission)
+    hasView = base_fields.Function(lambda ind: ind.current_user_has_view_permission())
+    hasEdit = base_fields.Function(lambda ind: ind.current_user_has_edit_permission())
 
     class Meta:
         # pylint: disable=missing-docstring
@@ -61,7 +61,7 @@ class BasicNamedIndividualSchema(ModelSchema):
     Detailed Individual schema exposes all useful fields.
     """
 
-    names = base_fields.Function(Individual.get_name_values)
+    names = base_fields.Function(lambda ind: ind.get_name_values())
     id = base_fields.Function(lambda ind: ind.guid)
 
     class Meta:
@@ -114,8 +114,8 @@ class DetailedIndividualSchema(NamedIndividualSchema):
     Detailed Individual schema exposes all useful fields.
     """
 
-    featuredAssetGuid = base_fields.Function(Individual.get_featured_asset_guid)
-    social_groups = base_fields.Function(Individual.get_social_groups_json)
+    featuredAssetGuid = base_fields.Function(lambda ind: ind.get_featured_asset_guid())
+    social_groups = base_fields.Function(lambda ind: ind.get_social_groups_json())
     relationships = base_fields.Nested(IndividualRelationshipSchema, many=True)
 
     class Meta(NamedIndividualSchema.Meta):
@@ -138,26 +138,28 @@ class ElasticsearchIndividualSchema(ModelSchema):
     ElasticsearchIndividualSchema is used for indexing individuals for ES
     """
 
-    featuredAssetGuid = base_fields.Function(Individual.get_featured_asset_guid)
-    names = base_fields.Function(Individual.get_name_values)
-    firstName = base_fields.Function(Individual.get_first_name)
-    firstName_keyword = base_fields.Function(Individual.get_first_name_keyword)
-    adoptionName = base_fields.Function(Individual.get_adoption_name)
+    featuredAssetGuid = base_fields.Function(lambda ind: ind.get_featured_asset_guid())
+    names = base_fields.Function(lambda ind: ind.get_name_values())
+    firstName = base_fields.Function(lambda ind: ind.get_first_name())
+    firstName_keyword = base_fields.Function(lambda ind: ind.get_first_name_keyword())
+    adoptionName = base_fields.Function(lambda ind: ind.get_adoption_name())
     encounters = base_fields.Nested(ElasticsearchEncounterSchema, many=True)
-    social_groups = base_fields.Function(Individual.get_social_groups_json)
-    sex = base_fields.Function(Individual.get_sex)
-    birth = base_fields.Function(Individual.get_time_of_birth)
-    death = base_fields.Function(Individual.get_time_of_death)
-    comments = base_fields.Function(Individual.get_comments)
-    customFields = base_fields.Function(Individual.get_custom_fields)
-    taxonomy_guid = base_fields.Function(Individual.get_taxonomy_guid_inherit_encounters)
-    has_annotations = base_fields.Function(Individual.has_annotations)
-    num_encounters = base_fields.Function(Individual.num_encounters)
-    last_seen = base_fields.Function(Individual.get_last_seen_time_isoformat)
-    last_seen_specificity = base_fields.Function(
-        Individual.get_last_seen_time_specificity
+    social_groups = base_fields.Function(lambda ind: ind.get_social_groups_json())
+    sex = base_fields.Function(lambda ind: ind.get_sex())
+    birth = base_fields.Function(lambda ind: ind.get_time_of_birth())
+    death = base_fields.Function(lambda ind: ind.get_time_of_death())
+    comments = base_fields.Function(lambda ind: ind.get_comments())
+    customFields = base_fields.Function(lambda ind: ind.get_custom_fields())
+    taxonomy_guid = base_fields.Function(
+        lambda ind: ind.get_taxonomy_guid_inherit_encounters()
     )
-    taxonomy_names = base_fields.Function(Individual.get_taxonomy_names)
+    has_annotations = base_fields.Function(lambda ind: ind.has_annotations())
+    num_encounters = base_fields.Function(lambda ind: ind.num_encounters())
+    last_seen = base_fields.Function(lambda ind: ind.get_last_seen_time_isoformat())
+    last_seen_specificity = base_fields.Function(
+        lambda ind: ind.get_last_seen_time_specificity()
+    )
+    taxonomy_names = base_fields.Function(lambda ind: ind.get_taxonomy_names())
 
     class Meta:
         # pylint: disable=missing-docstring
@@ -199,27 +201,29 @@ class ElasticsearchIndividualReturnSchema(ModelSchema):
     ElasticsearchIndividualSchema is used for showing results to the user upon return.
     """
 
-    featuredAssetGuid = base_fields.Function(Individual.get_featured_asset_guid)
-    names = base_fields.Function(Individual.get_name_values)
-    firstName = base_fields.Function(Individual.get_first_name)
-    firstName_keyword = base_fields.Function(Individual.get_first_name_keyword)
-    adoptionName = base_fields.Function(Individual.get_adoption_name)
-    social_groups = base_fields.Function(Individual.get_social_groups_json)
-    sex = base_fields.Function(Individual.get_sex)
-    birth = base_fields.Function(Individual.get_time_of_birth)
-    death = base_fields.Function(Individual.get_time_of_death)
-    comments = base_fields.Function(Individual.get_comments)
-    customFields = base_fields.Function(Individual.get_custom_fields)
-    taxonomy_guid = base_fields.Function(Individual.get_taxonomy_guid_inherit_encounters)
-    has_annotations = base_fields.Function(Individual.has_annotations)
-    last_seen = base_fields.Function(Individual.get_last_seen_time_isoformat)
-    last_seen_specificity = base_fields.Function(
-        Individual.get_last_seen_time_specificity
+    featuredAssetGuid = base_fields.Function(lambda ind: ind.get_featured_asset_guid())
+    names = base_fields.Function(lambda ind: ind.get_name_values())
+    firstName = base_fields.Function(lambda ind: ind.get_first_name())
+    firstName_keyword = base_fields.Function(lambda ind: ind.get_first_name_keyword())
+    adoptionName = base_fields.Function(lambda ind: ind.get_adoption_name())
+    social_groups = base_fields.Function(lambda ind: ind.get_social_groups_json())
+    sex = base_fields.Function(lambda ind: ind.get_sex())
+    birth = base_fields.Function(lambda ind: ind.get_time_of_birth())
+    death = base_fields.Function(lambda ind: ind.get_time_of_death())
+    comments = base_fields.Function(lambda ind: ind.get_comments())
+    customFields = base_fields.Function(lambda ind: ind.get_custom_fields())
+    taxonomy_guid = base_fields.Function(
+        lambda ind: ind.get_taxonomy_guid_inherit_encounters()
     )
-    taxonomy_names = base_fields.Function(Individual.get_taxonomy_names)
+    has_annotations = base_fields.Function(lambda ind: ind.has_annotations())
+    last_seen = base_fields.Function(lambda ind: ind.get_last_seen_time_isoformat())
+    last_seen_specificity = base_fields.Function(
+        lambda ind: ind.get_last_seen_time_specificity(),
+    )
+    taxonomy_names = base_fields.Function(lambda ind: ind.get_taxonomy_names())
 
-    encounters = base_fields.Function(Individual.get_encounter_guids)
-    num_encounters = base_fields.Function(Individual.num_encounters)
+    encounters = base_fields.Function(lambda ind: ind.get_encounter_guids())
+    num_encounters = base_fields.Function(lambda ind: ind.num_encounters())
 
     class Meta:
         # pylint: disable=missing-docstring

--- a/app/modules/sightings/schemas.py
+++ b/app/modules/sightings/schemas.py
@@ -16,10 +16,10 @@ class BaseSightingSchema(ModelSchema):
     Base Sighting schema exposes only the most general fields.
     """
 
-    hasView = base_fields.Function(Sighting.current_user_has_view_permission)
-    hasEdit = base_fields.Function(Sighting.current_user_has_edit_permission)
-    time = base_fields.Function(Sighting.get_time_isoformat_in_timezone)
-    timeSpecificity = base_fields.Function(Sighting.get_time_specificity)
+    hasView = base_fields.Function(lambda s: s.current_user_has_view_permission())
+    hasEdit = base_fields.Function(lambda s: s.current_user_has_edit_permission())
+    time = base_fields.Function(lambda s: s.get_time_isoformat_in_timezone())
+    timeSpecificity = base_fields.Function(lambda s: s.get_time_specificity())
 
     class Meta:
         # pylint: disable=missing-docstring
@@ -57,21 +57,21 @@ class ElasticsearchSightingSchema(BaseSightingSchema):
     Base Sighting schema exposes only the most general fields.
     """
 
-    time = base_fields.Function(Sighting.get_time_isoformat_in_timezone)
-    timeSpecificity = base_fields.Function(Sighting.get_time_specificity)
-    verbatimLocality = base_fields.Function(Sighting.get_locality)
-    locationId_id = base_fields.Function(Sighting.get_location_id)
-    locationId_value = base_fields.Function(Sighting.get_location_id_value)
-    locationId_keyword = base_fields.Function(Sighting.get_location_id_keyword)
+    time = base_fields.Function(lambda s: s.get_time_isoformat_in_timezone())
+    timeSpecificity = base_fields.Function(lambda s: s.get_time_specificity())
+    verbatimLocality = base_fields.Function(lambda s: s.get_locality())
+    locationId_id = base_fields.Function(lambda s: s.get_location_id())
+    locationId_value = base_fields.Function(lambda s: s.get_location_id_value())
+    locationId_keyword = base_fields.Function(lambda s: s.get_location_id_keyword())
     owners = base_fields.Nested(
         'PublicUserSchema',
         attribute='get_owners',
         many=True,
     )
-    comments = base_fields.Function(Sighting.get_comments)
-    taxonomy_guid = base_fields.Function(Sighting.get_taxonomy_guid)
-    customFields = base_fields.Function(Sighting.get_custom_fields)
-    submissionTime = base_fields.Function(Sighting.get_submission_time_isoformat)
+    comments = base_fields.Function(lambda s: s.get_comments())
+    taxonomy_guid = base_fields.Function(lambda s: s.get_taxonomy_guid())
+    customFields = base_fields.Function(lambda s: s.get_custom_fields())
+    submissionTime = base_fields.Function(lambda s: s.get_submission_time_isoformat())
 
     class Meta:
         # pylint: disable=missing-docstring
@@ -106,13 +106,13 @@ class TimedSightingSchema(CreateSightingSchema):
     Timed Sighting schema adds the stage times
     """
 
-    detection_start_time = base_fields.Function(Sighting.get_detection_start_time)
-    curation_start_time = base_fields.Function(Sighting.get_curation_start_time)
+    detection_start_time = base_fields.Function(lambda s: s.get_detection_start_time())
+    curation_start_time = base_fields.Function(lambda s: s.get_curation_start_time())
     identification_start_time = base_fields.Function(
-        Sighting.get_identification_start_time
+        lambda s: s.get_identification_start_time()
     )
-    unreviewed_start_time = base_fields.Function(Sighting.get_unreviewed_start_time)
-    review_time = base_fields.Function(Sighting.get_review_time)
+    unreviewed_start_time = base_fields.Function(lambda s: s.get_unreviewed_start_time())
+    review_time = base_fields.Function(lambda s: s.get_review_time())
 
     progress_identification = base_fields.Nested(
         'DetailedProgressSchema',
@@ -155,14 +155,14 @@ class AugmentedEdmSightingSchema(TimedSightingSchema):
         attribute='get_assets',
         many=True,
     )
-    featuredAssetGuid = base_fields.Function(Sighting.get_featured_asset_guid)
+    featuredAssetGuid = base_fields.Function(lambda s: s.get_featured_asset_guid())
     creator = base_fields.Nested('PublicUserSchema', attribute='get_owner', many=False)
     speciesDetectionModel = base_fields.Function(
         Sighting.config_field_getter('speciesDetectionModel', default=[])
     )
-    jobs = base_fields.Function(Sighting.get_jobs_json)
-    idConfigs = base_fields.Function(Sighting.get_id_configs)
-    submissionTime = base_fields.Function(Sighting.get_submission_time_isoformat)
+    jobs = base_fields.Function(lambda s: s.get_jobs_json())
+    idConfigs = base_fields.Function(lambda s: s.get_id_configs())
+    submissionTime = base_fields.Function(lambda s: s.get_submission_time_isoformat())
 
     class Meta(TimedSightingSchema.Meta):
         """
@@ -204,7 +204,7 @@ class DebugSightingSchema(AugmentedEdmSightingSchema):
         attribute='get_assets',
         many=True,
     )
-    jobs = base_fields.Function(Sighting.get_job_debug)
+    jobs = base_fields.Function(lambda s: s.get_job_debug())
 
     class Meta(AugmentedEdmSightingSchema.Meta):
         fields = AugmentedEdmSightingSchema.Meta.fields + ('jobs',)

--- a/app/modules/social_groups/schemas.py
+++ b/app/modules/social_groups/schemas.py
@@ -47,7 +47,7 @@ class DetailedSocialGroupSchema(BaseSocialGroupSchema):
     Detailed SocialGroup schema exposes all useful fields.
     """
 
-    members = base_fields.Function(SocialGroup.get_member_data_as_json)
+    members = base_fields.Function(lambda sg: sg.get_member_data_as_json())
 
     class Meta(BaseSocialGroupSchema.Meta):
         fields = BaseSocialGroupSchema.Meta.fields + (

--- a/app/modules/users/schemas.py
+++ b/app/modules/users/schemas.py
@@ -100,9 +100,13 @@ class DetailedUserPermissionsSchema(ModelSchema):
 class DetailedUserSchema(UserListSchema):
     """Detailed user schema exposes all fields used to render a normal user profile."""
 
-    collaborations = base_fields.Function(User.get_collaborations_as_json)
-    notification_preferences = base_fields.Function(User.get_notification_preferences)
-    individual_merge_requests = base_fields.Function(User.get_individual_merge_requests)
+    collaborations = base_fields.Function(lambda u: u.get_collaborations_as_json())
+    notification_preferences = base_fields.Function(
+        lambda u: u.get_notification_preferences()
+    )
+    individual_merge_requests = base_fields.Function(
+        lambda u: u.get_individual_merge_requests()
+    )
 
     class Meta(UserListSchema.Meta):
         fields = UserListSchema.Meta.fields + (

--- a/tests/modules/annotations/resources/test_create_annotation.py
+++ b/tests/modules/annotations/resources/test_create_annotation.py
@@ -144,6 +144,13 @@ def test_annotation_permission(
     annot_utils.read_annotation(flask_app_client, researcher_2, annotation_guid, 403)
     annot_utils.read_all_annotations(flask_app_client, researcher_2)
 
+    # Test locationId fallback
+    from app.modules.annotations.models import Annotation
+    from app.modules.annotations.schemas import AnnotationElasticsearchSchema
+
+    annotation = Annotation.query.get(annotation_guid)
+    assert AnnotationElasticsearchSchema().dump(annotation).data['locationId'] == 'test'
+
 
 @pytest.mark.skipif(
     module_unavailable('asset_groups'), reason='AssetGroups module disabled'


### PR DESCRIPTION
All the `base_fields.Function` in schemas that use a class method
instead of a function is updated from:

```
asset_src = base_fields.Function(Annotation.get_asset_src)
```

to

```
asset_src = base_fields.Function(lambda ann: annotation.get_asset_src())
```

That's because the first argument passed to the method is `{}` for some
reason which makes the default arguments like `sighting_fallback=True`
not work.

Add test for `locationId` fallback in `AnnotationElasticsearchSchema`.

