### PR TITLE
891 make individual merge delay into a site setting

### DIFF
--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -805,10 +805,11 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin):
                 f"merge passing membership to {socgrp} from {source_individual} [roles {data.get('roles')}]",
             )
 
-    # this might end up being a SiteSetting etc
     @classmethod
     def get_merge_request_deadline_days(cls):
-        return 14
+        from app.modules.site_settings.models import SiteSetting
+
+        return SiteSetting.get_value('individualMergeDefaultDelayDays')
 
     # does the actual work of setting up celery task to execute this merge
     # NOTE: this does not do any notification of users; see merge_request_from()

--- a/app/modules/site_settings/models.py
+++ b/app/modules/site_settings/models.py
@@ -367,6 +367,7 @@ class SiteSetting(db.Model, Timestamp):
         'splashImage': {'type': 'file', 'public': True},
         'splashVideo': {'type': 'file', 'public': True},
         'customCardImage': {'type': 'file', 'public': True},
+        'individualMergeDefaultDelayDays': {'type': int, 'public': False, 'default': 14},
     }
 
     if is_extension_enabled('intelligent_agent'):


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Make individual merge request delay a site setting
- Testing (with breakpoint) proved that the site setting is used.  
- Testing of site setting set not explicitly done as it's the same as all other site settings so not neccessary

