### PR TITLE
DEX-1457: stop-gap fix for ES woes

### DIFF
--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -176,7 +176,8 @@ class ElasticsearchIndividualSchema(ModelSchema):
     firstName_keyword = base_fields.Function(lambda ind: ind.get_first_name_keyword())
     adoptionName = base_fields.Function(lambda ind: ind.get_adoption_name())
     encounters = base_fields.Nested(ElasticsearchEncounterSchema, many=True)
-    social_groups = base_fields.Function(lambda ind: ind.get_social_groups_json())
+    # see DEX-1457 for why this was (temporarily?) disabled
+    # social_groups = base_fields.Function(lambda ind: ind.get_social_groups_json())
     sex = base_fields.Function(lambda ind: ind.get_sex())
     birth = base_fields.Function(lambda ind: ind.get_time_of_birth())
     death = base_fields.Function(lambda ind: ind.get_time_of_death())
@@ -238,7 +239,8 @@ class ElasticsearchIndividualReturnSchema(ModelSchema):
     firstName = base_fields.Function(lambda ind: ind.get_first_name())
     firstName_keyword = base_fields.Function(lambda ind: ind.get_first_name_keyword())
     adoptionName = base_fields.Function(lambda ind: ind.get_adoption_name())
-    social_groups = base_fields.Function(lambda ind: ind.get_social_groups_json())
+    # see DEX-1457 for why this was (temporarily?) disabled
+    # social_groups = base_fields.Function(lambda ind: ind.get_social_groups_json())
     sex = base_fields.Function(lambda ind: ind.get_sex())
     birth = base_fields.Function(lambda ind: ind.get_time_of_birth())
     death = base_fields.Function(lambda ind: ind.get_time_of_death())


### PR DESCRIPTION
## Pull Request Overview

- Disable `social_groups` attribute from Individual Elasticsearch index doc, as it was causing huge field-count and breaking ES.

**from DEX-1457 comment:**
> basically, the `social_groups` attribute in the indexing docs was making for explosive growth in field-count for the Individuals index.  this apparently was due to the fact the field count seems to include all _sub-documents_ indexed (basically data **within fields**) and social_groups was keyed off of **guids** – thus, each new individual in social groups created **its own unique field** and made the field-count grow and grow and grow….