### PR TITLE
Mark tests as skipped if elasticsearch is disabled

### DIFF
--- a/tests/extensions/test_elasticsearch.py
+++ b/tests/extensions/test_elasticsearch.py
@@ -78,7 +78,7 @@ def test_elasticsearch_utilities(
     from tests.modules.users.resources.utils import read_all_users_pagination
 
     if es.is_disabled():
-        return
+        pytest.skip('Elasticsearch disabled (via command-line)')
 
     body = {}
 
@@ -726,7 +726,7 @@ def test_model_search(flask_app_client, staff_user):
     from app.modules.users.models import User
 
     if es.is_disabled():
-        return
+        pytest.skip('Elasticsearch disabled (via command-line)')
 
     # Initial search to setup the oauth user
     elasticsearch(flask_app_client, staff_user, 'users')

--- a/tests/modules/missions/resources/test_create_mission.py
+++ b/tests/modules/missions/resources/test_create_mission.py
@@ -314,7 +314,7 @@ def test_get_mission_assets(flask_app_client, data_manager_1, test_root):
     from app.modules.missions.models import Mission, MissionCollection
 
     if es.is_disabled():
-        return
+        pytest.skip('Elasticsearch disabled (via command-line)')
 
     ASSETS = 1000
     MISSION_COLLECTIONS = 2

--- a/tests/modules/missions/resources/test_create_task.py
+++ b/tests/modules/missions/resources/test_create_task.py
@@ -22,7 +22,7 @@ def test_create_and_delete_mission_task(flask_app_client, data_manager_1, test_r
     )
 
     if es.is_disabled():
-        return
+        pytest.skip('Elasticsearch disabled (via command-line)')
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     transaction_ids = []

--- a/tests/modules/missions/resources/test_modify_task.py
+++ b/tests/modules/missions/resources/test_modify_task.py
@@ -22,7 +22,7 @@ def test_modify_mission_task_users(
     from app.modules.missions.models import Mission, MissionCollection, MissionTask
 
     if es.is_disabled():
-        return
+        pytest.skip('Elasticsearch disabled (via command-line)')
 
     transaction_id, test_filename = tus_utils.prep_tus_dir(test_root)
     transaction_ids = []


### PR DESCRIPTION
A few tests have code like:

```
if es.is_disabled():
    return
```

The tests are actually skipped, so it's better to change it to:

```
if es.is_disabled():
    pytest.skip('Elasticsearch disabled (via command-line)')
```

So the tests are shown as skipped in the pytest results

