### PR TITLE
Updates to tus limits

### DIFF
--- a/app/extensions/api/http_exceptions.py
+++ b/app/extensions/api/http_exceptions.py
@@ -4,7 +4,8 @@ HTTP exceptions collection
 --------------------------
 """
 
-from flask_restx_patched._http import HTTPStatus
+from http import HTTPStatus
+
 from flask_restx_patched.errors import abort as restplus_abort
 
 API_DEFAULT_HTTP_CODE_MESSAGES = {

--- a/app/extensions/api/namespace.py
+++ b/app/extensions/api/namespace.py
@@ -6,6 +6,7 @@ Extended Api Namespace implementation with an application-specific helpers
 import logging
 from contextlib import contextmanager
 from functools import wraps
+from http import HTTPStatus
 
 import flask_marshmallow
 import flask_sqlalchemy
@@ -13,7 +14,6 @@ import sqlalchemy
 from marshmallow import ValidationError
 from sqlalchemy.inspection import inspect
 
-from flask_restx_patched._http import HTTPStatus
 from flask_restx_patched.namespace import Namespace as BaseNamespace
 
 from . import http_exceptions

--- a/app/extensions/auth/oauth2.py
+++ b/app/extensions/auth/oauth2.py
@@ -14,6 +14,7 @@ More details are available here:
 import datetime
 import functools
 import logging
+from http import HTTPStatus
 
 import sqlalchemy
 from flask import request, session
@@ -21,7 +22,6 @@ from flask_login import current_user
 from flask_oauthlib import provider
 
 from app.extensions import api, db
-from flask_restx_patched._http import HTTPStatus
 
 log = logging.getLogger(__name__)
 

--- a/app/modules/annotations/parameters.py
+++ b/app/modules/annotations/parameters.py
@@ -3,6 +3,8 @@
 Input arguments (Parameters) for Annotations resources RESTful API
 -----------------------------------------------------------
 """
+from http import HTTPStatus
+
 from flask_login import current_user
 from flask_marshmallow import base_fields
 from marshmallow import validates_schema
@@ -10,7 +12,6 @@ from marshmallow import validates_schema
 from app.extensions.api import abort
 from app.modules.users.permissions import rules
 from flask_restx_patched import Parameters, PatchJSONParameters
-from flask_restx_patched._http import HTTPStatus
 
 from . import schemas
 from .models import Annotation

--- a/app/modules/annotations/resources.py
+++ b/app/modules/annotations/resources.py
@@ -7,9 +7,9 @@ RESTful API Annotations resources
 
 import json
 import logging
+from http import HTTPStatus
 
 from flask import request
-from flask_restx._http import HTTPStatus
 
 import app.extensions.logging as AuditLog
 from app.extensions import db

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -8,6 +8,7 @@ import datetime
 import enum
 import logging
 import uuid
+from http import HTTPStatus
 
 from flask import current_app, url_for
 from flask_login import current_user  # NOQA
@@ -24,7 +25,6 @@ from app.modules.names.models import DEFAULT_NAME_CONTEXT
 from app.modules.sightings.models import Sighting, SightingStage
 from app.modules.users.models import User
 from app.utils import HoustonException
-from flask_restx_patched._http import HTTPStatus
 
 from .metadata import AssetGroupMetadata
 

--- a/app/modules/asset_groups/resources.py
+++ b/app/modules/asset_groups/resources.py
@@ -8,6 +8,7 @@ RESTful API Asset_groups resources
 import json
 import logging
 import uuid
+from http import HTTPStatus
 
 import werkzeug
 from flask import request
@@ -22,7 +23,6 @@ from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 from app.utils import HoustonException
 from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 
 from . import parameters, schemas
 from .metadata import AssetGroupMetadata, AssetGroupMetadataError

--- a/app/modules/assets/parameters.py
+++ b/app/modules/assets/parameters.py
@@ -4,9 +4,10 @@ Input arguments (Parameters) for Assets resources RESTful API
 -------------------------------------------------------------
 """
 
+from http import HTTPStatus
+
 from app.extensions.api import abort
 from flask_restx_patched import PatchJSONParameters
-from flask_restx_patched._http import HTTPStatus
 
 from . import schemas
 

--- a/app/modules/assets/resources.py
+++ b/app/modules/assets/resources.py
@@ -6,6 +6,7 @@ RESTful API Assets resources
 """
 
 import logging
+from http import HTTPStatus
 
 import werkzeug
 from flask import request, send_file
@@ -15,7 +16,6 @@ from app.extensions.api import Namespace
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 
 from . import parameters, schemas
 from .models import Asset

--- a/app/modules/audit_logs/resources.py
+++ b/app/modules/audit_logs/resources.py
@@ -6,9 +6,9 @@ RESTful API Audit Logs resources
 """
 
 import logging
+from http import HTTPStatus
 
 from flask import request
-from flask_restx._http import HTTPStatus
 
 from app.extensions.api import Namespace
 from app.modules.users import permissions

--- a/app/modules/auth/resources.py
+++ b/app/modules/auth/resources.py
@@ -6,6 +6,7 @@ Auth resources
 """
 import json
 import logging
+from http import HTTPStatus
 from urllib.parse import urlencode
 
 from flask import current_app, redirect, request
@@ -15,7 +16,6 @@ from app.extensions import oauth2
 from app.extensions.api import Namespace, abort, api_v1
 from app.modules.users.models import User
 from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 
 from . import parameters, schemas
 from .models import Code, CodeDecisions, CodeTypes, OAuth2Client, db

--- a/app/modules/collaborations/resources.py
+++ b/app/modules/collaborations/resources.py
@@ -7,6 +7,7 @@ RESTful API Collaborations resources
 
 import json
 import logging
+from http import HTTPStatus
 
 from flask import request
 from flask_login import current_user  # NOQA
@@ -20,7 +21,6 @@ from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 from app.utils import HoustonException
 from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 
 from . import parameters, schemas
 from .models import Collaboration

--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -6,6 +6,7 @@ RESTful API Encounters resources
 """
 
 import logging
+from http import HTTPStatus
 
 from flask import current_app, make_response, request
 from flask_login import current_user  # NOQA
@@ -17,7 +18,6 @@ from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 from app.utils import HoustonException
 from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 
 from . import parameters, schemas
 from .models import Encounter

--- a/app/modules/fileuploads/resources.py
+++ b/app/modules/fileuploads/resources.py
@@ -8,13 +8,13 @@ which will set FileUpload values as properties on other objects.
 """
 
 import logging
+from http import HTTPStatus
 
 from flask import send_file
 from flask_login import current_user  # NOQA
 
 from app.extensions.api import Namespace
 from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 
 from .models import FileUpload
 

--- a/app/modules/individuals/parameters.py
+++ b/app/modules/individuals/parameters.py
@@ -4,6 +4,7 @@ Input arguments (Parameters) for Individuals resources RESTful API
 -----------------------------------------------------------
 """
 import logging
+from http import HTTPStatus
 from uuid import UUID
 
 from flask_marshmallow import base_fields
@@ -11,7 +12,6 @@ from flask_marshmallow import base_fields
 import app.modules.utils as util
 from app.utils import HoustonException
 from flask_restx_patched import Parameters, PatchJSONParameters
-from flask_restx_patched._http import HTTPStatus
 
 from . import schemas
 

--- a/app/modules/individuals/resources.py
+++ b/app/modules/individuals/resources.py
@@ -7,10 +7,10 @@ RESTful API Individuals resources
 
 import json
 import logging
+from http import HTTPStatus
 
 from flask import current_app, request, send_file
 from flask_login import current_user  # NOQA
-from flask_restx._http import HTTPStatus
 
 import app.extensions.logging as AuditLog
 from app.extensions import db

--- a/app/modules/integrity/resources.py
+++ b/app/modules/integrity/resources.py
@@ -6,9 +6,9 @@ RESTful API Integrity resources
 """
 
 import logging
+from http import HTTPStatus
 
 from flask import request
-from flask_restx._http import HTTPStatus
 
 from app.extensions import db
 from app.extensions.api import Namespace

--- a/app/modules/keywords/resources.py
+++ b/app/modules/keywords/resources.py
@@ -6,8 +6,7 @@ RESTful API Keywords resources
 """
 
 import logging
-
-from flask_restx._http import HTTPStatus
+from http import HTTPStatus
 
 from app.extensions import db
 from app.extensions.api import Namespace

--- a/app/modules/missions/resources.py
+++ b/app/modules/missions/resources.py
@@ -7,6 +7,7 @@ RESTful API Missions resources
 
 import logging
 import uuid
+from http import HTTPStatus
 
 import randomname
 import tqdm
@@ -22,7 +23,6 @@ from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 from app.utils import HoustonException
 from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 
 from . import parameters, schemas
 from .models import Mission, MissionCollection, MissionTask

--- a/app/modules/notifications/resources.py
+++ b/app/modules/notifications/resources.py
@@ -6,6 +6,7 @@ RESTful API Notifications resources
 """
 
 import logging
+from http import HTTPStatus
 
 from flask import request
 from flask_login import current_user  # NOQA
@@ -20,7 +21,6 @@ from app.extensions.api.parameters import (
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 
 from . import parameters, schemas
 from .models import Notification

--- a/app/modules/organizations/resources.py
+++ b/app/modules/organizations/resources.py
@@ -6,6 +6,7 @@ RESTful API Organizations resources
 """
 
 import logging
+from http import HTTPStatus
 
 from flask import request
 from flask_login import current_user  # NOQA
@@ -15,7 +16,6 @@ from app.extensions.api import Namespace
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 
 from . import parameters, schemas
 from .models import Organization

--- a/app/modules/progress/resources.py
+++ b/app/modules/progress/resources.py
@@ -6,8 +6,7 @@ RESTful API Progress resources
 """
 
 import logging
-
-from flask_restx._http import HTTPStatus
+from http import HTTPStatus
 
 from app.extensions.api import Namespace
 from app.modules.users import permissions

--- a/app/modules/projects/resources.py
+++ b/app/modules/projects/resources.py
@@ -6,6 +6,7 @@ RESTful API Projects resources
 """
 
 import logging
+from http import HTTPStatus
 
 from flask import request
 from flask_login import current_user  # NOQA
@@ -15,7 +16,6 @@ from app.extensions.api import Namespace
 from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 
 from . import parameters, schemas
 from .models import Project

--- a/app/modules/relationships/resources.py
+++ b/app/modules/relationships/resources.py
@@ -7,10 +7,10 @@ RESTful API Relationships resources
 
 import logging
 import uuid
+from http import HTTPStatus
 
 import dateutil
 from flask import request
-from flask_restx._http import HTTPStatus
 
 from app.extensions import db
 from app.extensions.api import Namespace

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -7,6 +7,7 @@ import datetime  # NOQA
 import enum
 import logging
 import uuid
+from http import HTTPStatus
 
 from flask import current_app, url_for
 
@@ -16,7 +17,6 @@ from app.modules.annotations.models import Annotation
 from app.modules.encounters.models import Encounter
 from app.modules.individuals.models import Individual
 from app.utils import HoustonException
-from flask_restx_patched._http import HTTPStatus
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -7,6 +7,7 @@ RESTful API Sightings resources
 
 import json
 import logging
+from http import HTTPStatus
 from uuid import UUID
 
 import werkzeug
@@ -21,7 +22,6 @@ from app.modules.users import permissions
 from app.modules.users.permissions.types import AccessOperation
 from app.utils import HoustonException
 from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 
 from . import parameters, schemas
 from .models import Sighting, SightingStage

--- a/app/modules/site_settings/resources.py
+++ b/app/modules/site_settings/resources.py
@@ -7,11 +7,11 @@ RESTful API Site Settings resources
 
 import json
 import logging
+from http import HTTPStatus
 from pathlib import Path
 
 from flask import current_app, redirect, request, url_for
 from flask_login import current_user  # NOQA
-from flask_restx._http import HTTPStatus
 
 import app.extensions.logging as AuditLog  # NOQA
 import app.version

--- a/app/modules/social_groups/resources.py
+++ b/app/modules/social_groups/resources.py
@@ -8,9 +8,9 @@ RESTful API Social Groups resources
 import json
 import logging
 import uuid
+from http import HTTPStatus
 
 from flask import request
-from flask_restx._http import HTTPStatus
 
 import app.extensions.logging as AuditLog
 from app.extensions import db

--- a/app/modules/users/parameters.py
+++ b/app/modules/users/parameters.py
@@ -5,6 +5,7 @@ Input arguments (Parameters) for User resources RESTful API
 -----------------------------------------------------------
 """
 import logging
+from http import HTTPStatus
 from pathlib import Path
 
 import PIL
@@ -18,7 +19,6 @@ from app.extensions.api import abort
 from app.extensions.api.parameters import PaginationParameters
 from app.utils import HoustonException
 from flask_restx_patched import Parameters, PatchJSONParameters
-from flask_restx_patched._http import HTTPStatus
 
 from . import schemas
 

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -5,6 +5,7 @@ RESTful API Rules
 -----------------------
 """
 import logging
+from http import HTTPStatus
 from typing import Any, Type
 
 from flask_login import current_user
@@ -13,7 +14,6 @@ from permission import Rule as BaseRule
 from app.extensions.api import abort
 from app.modules import is_module_enabled, module_required
 from app.modules.users.permissions.types import AccessOperation
-from flask_restx_patched._http import HTTPStatus
 
 log = logging.getLogger(__name__)  # pylint: disable=invalid-name
 

--- a/app/modules/users/resources.py
+++ b/app/modules/users/resources.py
@@ -6,6 +6,7 @@ RESTful API User resources
 """
 import json
 import logging
+from http import HTTPStatus
 
 from flask import current_app, redirect, request, send_file, session, url_for
 from flask_login import current_user
@@ -21,7 +22,6 @@ from app.extensions.email import Email
 from app.modules import is_module_enabled
 from app.modules.users.permissions.types import AccessOperation
 from flask_restx_patched import Resource
-from flask_restx_patched._http import HTTPStatus
 
 from . import parameters, permissions, schemas
 from .models import User, db

--- a/config/base.py
+++ b/config/base.py
@@ -130,7 +130,7 @@ class BaseConfig(FlaskConfigOverrides, RedisConfig):
 
     # specifically this is where tus "temporary" files go
     UPLOADS_DATABASE_PATH = str(DATA_ROOT / 'uploads')
-    UPLOADS_TTL_SECONDS = 60 * 60 * 1
+    UPLOADS_TTL_SECONDS = 24 * 60 * 60  # 24 hours
     UPLOADS_GIT_COMMIT = False
 
     FILEUPLOAD_BASE_PATH = str(DATA_ROOT / 'fileuploads')

--- a/config/base.py
+++ b/config/base.py
@@ -187,7 +187,7 @@ class BaseConfig(FlaskConfigOverrides, RedisConfig):
     PREMAILER_CACHE_MAXSIZE = 1024
     CONFIG_MODEL = 'zebra'
 
-    MAX_CONTENT_LENGTH = 30 * 1024 * 1024  # Maximum size of 30MB
+    MAX_CONTENT_LENGTH = 50 * 1024 * 1024  # Maximum size of 50MB
 
     PERMANENT_SESSION_LIFETIME = datetime.timedelta(days=7)
     SESSION_COOKIE_SECURE = False

--- a/config/base.py
+++ b/config/base.py
@@ -218,7 +218,7 @@ class BaseConfig(FlaskConfigOverrides, RedisConfig):
         'client_secret': _getenv('OAUTH_CLIENT_SECRET'),
     }
 
-    TUS_MAX_FILES_PER_TRANSACTION = int(_getenv('TUS_MAX_FILES_PER_TRANSACTION', 5000))
+    TUS_MAX_FILES_PER_TRANSACTION = int(_getenv('TUS_MAX_FILES_PER_TRANSACTION', 20000))
     TUS_MAX_TIME_PER_TRANSACTION = int(
         _getenv('TUS_MAX_TIME_PER_TRANSACTION', 24 * 60 * 60)
     )

--- a/flask_restx_patched/_http.py
+++ b/flask_restx_patched/_http.py
@@ -1,4 +1,0 @@
-# -*- coding: utf-8 -*-
-from flask_restx._http import HTTPStatus as flaskplus_HTTPStatus
-
-HTTPStatus = flaskplus_HTTPStatus

--- a/flask_restx_patched/api.py
+++ b/flask_restx_patched/api.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 import logging
+from http import HTTPStatus
 
 import requests
 from flask import jsonify
 from flask import make_response as original_flask_make_response
 from flask_restx import Api as OriginalApi
-from flask_restx._http import HTTPStatus
 from werkzeug import cached_property
 
 from .namespace import Namespace

--- a/flask_restx_patched/namespace.py
+++ b/flask_restx_patched/namespace.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 import os
 from functools import wraps
+from http import HTTPStatus
 
 import elasticsearch
 import flask
 import flask_marshmallow
 from flask_restx import Namespace as OriginalNamespace
-from flask_restx._http import HTTPStatus
 from flask_restx.utils import merge, unpack
 from webargs.flaskparser import parser as webargs_parser
 from werkzeug import cached_property  # NOQA

--- a/flask_restx_patched/parameters.py
+++ b/flask_restx_patched/parameters.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=missing-docstring
 import logging
+from http import HTTPStatus
 
 import sqlalchemy as sa
 from flask import request
 from flask_login import current_user
 from flask_marshmallow import Schema, base_fields
-from flask_restx._http import HTTPStatus
 from marshmallow import ValidationError, pre_load, validate, validates_schema
 from six import itervalues
 

--- a/flask_restx_patched/resource.py
+++ b/flask_restx_patched/resource.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=protected-access
+from http import HTTPStatus
+
 import flask
 from flask_restx import Resource as OriginalResource
-from flask_restx._http import HTTPStatus
 from werkzeug.exceptions import HTTPException
 
 

--- a/tasks/app/boilerplates_templates/crud_module/resources.py.jinja2
+++ b/tasks/app/boilerplates_templates/crud_module/resources.py.jinja2
@@ -9,7 +9,7 @@ import logging
 
 from flask_login import current_user
 from flask_restx_patched import Resource
-from flask_restx._http import HTTPStatus
+from http import HTTPStatus
 
 from app.extensions import db
 from app.extensions.api import Namespace

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -132,7 +132,7 @@ def test_configure_app_from_env_vars(monkeypatch):
 
 @pytest.mark.only_for_codex
 def test_max_content_length_codex(flask_app):
-    assert flask_app.config['MAX_CONTENT_LENGTH'] == 30 * 1024 * 1024
+    assert flask_app.config['MAX_CONTENT_LENGTH'] == 50 * 1024 * 1024
 
 
 @pytest.mark.only_for_mws


### PR DESCRIPTION
- DEX-1052 Increase TUS_MAX_FILES_PER_TRANSACTION to 20000

  The original, 5000, was too low.  We just want to include a limit that
  normal users won't hit.

- DEX-1052 Increase default MAX_CONTENT_LENGTH to 50MB

  This default is used in codex, in mws, it's still 100MB.  This limits
  the size of each uploaded file.

- Import HTTPStatus from built-in http module

  I checked the module we were importing from `flask_restx._http` and at
  the top of this file is:
  
  ```
  This file is backported from Python 3.5 http built-in module.
  ```
  
  Since we're using python 3.9, I think we can safely switch to the
  built-in `http` module.

- DEX-1052 Overwrite 413 error to be more user friendly

  When users upload files that exceed the MAX_CONTENT_LENGTH (50MB for
  codex), they will see this message when they click on the "?" next to
  "Upload failed":
  
  ```
  Upload failed
  
  Failed to upload 20190224_131607.jpg tus: unexpected response while
  uploading chunk, originated from request (method: PATCH, url:
  http://localhost/api/v1/tus/9fa47e65-b8b1-489c-bb79-69b1eeea16a9,
  response code: 413, response text: {
    "message": "The uploaded file has exceeded our limit of 50.0MB",
    "status": 413
  }
  , request id: n/a)
  ```
  
  The message they used to see:
  
  ```
  Upload failed
  
   Failed to upload Free-3.jpg tus: unexpected response while uploading chunk, originated from request (method: PATCH, url: http://localhost/api/v1/tus/aae6f115-017f-48e3-b94e-4b988e446cf5, response code: 413, response text: <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 3.2 Final//EN">
  <title>413 Request Entity Too Large</title>
  <h1>Request Entity Too Large</h1>
  <p>The data value transmitted exceeds the capacity limit.</p>
  , request id: n/a)
  ```
