### PR TITLE
DEX-1336: improvements to customField valid value logic

### DIFF
--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -526,9 +526,10 @@ class CustomFieldMixin(object):
             raise ValueError(
                 f'value {value} not valid for customField definition id {cfd_id} (on {self})'
             )
-        defn = SiteSettingCustomFields.get_definition(self.__class__.__name__, cfd_id)
         cf = self.custom_fields or {}
-        cf[cfd_id] = SiteSettingCustomFields.serialize_value(defn, value)
+        cf[cfd_id] = SiteSettingCustomFields.serialize_value(
+            self.__class__.__name__, cfd_id, value
+        )
 
         with db.session.begin(subtransactions=True):
             self.custom_fields = cf
@@ -562,8 +563,9 @@ class CustomFieldMixin(object):
                 raise ValueError(
                     f'value {value} not valid for customField definition id {cfd_id} (on {self})'
                 )
-            defn = SiteSettingCustomFields.get_definition(self.__class__.__name__, cfd_id)
-            cf[cfd_id] = SiteSettingCustomFields.serialize_value(defn, value)
+            cf[cfd_id] = SiteSettingCustomFields.serialize_value(
+                self.__class__.__name__, cfd_id, value
+            )
 
         with db.session.begin(subtransactions=True):
             self.custom_fields = cf

--- a/app/modules/site_settings/helpers.py
+++ b/app/modules/site_settings/helpers.py
@@ -485,7 +485,13 @@ class SiteSettingCustomFields(object):
     # turn it into how we want it stored in json for db
     #   note we assume everything is in order here - no validating!
     @classmethod
-    def serialize_value(cls, defn, value):
+    def serialize_value(cls, class_name, cfd_id, value):
+        defn = cls.get_definition(class_name, cfd_id)
+        assert defn
+        return cls._serialize_value_using_definition(defn, value)
+
+    @classmethod
+    def _serialize_value_using_definition(cls, defn, value):
         if value is None:
             return None
 
@@ -497,7 +503,7 @@ class SiteSettingCustomFields(object):
             defn_single['multiple'] = False
             arr = []
             for val in value:
-                arr.append(cls.serialize_value(defn_single, val))
+                arr.append(cls._serialize_value_using_definition(defn_single, val))
             return arr
 
         dtype = defn['schema']['displayType']

--- a/tests/extensions/custom_fields/test_custom_fields_ext.py
+++ b/tests/extensions/custom_fields/test_custom_fields_ext.py
@@ -132,8 +132,9 @@ def test_is_valid_value(flask_app, flask_app_client, admin_user):
     assert SiteSettingCustomFields.is_valid_value(defn, -123.2)
     assert SiteSettingCustomFields.is_valid_value(defn, 0.0)
     assert SiteSettingCustomFields.is_valid_value(defn, None)
-    assert not SiteSettingCustomFields.is_valid_value(defn, 123)
-    assert not SiteSettingCustomFields.is_valid_value(defn, 0)
+    #   we now allow ints to be cast as floats.  sorrynotsorry
+    # assert not SiteSettingCustomFields.is_valid_value(defn, 123)
+    # assert not SiteSettingCustomFields.is_valid_value(defn, 0)
     assert not SiteSettingCustomFields.is_valid_value(defn, 'word')
     assert not SiteSettingCustomFields.is_valid_value(defn, '')
     assert not SiteSettingCustomFields.is_valid_value(defn, [1.0, 2.0])

--- a/tests/extensions/custom_fields/test_custom_fields_ext.py
+++ b/tests/extensions/custom_fields/test_custom_fields_ext.py
@@ -14,6 +14,7 @@ from tests.utils import module_unavailable
 log = logging.getLogger(__name__)
 
 
+@pytest.mark.skipif(module_unavailable('sightings'), reason='Sightings module disabled')
 def test_get_definition(flask_app, flask_app_client, admin_user):
     from app.modules.site_settings.helpers import SiteSettingCustomFields
 
@@ -42,6 +43,7 @@ def test_get_definition(flask_app, flask_app_client, admin_user):
 
 
 # this will not (nor ever?) be exhaustive... but try to hit big ones
+@pytest.mark.skipif(module_unavailable('sightings'), reason='Sightings module disabled')
 def test_is_valid_value(flask_app, flask_app_client, admin_user, db):
     import datetime
 
@@ -316,6 +318,7 @@ def test_is_valid_value(flask_app, flask_app_client, admin_user, db):
 
 
 # returns ints based on type of failure (0 if success)
+@pytest.mark.skipif(module_unavailable('sightings'), reason='Sightings module disabled')
 def _set_and_reset_test(db, obj, cfd_id, value):
     try:
         obj.set_custom_field_value(cfd_id, value)


### PR DESCRIPTION
## Pull Request Overview

- Main ticket is DEX-1336 but also covers:
  - DEX-1038
  - DEX-1334 (partial)
  - DEX-1261 (basic code - ticket needs confirmation/investigation)
- Note DEX-1336 covers validation of _choices_ in select/multiselect via this PR
- Ignores top-level `type` in CustomField Definitions, as it is EDM-cruft
- Allows `int` values to be validated as `float`
- Some utility methods, notably `SiteSettingCustomFields.get_choices_from_definition()`
