### PR TITLE
new set operation op=identity

### DIFF
--- a/app/modules/missions/resources.py
+++ b/app/modules/missions/resources.py
@@ -370,7 +370,10 @@ class MissionTasksForMission(Resource):
         from app.modules.assets.models import Asset
 
         try:
-            asset_set = parameters.CreateMissionTaskParameters.perform_set_operations(
+            (
+                asset_set,
+                identity_dict,
+            ) = parameters.CreateMissionTaskParameters.perform_set_operations(
                 args, obj=mission, obj_cls=Asset
             )
         except ValidationError as exception:
@@ -736,7 +739,10 @@ class MissionTaskByID(Resource):
 
         starting_set = set(mission_task.assets)
         try:
-            asset_set = parameters.CreateMissionTaskParameters.perform_set_operations(
+            (
+                asset_set,
+                identity_dict,
+            ) = parameters.CreateMissionTaskParameters.perform_set_operations(
                 args, obj=mission_task.mission, obj_cls=Asset, starting_set=starting_set
             )
         except ValidationError as exception:

--- a/flask_restx_patched/parameters.py
+++ b/flask_restx_patched/parameters.py
@@ -500,7 +500,7 @@ class SetOperationsJSONParameters(Parameters):
         identity_state = {}
         for operation in operations:
             working_set = cls._process_set_operation(
-                operation, working_set, obj, obj_cls, identity_state
+                operation, working_set, identity_state, obj, obj_cls
             )
             if working_set is None:
                 log.info(

--- a/flask_restx_patched/parameters.py
+++ b/flask_restx_patched/parameters.py
@@ -529,8 +529,7 @@ class SetOperationsJSONParameters(Parameters):
         field_value = operation['value']
 
         if field_operaion in cls.OP_IDENTITY:
-            identity_state[field_name] = field_value
-            return working_set
+            return cls.identity(working_set, identity_state, field_name, field_value)
 
         resolved_set = set(cls.resolve(field_name, field_value, obj=obj))
 
@@ -558,6 +557,11 @@ class SetOperationsJSONParameters(Parameters):
         Resolve the (field, value) into an iterable of objects for the designated class
         """
         raise NotImplementedError()
+
+    @classmethod
+    def identity(cls, working_set, identity_state, key, value):
+        identity_state[key] = value
+        return working_set
 
     @classmethod
     def union(cls, working_set, resolved_set):


### PR DESCRIPTION
## Pull Request Overview

- Support new set operation `op=identity`, which does not affect actual set contents, but allows arbitrary field/value pairs to be passed through a set operation `POST`

### Example
```
POST
[
    { "op": "union",  ....  (standard set manipulation) ... },
    { "op": "identity", "path": "foo", value="bar" },
    { "op": "identity", "path": "fu", value="123"
]
```
In `resources.py` for example:
```
asset_set, identity_dict = parameters.CreateMissionTaskParameters.perform_set_operations()

identity_dict == {'foo': 'bar', 'fu': '123'}
```