### PR TITLE
DEX-1406: multiselect CustomField must have multiple=true to make sense

### DIFF
--- a/tests/extensions/custom_fields/test_custom_fields_ext.py
+++ b/tests/extensions/custom_fields/test_custom_fields_ext.py
@@ -147,6 +147,7 @@ def test_is_valid_value(flask_app, flask_app_client, admin_user, db):
         admin_user,
         'test_cfd_multiselect',
         displayType='multiselect',
+        multiple=True,
         schema_mods={
             'choices': [{'label': 'A', 'value': 'a'}, {'label': 'B', 'value': 'b'}],
         },
@@ -166,6 +167,7 @@ def test_is_valid_value(flask_app, flask_app_client, admin_user, db):
         'test_cfd_multiselect_required',
         displayType='multiselect',
         required=True,
+        multiple=True,
         schema_mods={
             'choices': [{'label': 'A', 'value': 'a'}, {'label': 'B', 'value': 'b'}],
         },


### PR DESCRIPTION
## Pull Request Overview

- Bugfix regarding `multiple=true` as it related to CustomField type `multiselect`
- Enforce above in CustomFieldDefinitions
- Tests reflect same
