### PR TITLE
1327 collaboration user error

### DIFF
--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -391,7 +391,6 @@ if elasticsearch is None:
         def elasticsearch(self, *args, **kwargs):
             return []
 
-
 else:
 
     def register_elasticsearch_model(*args, **kwargs):
@@ -411,13 +410,12 @@ if sage is None:
     class SageModel(object):
         pass
 
-
 else:
 
     SageModel = sage.SageModel
 
 
-class CommonHoustonModel(TimestampViewed, ElasticsearchModel):
+class HoustonModel(TimestampViewed, ElasticsearchModel):
     """
     A completely transient model that allows for Houston to wrap EDM or Sage
     responses into a model and allows for serialization of results with
@@ -496,18 +494,16 @@ class CommonHoustonModel(TimestampViewed, ElasticsearchModel):
         rule = ObjectActionRule(obj=self, action=AccessOperation.WRITE)
         return rule.check()
 
+    def get_all_owners(self):
+        if hasattr(self, 'owner'):
+            return [getattr(self, 'owner')]
+        # intentionally owners (plural) before owner(singular) as sighting has both
+        if hasattr(self, 'get_owners'):
+            return getattr(self, 'get_owners')()
+        if hasattr(self, 'get_owner'):
+            return [getattr(self, 'get_owner')()]
 
-class HoustonModel(CommonHoustonModel):
-    """
-    A permanent model that stores information for objects in Houston only.  A
-    HoustonModel is a fully-fledged database ORM object that has full CRUD
-    support and does not need to interface with an external component for any
-    information or metadata.
-
-    REST API Read Access : YES
-    Houston Exists Check : YES
-    Houston Read Access  : YES
-    """
+        return []
 
 
 class CustomFieldMixin(object):

--- a/app/modules/assets/models.py
+++ b/app/modules/assets/models.py
@@ -680,3 +680,6 @@ class Asset(db.Model, HoustonModel, SageModel):
     def user_is_owner(self, user: User) -> bool:
         # Asset has no owner, but it has one git_store that has an owner
         return self.git_store.user_is_owner(user)
+
+    def get_owner(self):
+        return self.git_store.owner

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -236,6 +236,10 @@ class DenyAbortMixin(object):
         Abort HTTP request by raising HTTP error exception with a specified
         HTTP code.
         """
+        log.debug(
+            'Access permission denied for %r on %r by %r'
+            % (self._action, self._module, current_user)
+        )
         return abort(code=self.DENY_ABORT_HTTP_CODE, message=self.DENY_ABORT_MESSAGE)
 
 
@@ -327,11 +331,7 @@ class ModuleActionRule(DenyAbortMixin, Rule):
                     current_user.is_active
                     & self._can_user_perform_action(current_user)
                 )
-        if not has_permission:
-            log.debug(
-                'Access permission denied for %r on %r by %r'
-                % (self._action, self._module, current_user)
-            )
+
         return has_permission
 
     # Permissions control entry point for real users, for all objects and all operations
@@ -358,7 +358,7 @@ class ModuleActionRule(DenyAbortMixin, Rule):
         return has_permission
 
 
-class ObjectActionRule(DenyAbortMixin, Rule):
+class ObjectActionRule(Rule):
     """
     Ensure that the current_user has has permission to perform the action on the object passed.
     """
@@ -377,6 +377,38 @@ class ObjectActionRule(DenyAbortMixin, Rule):
             user = current_user
         self._user = user
         super().__init__(**kwargs)
+
+    def deny(self):
+        """
+        Abort HTTP request by raising HTTP error exception with a specified
+        HTTP code.
+        """
+
+        # Object failure requires a bit more finesse in terms of the response to allow
+        # users to know how to fix the issue themselves
+        log.info(
+            f'Access permission denied for {self._action}, {self._obj} by {self._user}'
+        )
+        message = None
+        # A frequently seen user error is trying to edit data that they only have view permission on
+        # so give a more helpful error in that specific situation
+        if (
+            self._user
+            and not self._user.is_anonymous
+            and self._user.is_active
+            and self._action == AccessOperation.WRITE
+            and not self._permitted_via_collaboration(self._action)
+            and self._permitted_via_collaboration(AccessOperation.READ)
+        ):
+            message = 'You have permission to view but not edit '
+            message += f'{self._obj.__class__.__name__} {self._obj.guid}. '
+            owners = self._obj.get_all_owners()
+            if len(owners) == 1:
+                message += f'You will need to upgrade your collaboration with {owners[0].full_name} to an edit collaboration to do so'
+            else:
+                owner_names = [owner.full_name for owner in owners]
+                message += f'You will need an edit collaboration with any of {owner_names} to do so'
+        return abort(code=HTTPStatus.FORBIDDEN, message=message)
 
     def any_table_driven_permission(self):
         roles = OBJECT_USER_MAP.get((self._obj.__class__.__name__, self._action))
@@ -436,17 +468,12 @@ class ObjectActionRule(DenyAbortMixin, Rule):
 
             if not has_permission:
                 has_permission = self.elevated_permission() | (
-                    self._permitted_via_collaboration()
+                    self._permitted_via_collaboration(self._action)
                     | self._permitted_as_public_data()
                     # | self._permitted_via_org()
                     # | self._permitted_via_project()
                 )
 
-        if not has_permission:
-            log.info(
-                'Access permission denied for %r, %r by %r'
-                % (self._action, self._obj, self._user)
-            )
         return has_permission
 
     def _permitted_as_public_data(self):
@@ -503,7 +530,7 @@ class ObjectActionRule(DenyAbortMixin, Rule):
     #             project_index = project_index + 1
 
     @module_required('collaborations', resolve='warn', default=False)
-    def _permitted_via_collaboration(self):
+    def _permitted_via_collaboration(self, action):
         from app.modules.collaborations.models import Collaboration
 
         tried_users = [self._user]
@@ -511,9 +538,9 @@ class ObjectActionRule(DenyAbortMixin, Rule):
             (self._obj.__class__.__name__, self._action)
         )
 
-        if self._action == AccessOperation.READ:
+        if action == AccessOperation.READ:
             collab_users = Collaboration.get_users_for_read(self._user)
-        elif self._action == AccessOperation.WRITE:
+        elif action == AccessOperation.WRITE:
             collab_users = Collaboration.get_users_for_write(self._user)
         else:
             collab_users = []

--- a/tests/modules/collaborations/resources/test_collaboration_usage.py
+++ b/tests/modules/collaborations/resources/test_collaboration_usage.py
@@ -3,7 +3,12 @@
 import pytest
 
 import tests.modules.asset_groups.resources.utils as asset_group_utils
+import tests.modules.assets.resources.utils as asset_utils
 import tests.modules.collaborations.resources.utils as collab_utils
+import tests.modules.encounters.resources.utils as enc_utils
+import tests.modules.sightings.resources.utils as sighting_utils
+import tests.modules.site_settings.resources.utils as site_setting_utils
+import tests.utils as test_utils
 from tests.utils import module_unavailable
 
 
@@ -11,18 +16,17 @@ from tests.utils import module_unavailable
     module_unavailable('collaborations'), reason='Collaborations module disabled'
 )
 def test_use_collaboration(
-    flask_app_client, researcher_1, researcher_2, test_root, db, request
+    flask_app_client, researcher_1, researcher_2, admin_user, test_root, db, request
 ):
     from app.modules.collaborations.models import Collaboration
 
-    (
-        asset_group_uuid,
-        asset_group_sighting_guid,
-        asset_uuid,
-    ) = asset_group_utils.create_simple_asset_group(
+    uuids = sighting_utils.create_sighting(
         flask_app_client, researcher_1, request, test_root
     )
-
+    asset_group_uuid = uuids['asset_group']
+    sighting_guid = uuids['sighting']
+    asset_guid = uuids['assets'][0]
+    enc_guid = uuids['encounters'][0]
     data = {
         'user_guid': str(researcher_1.guid),
     }
@@ -37,4 +41,56 @@ def test_use_collaboration(
     )
     collab.set_approval_state_for_user(researcher_1.guid, 'approved')
 
+    # Researcher 2 should be able to view all the data but edit none of it
     asset_group_utils.read_asset_group(flask_app_client, researcher_2, asset_group_uuid)
+    asset_group_utils.read_asset_group_sighting(
+        flask_app_client, researcher_2, uuids['asset_group_sighting']
+    )
+    asset_utils.read_asset(flask_app_client, researcher_2, asset_guid)
+    enc_utils.read_encounter(flask_app_client, researcher_2, enc_guid)
+    sighting_utils.read_sighting(flask_app_client, researcher_2, sighting_guid)
+
+    # test an 'owner' example
+    tx = site_setting_utils.get_some_taxonomy_dict(flask_app_client, admin_user)
+    assert tx
+    assert 'id' in tx
+    taxonomy_guid = tx['id']
+    enc_patch = [
+        test_utils.patch_replace_op('taxonomy', taxonomy_guid),
+    ]
+    expected_err = f'You have permission to view but not edit Encounter {enc_guid}. '
+    expected_err += f'You will need to upgrade your collaboration with {researcher_1.full_name} to an edit collaboration to do so'
+    enc_utils.patch_encounter(
+        flask_app_client, enc_guid, researcher_2, enc_patch, 403, expected_err
+    )
+
+    # Test a get_owner example
+    asset_patch = [
+        {
+            'op': 'replace',
+            'path': '/image',
+            'value': {'rotate': {'angle': -90}},
+        },
+    ]
+    expected_err = f'You have permission to view but not edit Asset {asset_guid}. '
+    expected_err += f'You will need to upgrade your collaboration with {researcher_1.full_name} to an edit collaboration to do so'
+
+    asset_utils.patch_asset(
+        flask_app_client, uuids['assets'][0], researcher_2, asset_patch, 403, expected_err
+    )
+
+    # Test sighting as something with get_owners
+    sighting_patch = [
+        test_utils.patch_replace_op('featuredAssetGuid', '%s' % asset_guid),
+    ]
+
+    sighting_patch_resp = sighting_utils.patch_sighting(
+        flask_app_client,
+        researcher_2,
+        sighting_guid,
+        sighting_patch,
+        expected_status_code=403,
+    )
+    expected_err = f'You have permission to view but not edit Sighting {sighting_guid}. '
+    expected_err += f'You will need to upgrade your collaboration with {researcher_1.full_name} to an edit collaboration to do so'
+    assert sighting_patch_resp.json['message'] == expected_err


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- When a user has view but not the edit collab to perform action, give the user a helpful error message
- Operation unchanged but now uses a specific deny method in the ObjectActionRule to give a more helpful error message
- Also changed where the error message comes out as check was resulting in spurious logs as that is what is used for populating has_view and has_edit which was only going to cause debug confusion. 

---


