### PR TITLE
DEX-1458: be lax with numbers sent as strings (customFields)

### DIFF
--- a/app/modules/site_settings/helpers.py
+++ b/app/modules/site_settings/helpers.py
@@ -392,6 +392,26 @@ class SiteSettingCustomFields(object):
         if instance_type == float and isinstance(value, int):
             instance_type = int
 
+        # want int, got string, try conversion
+        if instance_type == int and isinstance(value, str):
+            try:
+                value = int(value)
+            except Exception as ex:
+                log.debug(
+                    f'value string "{value}" could not be made into an int: {str(ex)}'
+                )
+                return False
+
+        # want float, got string, try conversion
+        if instance_type == float and isinstance(value, str):
+            try:
+                value = float(value)
+            except Exception as ex:
+                log.debug(
+                    f'value string "{value}" could not be made into an float: {str(ex)}'
+                )
+                return False
+
         # try to convert str to uuid if appropriate
         if instance_type == uuid.UUID and isinstance(value, str):
             try:

--- a/tests/extensions/custom_fields/test_custom_fields_ext.py
+++ b/tests/extensions/custom_fields/test_custom_fields_ext.py
@@ -210,8 +210,10 @@ def test_is_valid_value(flask_app, flask_app_client, admin_user, db):
     assert SiteSettingCustomFields.is_valid_value(defn, 123)
     assert SiteSettingCustomFields.is_valid_value(defn, -123)
     assert SiteSettingCustomFields.is_valid_value(defn, 0)
+    assert SiteSettingCustomFields.is_valid_value(defn, '123')
     assert SiteSettingCustomFields.is_valid_value(defn, None)
     assert not SiteSettingCustomFields.is_valid_value(defn, 123.123)
+    assert not SiteSettingCustomFields.is_valid_value(defn, '123.123')
     assert not SiteSettingCustomFields.is_valid_value(defn, 1.0)
     assert not SiteSettingCustomFields.is_valid_value(defn, 0.0)  # i dont make the rules
     assert not SiteSettingCustomFields.is_valid_value(defn, 'word')
@@ -230,6 +232,8 @@ def test_is_valid_value(flask_app, flask_app_client, admin_user, db):
     defn = SiteSettingCustomFields.get_definition('Sighting', cfd_id)
     assert SiteSettingCustomFields.is_valid_value(defn, 123.1)
     assert SiteSettingCustomFields.is_valid_value(defn, -123.2)
+    assert SiteSettingCustomFields.is_valid_value(defn, '-123.2')
+    assert SiteSettingCustomFields.is_valid_value(defn, 123)
     assert SiteSettingCustomFields.is_valid_value(defn, 0.0)
     assert SiteSettingCustomFields.is_valid_value(defn, None)
     #   we now allow ints to be cast as floats.  sorrynotsorry


### PR DESCRIPTION
## Pull Request Overview

- CustomFields will accept **float** and **int** values as incoming strings (if they convert to int/float)
- Tests for above