### PR TITLE
DEX-1451: notification groupings

### DIFF
--- a/integration_tests/test_notifications.py
+++ b/integration_tests/test_notifications.py
@@ -34,6 +34,7 @@ def test_notification_preferences(session, login, logout, codex_url):
         'individual_merge_request': {'restAPI': True, 'email': False},
         'individual_merge_blocked': {'restAPI': True, 'email': False},
         'individual_merge_complete': {'restAPI': True, 'email': False},
+        'individual_merge_all': {'restAPI': True, 'email': False},
     }
     user_guid = response.json()['guid']
 
@@ -77,6 +78,7 @@ def test_notification_preferences(session, login, logout, codex_url):
         'individual_merge_request': {'restAPI': False, 'email': False},
         'individual_merge_blocked': {'restAPI': True, 'email': False},
         'individual_merge_complete': {'restAPI': True, 'email': False},
+        'individual_merge_all': {'restAPI': True, 'email': False},
     }
 
     # DELETE user


### PR DESCRIPTION
## Pull Request Overview

- Introduce NotificationType that can be a super-type to other
- `subtype_of: [ list of NotificationTypes ]` in `NOTIFICATION_CONFIG` can allow for multiple super-types
- Channels set as boolean **OR** of sub and super types (any single True will set that channel True)
