### PR TITLE
1405 allow lat&long to be strings

### DIFF
--- a/app/modules/asset_groups/metadata.py
+++ b/app/modules/asset_groups/metadata.py
@@ -69,10 +69,20 @@ class AssetGroupMetadata(object):
                 )
         elif not isinstance(dictionary[field], field_type):
 
-            # change the int type to what it should be
-            if field_type == float and isinstance(dictionary[field], int):
-                # change the int type to what it should be
-                dictionary[field] = float(dictionary[field])
+            # change the int/string type to what it should be. FE sends an int if no decimal provided.
+            # Bulk import sends a string for lat/long
+            if field_type == float and (
+                isinstance(dictionary[field], int) or isinstance(dictionary[field], str)
+            ):
+                # change the int/str type to what it should be
+                try:
+                    dictionary[field] = float(dictionary[field])
+                except ValueError:
+                    raise AssetGroupMetadataError(
+                        log,
+                        f'Cannot convert {dictionary[field]} to float for {field} in {error_str}',
+                    )
+
             elif dictionary[field]:
                 # if present it must be the correct type
                 raise AssetGroupMetadataError(

--- a/tests/modules/asset_groups/resources/test_create_asset_group.py
+++ b/tests/modules/asset_groups/resources/test_create_asset_group.py
@@ -218,21 +218,23 @@ def test_create_asset_group_invalid_gps(
         flask_app_client, researcher_1, data.get(), 400, expected_error
     )
 
-    # How confident is everyone that this doesn't exist anywhere in old world?
     expected_error = (
         'decimalLongitude field had incorrect type, expected float in Sighting 1'
     )
+    data.set_sighting_field(0, 'decimalLongitude', [25, 999])
+    asset_group_utils.create_asset_group(
+        flask_app_client, researcher_1, data.get(), 400, expected_error
+    )
+    # How confident is everyone that this doesn't exist anywhere in old world?
+
+    expected_error = 'Cannot convert twenty five point nine nine nine to float for decimalLongitude in Sighting 1'
     data.set_sighting_field(0, 'decimalLongitude', 'twenty five point nine nine nine')
     asset_group_utils.create_asset_group(
         flask_app_client, researcher_1, data.get(), 400, expected_error
     )
 
-    data.set_sighting_field(0, 'decimalLongitude', [25, 999])
-    asset_group_utils.create_asset_group(
-        flask_app_client, researcher_1, data.get(), 400, expected_error
-    )
-
     # Yes this is how some people (the french) represent floating point values
+    expected_error = 'Cannot convert 25,999 to float for decimalLongitude in Sighting 1'
     data.set_sighting_field(0, 'decimalLongitude', '25,999')
     asset_group_utils.create_asset_group(
         flask_app_client, researcher_1, data.get(), 400, expected_error
@@ -266,13 +268,11 @@ def test_create_asset_group_invalid_gps(
     )
 
     data.set_encounter_field(0, 0, 'decimalLatitude', 'twenty five point nine nine nine')
-    expected_error = (
-        'decimalLatitude field had incorrect type, expected float in Encounter 1.1'
-    )
+    expected_error = 'Cannot convert twenty five point nine nine nine to float for decimalLatitude in Encounter 1.1'
     asset_group_utils.create_asset_group(
         flask_app_client, researcher_1, data.get(), 400, expected_error
     )
-
+    expected_error = 'Cannot convert null to float for decimalLatitude in Encounter 1.1'
     data.set_encounter_field(0, 0, 'decimalLatitude', 'null')
     asset_group_utils.create_asset_group(
         flask_app_client, researcher_1, data.get(), 400, expected_error
@@ -291,8 +291,10 @@ def test_create_asset_group_invalid_gps(
         flask_app_client, researcher_1, data.get(), 400, expected_error
     )
 
-    # allowed incorrect type, user can enter this manually on the FE so we should allow it
+    # allowed incorrect type, user can enter integer manually on the FE so we should allow it
+    # Bulk upload contains lat& long as strings so need to allow that too
     data.set_encounter_field(0, 0, 'decimalLatitude', 90)
+    data.set_encounter_field(0, 0, 'decimalLongitude', '90.34')
     create_resp = asset_group_utils.create_asset_group(
         flask_app_client, researcher_1, data.get()
     ).json


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- DecimalLat & long come from bulk upload as strings of the floats. This needs to be permitted 
- Tests reworked to expect strings to be permitted for lat/long but only for valid values
