### PR TITLE
DEX-1337: handle special PATCH to remove a single CustomFieldDefinition

### DIFF
--- a/app/modules/site_settings/helpers.py
+++ b/app/modules/site_settings/helpers.py
@@ -277,28 +277,6 @@ class SiteSettingCustomFields(object):
                 return defn
         return None
 
-    @classmethod
-    # replace=False will silently fail if already exists
-    def add_definition(cls, class_name, guid, defn, replace=False):
-        from .models import SiteSetting
-
-        # bad class_name will get raise HoustonException
-        data = SiteSetting.get_value(f'site.custom.customFields.{class_name}')
-        if not data or not isinstance(data.get('definitions'), list):
-            data = {'definitions': []}
-        found = False
-        for i in range(len(data['definitions'])):
-            if guid == data['definitions'][i].get('id'):
-                if replace:
-                    found = True
-                    data['definitions'][i] = defn
-                else:
-                    return  # exists - no update!
-        if not found:
-            data['definitions'].append(defn)
-        AuditLog.audit_log(log, f'add_definition added {guid} to {class_name}')
-        SiteSetting.set(f'site.custom.customFields.{class_name}', data=data)
-
     # WARNING: this does no safety check (_drop_data etc), so really other code that
     #   wraps this should be used, e.g. patch_remove()
     @classmethod

--- a/app/modules/site_settings/helpers.py
+++ b/app/modules/site_settings/helpers.py
@@ -397,10 +397,10 @@ class SiteSettingCustomFields(object):
     def patch_remove(cls, key, force_removal=False):
         import re
 
-        m = re.search(r'site.custom.customFields.(\w+)/([\w\-]+)', key)
-        assert m and len(m.groups()) == 2
-        class_name = m.group(1)
-        cf_id = m.group(2)
+        match_obj = re.search(r'site.custom.customFields.(\w+)/([\w\-]+)', key)
+        assert match_obj and len(match_obj.groups()) == 2
+        class_name = match_obj.group(1)
+        cf_id = match_obj.group(2)
         defn = cls.get_definition(class_name, cf_id)
         if not defn:
             raise ValueError(f'invalid guid {cf_id} for class {class_name}')

--- a/app/modules/site_settings/models.py
+++ b/app/modules/site_settings/models.py
@@ -510,6 +510,10 @@ class SiteSetting(db.Model, Timestamp):
 
     @classmethod
     def forget_key_value(cls, key):
+        # this covers direct removal of both customFields.CLASS definitions and customFieldCategories
+        if key.startswith('site.custom.customField'):
+            raise NotImplementedError('cannot forget key value for customFields')
+
         assert key in cls.HOUSTON_SETTINGS.keys()
         key_data = cls.HOUSTON_SETTINGS[key]
 

--- a/app/modules/site_settings/resources.py
+++ b/app/modules/site_settings/resources.py
@@ -275,6 +275,8 @@ class MainConfiguration(Resource):
                         SiteSetting.forget_key_value(arg['path'])
                 except HoustonException as ex:
                     abort(ex.status_code, ex.message)
+                except ValueError as ex:
+                    abort(409, str(ex))
             else:
                 abort(400, f'op {arg["op"]} not supported on {arg["path"]}')
 

--- a/app/modules/site_settings/resources.py
+++ b/app/modules/site_settings/resources.py
@@ -260,13 +260,19 @@ class MainConfiguration(Resource):
         Patch SiteSetting details.
         """
         from app.extensions.elapsed_time import ElapsedTime
+        from app.modules.site_settings.helpers import SiteSettingCustomFields
 
         timer = ElapsedTime()
         request_in_ = json.loads(request.data)
         for arg in request_in_:
             if arg['op'] == 'remove':
                 try:
-                    SiteSetting.forget_key_value(arg['path'])
+                    if arg['path'] and arg['path'].startswith('site.custom.customField'):
+                        SiteSettingCustomFields.patch_remove(
+                            arg['path'], arg.get('force', False)
+                        )
+                    else:
+                        SiteSetting.forget_key_value(arg['path'])
                 except HoustonException as ex:
                     abort(ex.status_code, ex.message)
             else:

--- a/tests/extensions/custom_fields/test_custom_fields_ext.py
+++ b/tests/extensions/custom_fields/test_custom_fields_ext.py
@@ -288,35 +288,15 @@ def test_definition_manipulation(flask_app, flask_app_client, admin_user):
     from app.modules.site_settings.helpers import SiteSettingCustomFields
     from app.modules.site_settings.models import SiteSetting
 
-    guid = str(uuid.uuid4())
-    defn = {'id': guid}
-    # bunk class
-    with pytest.raises(HoustonException) as exc:
-        SiteSettingCustomFields.add_definition('fubar', guid, defn)
-    assert str(exc.value) == 'Key site.custom.customFields.fubar Not supported'
-
-    SiteSettingCustomFields.add_definition('Sighting', guid, defn)
-    defn_check = SiteSettingCustomFields.get_definition('Sighting', guid)
-    assert defn == defn_check
-
-    # diff defn but we dont force replace
-    defn_new = {'id': guid, 'new': True}
-    SiteSettingCustomFields.add_definition('Sighting', guid, defn_new)
-    defn_check = SiteSettingCustomFields.get_definition('Sighting', guid)
-    assert defn == defn_check
-
-    # but now we do replace
-    SiteSettingCustomFields.add_definition('Sighting', guid, defn_new, replace=True)
-    defn_check = SiteSettingCustomFields.get_definition('Sighting', guid)
-    assert defn_new == defn_check
-
-    data = SiteSetting.get_value('site.custom.customFields.Sighting')
-    assert 'definitions' in data
-    assert len(data['definitions']) == 1
-
-    # no data for this so should be removed without issue
-    SiteSettingCustomFields.remove_definition('Sighting', guid)
-    defn = SiteSettingCustomFields.get_definition('Sighting', guid)
+    # remove via the method
+    cfd_id = setting_utils.custom_field_create(
+        flask_app_client, admin_user, 'test1', cls='Sighting'
+    )
+    assert cfd_id is not None
+    defn = SiteSettingCustomFields.get_definition('Sighting', cfd_id)
+    assert defn
+    SiteSettingCustomFields.remove_definition('Sighting', cfd_id)
+    defn = SiteSettingCustomFields.get_definition('Sighting', cfd_id)
     assert not defn
     data = SiteSetting.get_value('site.custom.customFields.Sighting')
     assert 'definitions' in data

--- a/tests/extensions/custom_fields/test_custom_fields_ext.py
+++ b/tests/extensions/custom_fields/test_custom_fields_ext.py
@@ -320,3 +320,24 @@ def test_definition_manipulation(flask_app, flask_app_client, admin_user):
     data = SiteSetting.get_value('site.custom.customFields.Sighting')
     assert 'definitions' in data
     assert len(data['definitions']) == 0
+
+    # now lets add one and remove it via the special patch from DEX-1337
+    cfd_id = setting_utils.custom_field_create(
+        flask_app_client, admin_user, 'test2', cls='Sighting'
+    )
+    assert cfd_id is not None
+    defn = SiteSettingCustomFields.get_definition('Sighting', cfd_id)
+    assert defn
+    setting_utils.patch_main_setting(
+        flask_app_client,
+        admin_user,
+        '',
+        [
+            {
+                'path': 'site.custom.customFields.Sighting/' + cfd_id,
+                'op': 'remove',
+            }
+        ],
+    )
+    defn = SiteSettingCustomFields.get_definition('Sighting', cfd_id)
+    assert not defn

--- a/tests/extensions/custom_fields/test_custom_fields_ext.py
+++ b/tests/extensions/custom_fields/test_custom_fields_ext.py
@@ -283,6 +283,7 @@ def test_set_and_reset_values(
     assert _set_and_reset_test(db, sight, cfd_id, 'true') == 1
 
 
+@pytest.mark.skipif(module_unavailable('encounters'), reason='Encounters module disabled')
 def test_definition_manipulation(flask_app, flask_app_client, admin_user):
     from app.modules.site_settings.helpers import SiteSettingCustomFields
     from app.modules.site_settings.models import SiteSetting

--- a/tests/modules/sightings/resources/test_custom_fields.py
+++ b/tests/modules/sightings/resources/test_custom_fields.py
@@ -166,3 +166,18 @@ def test_custom_fields_on_sighting(
     assert full_sighting.json['customFields'][cfd_id] == new_cfd_test_value
     assert cfd_multi_id in full_sighting.json['customFields']
     assert full_sighting.json['customFields'][cfd_multi_id] == new_cfd_multi_value
+
+    # now since we have some values in use, lets make sure we cannot delete the definition
+    res = setting_utils.patch_main_setting(
+        flask_app_client,
+        admin_user,
+        '',
+        [
+            {
+                'path': 'site.custom.customFields.Sighting/' + cfd_id,
+                'op': 'remove',
+            }
+        ],
+        400,
+    )
+    assert 'in use by' in res.json['message']


### PR DESCRIPTION
## Pull Request Overview

- `PATCH /api/v1/site-settings/main` with `path=site.custom.customFields.CLASS/GUID` and `op=remove` now supported
- safety/sanity check on _other_ customFields.CLASS modifications (basically disabled)
- likewise `SiteSetting.forget_key_value()` protected from same
- will not remove in-use definitions
- some `SiteSettingCustomFields` utility functions: `add_definition()`, `remove_definition()`

### Notes
- further support for _blowing away data_ along with **in-use** definitions will be handled in DEX-1367