### PR TITLE
Fixes the build for me, also fixes an old warning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ REVISION = git_version()
 SUFFIX = REVISION[:8]
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 if SUFFIX:
-    VERSION = '{}.{}'.format(VERSION, SUFFIX)
+    VERSION = '{}+{}'.format(VERSION, SUFFIX)
 PACKAGES = ['.']
 
 

--- a/tests/extensions/prometheus/test_prometheus.py
+++ b/tests/extensions/prometheus/test_prometheus.py
@@ -23,9 +23,9 @@ def test_update_info(request):
     _update_info()
 
     info_dict = info.info.call_args[0][0]
-    assert re.match('[0-9a-f.]+$', info_dict['version'])
+    assert re.match('[0-9a-f.+]+$', info_dict['version'])
     assert re.match('[0-9a-f.]+$', info_dict['git_revision'])
-    assert re.match('[0-9a-f.]+$', info_dict['full_version'])
+    assert re.match('[0-9a-f.+]+$', info_dict['full_version'])
 
 
 @pytest.mark.skipif(module_unavailable('encounters'), reason='Encounters module disabled')


### PR DESCRIPTION
According to PEP 440, version numbers should be only numbers separated by dots. If there are any letters (e.g. a git SHA in hex) that part must be at the end after a +, not a dot.

For context if you weren't following slack drama, houston was unable to build for most of us today. We suspect a library we use was updated, causing a long-standing warning about PEP 440 non-conformance in Houston's version number to actually break the build:

```
houston_1         | WARNING: Built editable for Houston is invalid: Metadata 1.2 mandates PEP 440 version, but '0.1.0.15eed76c' is not
houston_1         | Failed to build Houston
houston_1         | ERROR: Could not build wheels for Houston, which is required to install pyproject.toml-based projects
```

This one character change allowed us to get the containers up.