### PR TITLE
SCT-105: prevent duplicate filenames in mission

### DIFF
--- a/tests/modules/missions/resources/test_create_mission.py
+++ b/tests/modules/missions/resources/test_create_mission.py
@@ -97,6 +97,7 @@ def test_delete_mission_cleanup(flask_app_client, admin_user, test_root):
     transaction_ids = []
     transaction_ids.append(transaction_id)
     mission_guid = None
+    filenames = ['zebra.jpg', 'zebra2.jpg', 'zebra-flopped.jpg']
 
     try:
         response = mission_utils.create_mission(
@@ -114,7 +115,7 @@ def test_delete_mission_cleanup(flask_app_client, admin_user, test_root):
         new_mission_collections = []
         for index in range(3):
             transaction_id = str(random_guid())
-            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id)
+            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id, filename=filenames[index])
             transaction_ids.append(transaction_id)
 
             nonce, description = mission_utils.make_name('mission collection')

--- a/tests/modules/missions/resources/test_create_task.py
+++ b/tests/modules/missions/resources/test_create_task.py
@@ -46,7 +46,9 @@ def test_create_and_delete_mission_task(flask_app_client, admin_user, test_root,
         new_mission_collections = []
         for index in range(4):
             transaction_id = str(random_guid())
-            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id, filename=filenames[index])
+            tus_utils.prep_tus_dir(
+                test_root, transaction_id=transaction_id, filename=filenames[index]
+            )
 
             exp_code = 200
             # index 1 is when we test failing upon duplicate filename [SCT-105]
@@ -62,7 +64,10 @@ def test_create_and_delete_mission_task(flask_app_client, admin_user, test_root,
                 expected_status_code=exp_code,
             )
             if index == 1:
-                assert response.json['message'] == 'This Mission already contains files with these names: zebra.jpg'
+                assert (
+                    response.json['message']
+                    == 'This Mission already contains files with these names: zebra.jpg'
+                )
                 continue
 
             transaction_ids.append(transaction_id)
@@ -177,7 +182,9 @@ def test_mission_task_permission(
         new_mission_collections = []
         for index in range(3):
             transaction_id = str(random_guid())
-            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id, filename=filenames[index])
+            tus_utils.prep_tus_dir(
+                test_root, transaction_id=transaction_id, filename=filenames[index]
+            )
             transaction_ids.append(transaction_id)
 
             nonce, description = mission_utils.make_name('mission collection')
@@ -274,6 +281,7 @@ def test_mission_task_create_with_identity_op(
     transaction_ids = []
     transaction_ids.append(transaction_id)
     mission_guid = None
+    filenames = ['zebra.jpg', 'zebra2.jpg', 'zebra-flopped.jpg']
 
     try:
         response = mission_utils.create_mission(
@@ -291,7 +299,9 @@ def test_mission_task_create_with_identity_op(
         new_mission_collections = []
         for index in range(3):
             transaction_id = str(random_guid())
-            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id)
+            tus_utils.prep_tus_dir(
+                test_root, transaction_id=transaction_id, filename=filenames[index]
+            )
             transaction_ids.append(transaction_id)
 
             nonce, description = mission_utils.make_name('mission collection')
@@ -399,7 +409,9 @@ def test_set_operation_permission(
         new_mission_collections_1 = []
         for index in range(3):
             transaction_id = str(random_guid())
-            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id, filename=filenames[index])
+            tus_utils.prep_tus_dir(
+                test_root, transaction_id=transaction_id, filename=filenames[index]
+            )
             transaction_ids.append(transaction_id)
 
             nonce, description = mission_utils.make_name('mission collection')
@@ -438,7 +450,9 @@ def test_set_operation_permission(
         new_mission_collections_2 = []
         for index in range(3):
             transaction_id = str(random_guid())
-            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id, filename=filenames[index])
+            tus_utils.prep_tus_dir(
+                test_root, transaction_id=transaction_id, filename=filenames[index]
+            )
             transaction_ids.append(transaction_id)
 
             nonce, description = mission_utils.make_name('mission collection')

--- a/tests/modules/missions/resources/test_get_collection.py
+++ b/tests/modules/missions/resources/test_get_collection.py
@@ -25,6 +25,7 @@ def test_get_mission_collection_by_search(flask_app_client, admin_user, test_roo
     mission_guid = response.json['guid']
     temp_mission = Mission.query.get(mission_guid)
     assert len(temp_mission.collections) == 0
+    filenames = ['zebra.jpg', 'zebra2.jpg', 'zebra-flopped.jpg']
 
     previous_list = mission_utils.read_all_mission_collections(
         flask_app_client, admin_user
@@ -34,7 +35,7 @@ def test_get_mission_collection_by_search(flask_app_client, admin_user, test_roo
     new_mission_collections = []
     for index in range(3):
         transaction_id = str(random_guid())
-        tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id)
+        tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id, filename=filenames[index])
         transaction_ids.append(transaction_id)
 
         nonce, description = mission_utils.make_name('mission collection')

--- a/tests/modules/missions/resources/test_get_task.py
+++ b/tests/modules/missions/resources/test_get_task.py
@@ -22,6 +22,7 @@ def test_get_mission_task_by_search(flask_app_client, admin_user, test_root):
     transaction_ids = []
     transaction_ids.append(transaction_id)
     mission_guid = None
+    filenames = ['zebra.jpg', 'zebra2.jpg', 'zebra-flopped.jpg']
 
     try:
         response = mission_utils.create_mission(
@@ -39,7 +40,7 @@ def test_get_mission_task_by_search(flask_app_client, admin_user, test_root):
         new_mission_collections = []
         for index in range(3):
             transaction_id = str(random_guid())
-            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id)
+            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id, filename=filenames[index])
             transaction_ids.append(transaction_id)
 
             nonce, description = mission_utils.make_name('mission collection')

--- a/tests/modules/missions/resources/test_modify_task.py
+++ b/tests/modules/missions/resources/test_modify_task.py
@@ -28,6 +28,7 @@ def test_modify_mission_task_users(
     transaction_ids = []
     transaction_ids.append(transaction_id)
     mission_guid = None
+    filenames = ['zebra.jpg', 'zebra2.jpg', 'zebra-flopped.jpg']
 
     try:
         response = mission_utils.create_mission(
@@ -45,7 +46,7 @@ def test_modify_mission_task_users(
         new_mission_collections = []
         for index in range(3):
             transaction_id = str(random_guid())
-            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id)
+            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id, filename=filenames[index])
             transaction_ids.append(transaction_id)
 
             nonce, description = mission_utils.make_name('mission collection')
@@ -156,6 +157,7 @@ def test_owner_permission(flask_app_client, admin_user, admin_user_2, test_root)
     transaction_ids = []
     transaction_ids.append(transaction_id)
     mission_guid = None
+    filenames = ['zebra.jpg', 'zebra2.jpg', 'zebra-flopped.jpg']
 
     try:
         response = mission_utils.create_mission(
@@ -173,7 +175,7 @@ def test_owner_permission(flask_app_client, admin_user, admin_user_2, test_root)
         new_mission_collections = []
         for index in range(3):
             transaction_id = str(random_guid())
-            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id)
+            tus_utils.prep_tus_dir(test_root, transaction_id=transaction_id, filename=filenames[index])
             transaction_ids.append(transaction_id)
 
             nonce, description = mission_utils.make_name('mission collection')


### PR DESCRIPTION
## Pull Request Overview

- Disallow duplicate filenames on Assets within entire Mission (e.g. across Collections)
- Test above
- Alter existing tests to not use duplicate filenames