### PR TITLE
1444 custom latlong not mandatory in patch

### DIFF
--- a/app/modules/site_settings/helpers.py
+++ b/app/modules/site_settings/helpers.py
@@ -476,10 +476,14 @@ class SiteSettingCustomFields(object):
                 value[0] = float(value[0])
             if isinstance(value[1], int):
                 value[1] = float(value[1])
-            if not util.is_valid_latitude(value[0]):
+            if not value[0] and not value[1]:
+                if cf_defn.get('required', False):
+                    log.debug('latlong is mandatory')
+                    return False
+            elif not util.is_valid_latitude(value[0]):
                 log.debug(f'latlong latitude={value[0]} is invalid')
                 return False
-            if not util.is_valid_longitude(value[1]):
+            elif not util.is_valid_longitude(value[1]):
                 log.debug(f'latlong longitude={value[1]} is invalid')
                 return False
 

--- a/app/modules/site_settings/helpers.py
+++ b/app/modules/site_settings/helpers.py
@@ -476,7 +476,7 @@ class SiteSettingCustomFields(object):
                 value[0] = float(value[0])
             if isinstance(value[1], int):
                 value[1] = float(value[1])
-            if not value[0] and not value[1]:
+            if value[0] is None and value[1] is None:
                 if cf_defn.get('required', False):
                     log.debug('latlong is mandatory')
                     return False

--- a/tests/extensions/custom_fields/test_custom_fields_ext.py
+++ b/tests/extensions/custom_fields/test_custom_fields_ext.py
@@ -477,6 +477,7 @@ def test_set_and_reset_values(
     )
     assert _set_and_reset_test(db, sight, cfd_id, [0.001, 120]) == 0
     assert _set_and_reset_test(db, sight, cfd_id, [333, 444]) == 1
+    assert _set_and_reset_test(db, sight, cfd_id, [None, None]) == 0
 
     # individual
     indiv = Individual()

--- a/tests/extensions/custom_fields/test_custom_fields_ext.py
+++ b/tests/extensions/custom_fields/test_custom_fields_ext.py
@@ -478,6 +478,7 @@ def test_set_and_reset_values(
     assert _set_and_reset_test(db, sight, cfd_id, [0.001, 120]) == 0
     assert _set_and_reset_test(db, sight, cfd_id, [333, 444]) == 1
     assert _set_and_reset_test(db, sight, cfd_id, [None, None]) == 0
+    assert _set_and_reset_test(db, sight, cfd_id, [0, 0]) == 0
 
     # individual
     indiv = Individual()


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Custom lat long no longer mandatory in patching 



