### PR TITLE
1422 pass sage uri in site info message

### DIFF
--- a/app/modules/site_settings/resources.py
+++ b/app/modules/site_settings/resources.py
@@ -502,17 +502,21 @@ class SiteInfo(Resource):
 
         sage_version = current_app.sage.get_dict('version.dict', None)
         if isinstance(sage_version, dict):
-            sage_version = sage_version['response']
+            sage_version = sage_version['response']['version']
         else:
             # sage returns a non 200 response
             sage_version = repr(sage_version)
-
+        sage_uris = current_app.config.get('SAGE_URIS')
+        default_sage_uri = sage_uris.get('default')
         return {
             'houston': {
                 'version': app.version.version,
                 'git_version': app.version.git_revision,
             },
-            'sage': sage_version,
+            'sage': {
+                'version': sage_version,
+                'uri': default_sage_uri,
+            },
         }
 
 

--- a/tests/modules/site_settings/resources/test_site_info.py
+++ b/tests/modules/site_settings/resources/test_site_info.py
@@ -32,6 +32,7 @@ def test_site_info(flask_app_client):
         },
         'sage': {
             'version': '3.5.1.dev23',
+            'uri': 'http://sage:5000/',
         },
     }
 
@@ -52,7 +53,10 @@ def test_site_info_api_error(flask_app_client):
             'version': app.version.version,
             'git_version': app.version.git_revision,
         },
-        'sage': '<Response [404]>',
+        'sage': {
+            'version': '<Response [404]>',
+            'uri': 'http://sage:5000/',
+        },
     }
 
 


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Sage URI now in site info message 

---

**REST API Updates**

```
[GET] /api/v1/site-settings/site-info
{
        'houston': {
            'version': version number,
            'git_version': git version number,
        },
        'sage': {
            'version': '3.5.1.dev23',
            'uri': 'http://sage:5000/',
        },
    }

```

