### PR TITLE
1276 site settings again

### DIFF
--- a/app/extensions/tus/__init__.py
+++ b/app/extensions/tus/__init__.py
@@ -389,7 +389,7 @@ def tus_filepaths_from(
     )
 
     if not os.path.exists(upload_dir):
-        raise OSError('Upload_dir = {!r} is missing'.format(upload_dir))
+        raise HoustonException(log, 'Upload_dir = {!r} is missing'.format(upload_dir))
 
     log.debug(f'_tus_filepaths_from passed paths: {paths}')
     filepaths = []

--- a/app/modules/auth/utils.py
+++ b/app/modules/auth/utils.py
@@ -176,7 +176,7 @@ def recaptcha_required(func):
     def inner(*args, **kwargs):
         from app.modules.site_settings.models import SiteSetting
 
-        if not SiteSetting.get_string('recaptchaPublicKey'):
+        if not SiteSetting.get_value('recaptchaPublicKey'):
             log.debug('Recaptcha skipped (recaptchaPublicKey not set)')
             return func(*args, **kwargs)
 
@@ -191,7 +191,7 @@ def recaptcha_required(func):
                 response = requests.post(
                     current_app.config.get('RECAPTCHA_SITE_VERIFY_API'),
                     data={
-                        'secret': SiteSetting.get_string('recaptchaSecretKey'),
+                        'secret': SiteSetting.get_value('recaptchaSecretKey'),
                         'response': token,
                     },
                 ).json()

--- a/app/modules/site_settings/helpers.py
+++ b/app/modules/site_settings/helpers.py
@@ -59,8 +59,9 @@ class SiteSettingSpecies(object):
         for spec in value:
             validate_fields(spec, species_fields, 'site.species')
 
+    # Needs to be a separate function to generate the id for the species
     @classmethod
-    def set(cls, key, value, key_data):
+    def set(cls, key, value):
         import uuid
 
         from .models import SiteSetting
@@ -70,7 +71,7 @@ class SiteSettingSpecies(object):
             if 'id' not in spec:
                 spec['id'] = str(uuid.uuid4())
 
-        SiteSetting.set(key, data=value, public=key_data.get('public', True))
+        SiteSetting.set_after_validation(key, value)
 
 
 class SiteSettingModules(object):
@@ -344,8 +345,8 @@ class SiteSettingCustomFields(object):
                 new_list.append(defn)
         if found:
             AuditLog.audit_log(log, f'remove_definition dropped {guid} for {class_name}')
-            SiteSetting.set(
-                f'site.custom.customFields.{class_name}', data={'definitions': new_list}
+            SiteSetting.set_rest_block_data(
+                {f'site.custom.customFields.{class_name}': {'definitions': new_list}}
             )
 
     # expects cf_defn as from above

--- a/app/modules/site_settings/models.py
+++ b/app/modules/site_settings/models.py
@@ -4,6 +4,7 @@ Site Settings database models
 --------------------
 """
 import logging
+import uuid
 
 from flask import current_app
 from flask_login import current_user  # NOQA
@@ -204,6 +205,10 @@ class SiteSetting(db.Model, Timestamp):
             },
             'validate_function': SiteSettingCustomFields.validate_individuals,
         },
+        'preferred_language': {
+            'type': str,
+            'default': 'en_us',
+        },
         'email_service': {
             'type': str,
             'public': False,
@@ -358,6 +363,10 @@ class SiteSetting(db.Model, Timestamp):
             'public': False,
             'default': lambda: current_app.config.get('RECAPTCHA_SECRET_KEY'),
         },
+        'logo': {'type': 'file', 'public': True},
+        'splashImage': {'type': 'file', 'public': True},
+        'splashVideo': {'type': 'file', 'public': True},
+        'customCardImage': {'type': 'file', 'public': True},
     }
 
     if is_extension_enabled('intelligent_agent'):
@@ -402,46 +411,18 @@ class SiteSetting(db.Model, Timestamp):
         return query
 
     @classmethod
-    def set(
-        cls,
-        key,
-        file_upload_guid=None,
-        string=None,
-        public=None,
-        data=None,
-        boolean=None,
-        override_readonly=False,
-    ):
-        if not file_upload_guid and not cls.is_houston_setting(key):
-            # Can set any file you wish but value settings must be in the approved list
-            raise ValueError(f'forbidden to directly set key {key}')
-        key_conf = cls._get_houston_setting_conf(key)
-        if key_conf.get('read_only', False) and not override_readonly:
-            raise ValueError(f'read-only key {key}')
-
-        kwargs = {
-            'key': key,
-            'file_upload_guid': file_upload_guid,
-            'string': string,
-            'data': data,
-            'boolean': boolean,
-        }
-        if public is not None:
-            kwargs['public'] = public
-        setting = cls(**kwargs)
-        with db.session.begin(subtransactions=True):
-            return db.session.merge(setting)
-
-    @classmethod
-    def get_setting_keys(cls):
+    def _get_keys(cls):
         return cls.HOUSTON_SETTINGS.keys()
 
     @classmethod
-    def is_houston_setting(cls, key):
-        return key in cls.HOUSTON_SETTINGS.keys()
+    def is_houston_setting(cls, key, include_files=False):
+        if include_files:
+            return key in cls._get_keys()
+        else:
+            return key in cls._get_keys() and cls.HOUSTON_SETTINGS[key]['type'] != 'file'
 
     @classmethod
-    def _get_houston_setting_conf(cls, key):
+    def _get_setting_conf(cls, key):
         if cls.is_houston_setting(key):
             return cls.HOUSTON_SETTINGS[key]
         else:
@@ -466,9 +447,58 @@ class SiteSetting(db.Model, Timestamp):
         return def_val
 
     @classmethod
-    def set_key_value(cls, key, value):
+    def set_after_validation(cls, key, value):
         assert key in cls.HOUSTON_SETTINGS.keys()
         key_data = cls.HOUSTON_SETTINGS[key]
+
+        file_upload_guid = None
+        string = None
+        data = None
+        boolean = None
+        val_type = key_data['type']
+        is_public = key_data.get('public', True)
+        if val_type == dict or val_type == list:
+            data = value
+        elif val_type == bool:
+            assert isinstance(value, bool)
+            boolean = value
+        elif val_type == str:
+            assert isinstance(value, str)
+            string = value
+        elif val_type == 'file':
+            file_upload_guid = value
+        else:
+            # Catch if anyone adds a new 'type' to the houston settings
+            assert False, f'Site setting type {val_type} not supported'
+        log.debug(f'About to update Houston Setting key={key}')
+        existing = cls.query.get(key)
+        if existing:
+            log.debug(f'currently this is {existing}')
+        kwargs = {
+            'key': key,
+            'file_upload_guid': file_upload_guid,
+            'string': string,
+            'data': data,
+            'boolean': boolean,
+            'public': is_public,
+        }
+        setting = cls(**kwargs)
+        with db.session.begin(subtransactions=True):
+            if not cls.query.get(key):
+                db.session.add(setting)
+            else:
+                db.session.merge(setting)
+        if is_public:
+            log.debug(f'updating Houston Setting key={key} value={value}')
+        else:
+            log.debug(f'updating Houston Setting key={key}')
+        return setting
+
+    @classmethod
+    def set_key_value(cls, key, value, override_readonly=False):
+        assert key in cls.HOUSTON_SETTINGS.keys()
+        key_data = cls.HOUSTON_SETTINGS[key]
+        assert 'type' in key_data.keys()
 
         if 'sub_field' in key_data:
             # some fields are passed at a sub field level, for no readily apparent reason
@@ -478,7 +508,12 @@ class SiteSetting(db.Model, Timestamp):
                 )
             value = value[key_data['sub_field']]
 
-        if not isinstance(value, key_data['type']):
+        if key_data['type'] == 'file':
+            if not isinstance(value, uuid.UUID):
+                msg = f'Houston Setting key={key}, value incorrect type value={value},'
+                msg += 'needs to be uuid'
+                raise HoustonException(log, msg)
+        elif not isinstance(value, key_data['type']):
             msg = f'Houston Setting key={key}, value incorrect type value={value},'
             msg += f'needs to be {key_data["type"]}'
             raise HoustonException(log, msg)
@@ -486,27 +521,18 @@ class SiteSetting(db.Model, Timestamp):
         if 'validate_function' in key_data:
             key_data['validate_function'](value)
 
-        is_public = key_data.get('public', True)
+        if key_data.get('read_only', False) and not override_readonly:
+            raise ValueError(f'read-only key {key}')
         if 'set_function' in key_data:
-            key_data['set_function'](key, value, key_data)
-        elif isinstance(value, str):
-            if is_public:
-                log.debug(f'updating Houston Setting key={key} value={value}')
-            else:
-                log.debug(f'updating Houston Setting key={key}')
-            cls.set(key, string=value, public=is_public)
-        elif isinstance(value, dict) or isinstance(value, list):
-            log.debug(f'updating Houston Setting key={key}')
-            cls.set(key, data=value, public=key_data.get('public', True))
-        elif isinstance(value, bool):
-            log.debug(f'updating Houston Setting key={key}')
-            cls.set(key, boolean=value, public=key_data.get('public', True))
+            key_data['set_function'](key, value)
+            setting = cls.query.get(key)
         else:
-            msg = f'Houston Setting key={key}, value is not string, list or dict; value={value}'
-            raise HoustonException(log, msg)
+            setting = cls.set_after_validation(key, value)
 
         if 'update_function' in key_data:
             key_data['update_function'](value)
+
+        return setting
 
     @classmethod
     def forget_key_value(cls, key):
@@ -524,27 +550,6 @@ class SiteSetting(db.Model, Timestamp):
 
             if 'update_function' in key_data:
                 key_data['update_function']()
-
-    @classmethod
-    def get_string(cls, key, default=None):
-        setting = cls.query.get(key)
-        if not setting and default is None:
-            return cls._get_default_value(key)
-        return setting.string if setting else default
-
-    @classmethod
-    def get_json(cls, key, default=None):
-        setting = cls.query.get(key)
-        if not setting and default is None:
-            return cls._get_default_value(key)
-        return setting.data if setting else default
-
-    @classmethod
-    def get_boolean(cls, key, default=None):
-        setting = cls.query.get(key)
-        if not setting and default is None:
-            return cls._get_default_value(key)
-        return setting.boolean if setting else default
 
     @classmethod
     def get_value(cls, key, default=None, **kwargs):
@@ -580,28 +585,33 @@ class SiteSetting(db.Model, Timestamp):
         return key == 'block'
 
     @classmethod
-    def _set_houston_rest_data(cls, data):
-        assert isinstance(data, dict)
+    def set_rest_block_data(cls, data):
+        ret_data = {}
+
         success_keys = []
         # All keys must be valid
         for key in data.keys():
-            if key not in cls.get_setting_keys():
+            if key not in cls._get_keys():
                 raise HoustonException(log, f'{key} not supported')
         for key in data.keys():
-            if key in cls.get_setting_keys():
+            if key in cls._get_keys():
                 if data[key] is not None:
                     cls.set_key_value(key, data[key])
                 else:
                     cls.forget_key_value(key)
                 success_keys.append(key)
 
-        return success_keys
+        ret_data['updated'] = success_keys
+        for key in success_keys:
+            del data[key]
+        if not data:  # All keys processed
+            return ret_data
 
-    # All houston rest value getting needs common logic so factored out into separate function
+    # All rest value getting needs common logic so factored out into separate function
     @classmethod
-    def get_houston_rest_value(cls, key):
+    def get_rest_value(cls, key):
         init_value = cls.get_value(key)
-        key_conf = cls._get_houston_setting_conf(key)
+        key_conf = cls._get_setting_conf(key)
 
         # Only admin can read private data
         if not key_conf.get('public', True):
@@ -617,42 +627,35 @@ class SiteSetting(db.Model, Timestamp):
 
         from app.modules.users.models import User
 
-        houston_data = {'site.adminUserInitialized': User.admin_user_initialized()}
+        config_data = {'site.adminUserInitialized': User.admin_user_initialized()}
 
         # Create the site.images
-        houston_settings = cls.query.filter_by(public=True).order_by('key')
+        settings = cls.query.filter_by(public=True).order_by('key')
         site_images = {}
-        for setting in houston_settings:
+        for setting in settings:
             if setting.file_upload is not None:
                 site_images[setting.key] = url_for(
                     'api.fileuploads_file_upload_src_u_by_id_2',
                     fileupload_guid=str(setting.file_upload.guid),
                     _external=False,
                 )
-        houston_data['site.images'] = site_images
+        config_data['site.images'] = site_images
 
-        # Populate all the houston values that are accessible to the current user
+        # Populate all the values that are accessible to the current user
         is_admin = getattr(current_user, 'is_admin', False)
         for key, type_def in cls.HOUSTON_SETTINGS.items():
+            is_file = type_def.get('type') == 'file'
             permission = type_def.get('permission', lambda: True)()
-            if is_admin or type_def.get('public', True) and permission:
-                houston_data[key] = {'value': cls.get_houston_rest_value(key)}
-                if key == 'site.custom.customFields.Sighting':
-                    houston_data['site.custom.customFields.Occurrence'] = {
-                        'value': cls.get_houston_rest_value(key)
-                    }
-                if key == 'site.custom.customFields.Individual':
-                    houston_data['site.custom.customFields.MarkedIndividual'] = {
-                        'value': cls.get_houston_rest_value(key)
-                    }
+            if (is_admin or type_def.get('public', True) and permission) and not is_file:
+                config_data[key] = {'value': cls.get_rest_value(key)}
 
-        return {'response': {'configuration': houston_data}}
+        return {'response': {'configuration': config_data}}
 
     ###############################################
     # Definitions based code. Currently, only support getting all the definitions as a block, not individually
     @classmethod
-    def _get_houston_definition(cls, key):
-        key_conf = cls._get_houston_setting_conf(key)
+    def _get_definition(cls, key):
+        key_conf = cls._get_setting_conf(key)
         is_public = key_conf.get('public', True)
         field_type = 'string'
         display_type = 'string'
@@ -690,13 +693,13 @@ class SiteSetting(db.Model, Timestamp):
 
     @classmethod
     def get_all_rest_definitions(cls):
-        houston_definitions = {}
-        for key in cls.get_setting_keys():
-            houston_definitions[key] = cls._get_houston_definition(key)
+        definitions = {}
+        for key in cls._get_keys():
+            definitions[key] = cls._get_definition(key)
 
         # Populate site.species suggested values from the ia_config
         # TODO factor this out of here
-        species_json = houston_definitions['site.species']
+        species_json = definitions['site.species']
         from app.modules.ia_config_reader import IaConfig
 
         ia_config_reader = IaConfig()
@@ -722,33 +725,21 @@ class SiteSetting(db.Model, Timestamp):
                     },
                 )
 
-        return {'response': {'configuration': houston_definitions}}
+        return {'response': {'configuration': definitions}}
 
     #####################################
     # Other APIs
-
-    @classmethod
-    def set_rest_block_data(cls, data, files):
-        ret_data = {}
-        success_keys = cls._set_houston_rest_data(data)
-        ret_data['updated'] = success_keys
-        for key in success_keys:
-            del data[key]
-        if not data:  # All keys processed
-            return ret_data
-
-        return ret_data
 
     # the idea here is to have a unique uuid for each installation
     #   this should be used to read this value, as it will create it if it does not exist
     @classmethod
     def get_system_guid(cls):
-        val = cls.get_string('system_guid')
+        val = cls.get_value('system_guid')
         if not val:
             import uuid
 
             val = str(uuid.uuid4())
-            cls.set('system_guid', string=val, public=True, override_readonly=True)
+            cls.set_key_value('system_guid', val, override_readonly=True)
         return val
 
 

--- a/app/modules/site_settings/models.py
+++ b/app/modules/site_settings/models.py
@@ -470,10 +470,13 @@ class SiteSetting(db.Model, Timestamp):
         else:
             # Catch if anyone adds a new 'type' to the houston settings
             assert False, f'Site setting type {val_type} not supported'
-        log.debug(f'About to update Houston Setting key={key}')
-        existing = cls.query.get(key)
-        if existing:
-            log.debug(f'currently this is {existing}')
+
+        # useful debug for strange issues debugging but commented out as too verbose for mainline code
+        # log.debug(f'About to update Houston Setting key={key}')
+        # existing = cls.query.get(key)
+        # if existing:
+        #     log.debug(f'currently this is {existing}')
+
         kwargs = {
             'key': key,
             'file_upload_guid': file_upload_guid,

--- a/app/modules/social_groups/models.py
+++ b/app/modules/social_groups/models.py
@@ -88,7 +88,7 @@ class SocialGroup(db.Model, HoustonModel):
     def get_role_data(cls, role_guid):
         from app.modules.site_settings.models import SiteSetting
 
-        permitted_role_data = SiteSetting.get_json('social_group_roles')
+        permitted_role_data = SiteSetting.get_value('social_group_roles')
         permitted_role_guids = [role['guid'] for role in permitted_role_data]
         if role_guid not in permitted_role_guids:
             return None
@@ -102,7 +102,7 @@ class SocialGroup(db.Model, HoustonModel):
     def site_settings_updated(cls):
         from app.modules.site_settings.models import SiteSetting
 
-        permitted_role_data = SiteSetting.get_json('social_group_roles')
+        permitted_role_data = SiteSetting.get_value('social_group_roles')
         all_groups = SocialGroup.query.all()
         for group in all_groups:
             current_roles_singular = {}

--- a/tasks/app/email.py
+++ b/tasks/app/email.py
@@ -24,11 +24,11 @@ def send(
     # app.config['DEBUG'] = True
     app.config['MAIL_OVERRIDE_RECIPIENTS'] = None
 
-    SiteSetting.set('email_service', string='mailchimp')
+    SiteSetting.set_key_value('email_service', 'mailchimp')
     if username:
-        SiteSetting.set('email_service_username', string=username)
+        SiteSetting.set_key_value('email_service_username', username)
     if password:
-        SiteSetting.set('email_service_password', string=password)
+        SiteSetting.set_key_value('email_service_password', password)
 
     msg = Email(subject=subject, recipients=[recipient])
     msg.body = body

--- a/tasks/app/site_settings.py
+++ b/tasks/app/site_settings.py
@@ -8,16 +8,16 @@ from tasks.utils import app_context_task
 
 @app_context_task(
     help={
-        'key': 'Setting name, e.g. header_image',
+        'key': 'Setting name, e.g. logo',
         'filepath': '/path/to/local/file.foo',
     }
 )
-def set(context, key, filepath, public=True):
+def set(context, key, filepath):
     fup = FileUpload.create_fileupload_from_path(filepath, copy=True)
 
     with db.session.begin():
         db.session.add(fup)
-        setting = SiteSetting.set(key, fup.guid, public=public)
+        setting = SiteSetting.set_key_value(key, fup.guid)
     print(repr(setting))
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -200,9 +200,9 @@ def email_setup(flask_app):
     flask_app.config['MAIL_OVERRIDE_RECIPIENTS'] = None
 
     # this mocks using mailchimp, but wont send since we are in TESTING
-    SiteSetting.set('email_service', string='mailchimp')
-    SiteSetting.set('email_service_username', string='testing_' + str(uuid.uuid4()))
-    SiteSetting.set('email_service_password', string='testing_' + str(uuid.uuid4()))
+    SiteSetting.set_key_value('email_service', 'mailchimp')
+    SiteSetting.set_key_value('email_service_username', 'testing_' + str(uuid.uuid4()))
+    SiteSetting.set_key_value('email_service_password', 'testing_' + str(uuid.uuid4()))
 
     yield
 

--- a/tests/extensions/intelligent_agent/test_agents.py
+++ b/tests/extensions/intelligent_agent/test_agents.py
@@ -37,9 +37,9 @@ def get_fake_tweet():
 def set_keys():
     from app.extensions.intelligent_agent.models import TwitterBot
 
-    SiteSetting.set(TwitterBot.site_setting_id('enabled'), boolean=True)
+    SiteSetting.set_key_value(TwitterBot.site_setting_id('enabled'), True)
     for req in req_keys:
-        SiteSetting.set(TwitterBot.site_setting_id(req), string='TEST_VALUE')
+        SiteSetting.set_key_value(TwitterBot.site_setting_id(req), 'TEST_VALUE')
 
 
 @pytest.mark.skipif(
@@ -50,7 +50,7 @@ def test_twitter_basics(flask_app):
     from app.extensions.intelligent_agent.models import IntelligentAgent, TwitterBot
 
     assert not TwitterBot.is_enabled()
-    SiteSetting.set(TwitterBot.site_setting_id('enabled'), boolean=True)
+    SiteSetting.set_key_value(TwitterBot.site_setting_id('enabled'), True)
     assert TwitterBot.is_enabled()
     assert not TwitterBot.is_ready()
 
@@ -88,12 +88,12 @@ def test_twitter_connectivity(flask_app_client):
     me_value.data.name = 'B'
 
     with patch.object(tweepy.Client, 'get_me', return_value=me_value):
-        SiteSetting.set(TwitterBot.site_setting_id('enabled'), boolean=False)
+        SiteSetting.set_key_value(TwitterBot.site_setting_id('enabled'), False)
         assert not tb.is_ready()
         res = tb.test_setup()
         assert not res.get('success')
         assert res.get('message') == 'Not enabled.'
-        SiteSetting.set(TwitterBot.site_setting_id('enabled'), boolean=True)
+        SiteSetting.set_key_value(TwitterBot.site_setting_id('enabled'), True)
         res = tb.test_setup()
         assert res.get('success')
         assert res.get('username') == 'A'

--- a/tests/modules/asset_groups/test_tus_creation.py
+++ b/tests/modules/asset_groups/test_tus_creation.py
@@ -25,7 +25,7 @@ def test_create_asset_group_from_tus(flask_app, db, researcher_1, test_root):
     )
     if (transaction_dir).exists():
         shutil.rmtree(transaction_dir)
-    with pytest.raises(OSError):
+    with pytest.raises(HoustonException):
         sub, _ = AssetGroup.create_from_tus('PYTEST', researcher_1, tid)
 
     # now with a file dir+files but ask for wrong one

--- a/tests/modules/missions/test_collection_tus_creation.py
+++ b/tests/modules/missions/test_collection_tus_creation.py
@@ -32,7 +32,7 @@ def test_create_mission_collection_from_tus(flask_app, db, data_manager_1, test_
     )
     if (transaction_dir).exists():
         shutil.rmtree(transaction_dir)
-    with pytest.raises(OSError):
+    with pytest.raises(HoustonException):
         sub, _ = MissionCollection.create_from_tus(
             'PYTEST', data_manager_1, tid, mission=temp_mission
         )

--- a/tests/modules/site_settings/resources/test_bundles.py
+++ b/tests/modules/site_settings/resources/test_bundles.py
@@ -39,9 +39,9 @@ BUNDLE_PATH = 'block'
 def test_bundle_read(flask_app_client, request, admin_user, researcher_1, keys, user_var):
     from app.modules.site_settings.models import SiteSetting
 
-    SiteSetting.set('recaptchaPublicKey', string='recaptcha-key')
+    SiteSetting.set_key_value('recaptchaPublicKey', 'recaptcha-key')
     request.addfinalizer(lambda: SiteSetting.forget_key_value('recaptchaPublicKey'))
-    SiteSetting.set('flatfileKey', string='flatfile-key')
+    SiteSetting.set_key_value('flatfileKey', 'flatfile-key')
     request.addfinalizer(lambda: SiteSetting.forget_key_value('flatfileKey'))
 
     response = conf_utils.read_main_settings(flask_app_client, eval(user_var))

--- a/tests/tasks/app/test_site_settings.py
+++ b/tests/tasks/app/test_site_settings.py
@@ -10,7 +10,7 @@ from app.modules.site_settings.models import SiteSetting
 
 def test_site_settings(flask_app, db, request, test_root):
     def cleanup():
-        header_image = SiteSetting.query.get('header_image')
+        header_image = SiteSetting.query.get('logo')
         if header_image:
             file_path = Path(header_image.file_upload.get_absolute_path())
             with db.session.begin():
@@ -25,15 +25,15 @@ def test_site_settings(flask_app, db, request, test_root):
         with mock.patch('sys.stdout', new=io.StringIO()) as stdout:
             from tasks.app import site_settings
 
-            site_settings.set(MockContext(), 'header_image', str(test_image))
+            site_settings.set(MockContext(), 'logo', str(test_image))
             set_output = stdout.getvalue().strip()
             last_line = set_output.split('\n')[-1].strip()
 
             assert last_line.startswith(
-                "<SiteSetting(key='header_image' file_upload_guid='"
-            )
+                "<SiteSetting(key='logo' file_upload_guid='"
+            ), last_line
 
         with mock.patch('sys.stdout', new=io.StringIO()) as stdout:
-            site_settings.get(MockContext(), 'header_image')
+            site_settings.get(MockContext(), 'logo')
             new_line = stdout.getvalue().strip()
             assert new_line == last_line


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Site settings rework from comments on previous refactorings
- FE can only create the files that the BE is configured to support. 
- FE cannot create a file by posting the guid of the file, only the transaction Id of where the file is (it never did and this just made the code messier)
- Code simplified

