### PR TITLE
SCT-247: op=identity passing of title and assigned-users

### DIFF
--- a/app/modules/missions/parameters.py
+++ b/app/modules/missions/parameters.py
@@ -192,6 +192,9 @@ class CreateMissionTaskParameters(SetOperationsJSONParameters):
         'collections',
         'tasks',
         'assets',
+        # these are for identity op (passthru)
+        'users',
+        'title',
     ]
 
     PATH_CHOICES = tuple('/%s' % field for field in VALID_FIELDS)

--- a/app/modules/missions/parameters.py
+++ b/app/modules/missions/parameters.py
@@ -192,7 +192,6 @@ class CreateMissionTaskParameters(SetOperationsJSONParameters):
         'collections',
         'tasks',
         'assets',
-        'pass',  # this just allows this to pass through for use in resources.py
     ]
 
     PATH_CHOICES = tuple('/%s' % field for field in VALID_FIELDS)
@@ -262,8 +261,6 @@ class CreateMissionTaskParameters(SetOperationsJSONParameters):
                         )
 
             return assets
-        elif field == 'pass':
-            return []
 
         return None
 

--- a/app/modules/missions/parameters.py
+++ b/app/modules/missions/parameters.py
@@ -192,6 +192,7 @@ class CreateMissionTaskParameters(SetOperationsJSONParameters):
         'collections',
         'tasks',
         'assets',
+        'pass',  # this just allows this to pass through for use in resources.py
     ]
 
     PATH_CHOICES = tuple('/%s' % field for field in VALID_FIELDS)
@@ -261,6 +262,8 @@ class CreateMissionTaskParameters(SetOperationsJSONParameters):
                         )
 
             return assets
+        elif field == 'pass':
+            return []
 
         return None
 

--- a/app/modules/missions/resources.py
+++ b/app/modules/missions/resources.py
@@ -383,15 +383,8 @@ class MissionTasksForMission(Resource):
             db.session, default_error_message='Failed to create a new MissionTask'
         )
 
-        passed_data = {}
-        for arg in args:
-            if arg.get('path') == '/pass':
-                passed_data = arg.get('value', {})
-                if not isinstance(passed_data, dict):
-                    abort(409, message=f'path=/pass given non-dict value: {passed_data}')
-                break
-
-        title = passed_data.get('title')
+        # use data (potentially) passed via op=identity
+        title = identity_dict.get('title')
         if title is None:
             # Pick a random title with an adjective noun structure (see here: https://github.com/imsky/wordlists)
             if USE_GLOBALLY_UNIQUE_MISSION_TASK_NAMES:
@@ -421,11 +414,11 @@ class MissionTasksForMission(Resource):
             assert title is not None
             assert title not in titles
 
-        users_to_assign = {current_user}  # always get current_user
-        if isinstance(passed_data.get('users'), list):
+        users_to_assign = {current_user}  # always assign current_user
+        if isinstance(identity_dict.get('users'), list):
             from app.modules.users.models import User
 
-            for user_guid in passed_data.get('users'):
+            for user_guid in identity_dict.get('users'):
                 user = User.query.get(user_guid)
                 if not user:
                     abort(409, message=f'wanting to assign invalid user guid={user_guid}')

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -467,6 +467,15 @@ def patch_replace_op(path, value, guid=None):
     return operation
 
 
+def set_identity_op(path, value):
+    operation = {
+        'op': 'identity',
+        'path': '/{}'.format(path),
+        'value': value,
+    }
+    return operation
+
+
 def set_union_op(path, value):
     operation = {
         'op': 'union',


### PR DESCRIPTION
## Pull Request Overview

- Utilize new `op=identity` to allow (optional) setting **title** and **assigned users** via `POST /api/v1/missions/GUID/tasks`
- Tests for above

### Example
```
POST /api/v1/missions/GUID/tasks
[
    { "op": "union",  ....  (standard set manipulation) ... },
    { "op": "identity", "path": "/title", value="my new task" },
    { "op": "identity", "path": "/users", value=[UGUID0, ..., UGUIDn]}
]
```