### PR TITLE
1215 prometheus data collection bugs fixed, still doesn't work

### DIFF
--- a/app/extensions/prometheus/__init__.py
+++ b/app/extensions/prometheus/__init__.py
@@ -141,6 +141,7 @@ def _update_taxonomies(*args, **kwargs):
 
     encounters_taxonomies = set(collector)
     for taxonomy in sorted(encounters_taxonomies):
+        value = collector.count(taxonomy)
         taxonomies.labels(taxonomy=taxonomy, metric='encounters').set(value)
 
     all_taxonomies = individuals_taxonomies | encounters_taxonomies

--- a/app/extensions/prometheus/__init__.py
+++ b/app/extensions/prometheus/__init__.py
@@ -330,6 +330,7 @@ def send_update(data):
         client_secret = oauth_user.get('client_secret')
 
         token_url = url_for('api.auth_o_auth2_tokens', _external=True)
+        token_url = 'http://houston:5000/api/v1/auth/tokens'
 
         client = BackendApplicationClient(
             client_id=client_id, scope=['prometheus:read', 'prometheus:write']
@@ -343,5 +344,6 @@ def send_update(data):
         )
 
         update_url = url_for('api.prometheus_prometheus_update', _external=True)
+        update_url = 'http://houston:5000'  # need actual url here
         response = session.request('POST', update_url, json=data)
         return response

--- a/app/extensions/prometheus/__init__.py
+++ b/app/extensions/prometheus/__init__.py
@@ -126,7 +126,9 @@ def _update_taxonomies(*args, **kwargs):
 
     individuals = Individual.query.all()
     for individual in tqdm.tqdm(individuals, desc='Individuals Taxonomy'):
-        collector += individual.get_taxonomy_names()
+        tx_names = individual.get_taxonomy_names()
+        if tx_names:
+            collector += tx_names
 
     individuals_taxonomies = set(collector)
     for taxonomy in sorted(individuals_taxonomies):

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -233,7 +233,7 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin):
         else:
             taxonomy_guid = self.taxonomy_guid
         if not taxonomy_guid:
-            return None
+            return []
 
         from app.modules.site_settings.models import Taxonomy
 

--- a/app/modules/site_settings/__init__.py
+++ b/app/modules/site_settings/__init__.py
@@ -4,6 +4,7 @@ Site Settings module
 ============
 """
 
+from app.extensions import register_prometheus_model
 from app.extensions.api import api_v1
 from app.modules import is_module_enabled
 
@@ -27,3 +28,4 @@ def init_app(app, **kwargs):
     from . import models, resources  # NOQA
 
     api_v1.add_namespace(resources.api)
+    register_prometheus_model(models.Taxonomy)

--- a/app/modules/site_settings/models.py
+++ b/app/modules/site_settings/models.py
@@ -1078,6 +1078,17 @@ class Taxonomy:
     def get_all_names(self):
         return self.commonNames + [self.scientificName]
 
+    @classmethod
+    @property
+    def query(cls):
+        # Need to generate a query object from which count() can be called. Prometheus presumes that
+        # Taxonomies is it's own DB which it isn't so we need to 'pretend'
+        class TaxonomyQuery(object):
+            def count(self):
+                return len(Taxonomy.get_configuration_value())
+
+        return TaxonomyQuery()
+
     def __eq__(self, other):
         if not isinstance(other, Taxonomy):
             return False

--- a/app/modules/site_settings/models.py
+++ b/app/modules/site_settings/models.py
@@ -1085,7 +1085,10 @@ class Taxonomy:
         # Taxonomies is it's own DB which it isn't so we need to 'pretend'
         class TaxonomyQuery(object):
             def count(self):
-                return len(Taxonomy.get_configuration_value())
+                conf = SiteSetting.get_value('site.species')
+                if not conf or not isinstance(conf, list):
+                    return 0
+                return len(conf)
 
         return TaxonomyQuery()
 

--- a/tasks/codex/__init__.py
+++ b/tasks/codex/__init__.py
@@ -21,6 +21,7 @@ from tasks.codex import (
     organizations,
     progress,
     projects,
+    prometheus,
     sightings,
 )
 
@@ -37,6 +38,7 @@ namespace = Collection(
     organizations,
     progress,
     projects,
+    prometheus,
     sightings,
     run,
     edm,

--- a/tasks/codex/prometheus.py
+++ b/tasks/codex/prometheus.py
@@ -11,8 +11,8 @@ def update(context, debug=False):
     """
     Manually update prometheus, very useful for debugging
     """
-    from app.extensions.prometheus import update
+    from app.extensions.prometheus.tasks import prometheus_update
 
     if debug:
         breakpoint()
-    update()
+    prometheus_update()

--- a/tasks/codex/prometheus.py
+++ b/tasks/codex/prometheus.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""
+Application projects management related tasks for Invoke.
+"""
+
+from tasks.utils import app_context_task
+
+
+@app_context_task
+def update(context, debug=False):
+    """
+    Manually update prometheus, very useful for debugging
+    """
+    from app.extensions.prometheus import update
+
+    if debug:
+        breakpoint()
+    update()


### PR DESCRIPTION
<!--

Pre-Pull Request Checklist

- Ensure that the PR is properly rebased
  - Example: The PR is rebased on `develop` (commit: `<insert develop commit hash>`)
  - Use `/rebase` as a PR comment to rebase it once created
- Ensure that the PR uses a consolidated database migration
  - Example: One database migration is proposed (revision `<insert develop revision>` -> `<insert new revision>`)
- Ensure that the PR is properly sanitized
  - Example: No sensitive data or large content was added to this PR

-->


## Pull Request Overview

- Bug in encounters get_taxonomy_names fixed
- Bug in prometheus encounter data gathering fixed
- CLI Task helper added to aid debugging update

Draft as update is still not working and I don't know why:
```
celery-worker3_1  |     httplib_response = self._make_request(
celery-worker3_1  |   File "/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 398, in _make_request
celery-worker3_1  |     conn.request(method, url, **httplib_request_kw)
celery-worker3_1  |   File "/usr/local/lib/python3.9/site-packages/urllib3/connection.py", line 239, in request
celery-worker3_1  |     super(HTTPConnection, self).request(method, url, body=body, headers=headers)
celery-worker3_1  |   File "/usr/local/lib/python3.9/http/client.py", line 1285, in request
celery-worker3_1  |     self._send_request(method, url, body, headers, encode_chunked)
celery-worker3_1  |   File "/usr/local/lib/python3.9/http/client.py", line 1331, in _send_request
celery-worker3_1  |     self.endheaders(body, encode_chunked=encode_chunked)
celery-worker3_1  |   File "/usr/local/lib/python3.9/http/client.py", line 1280, in endheaders
celery-worker3_1  |     self._send_output(message_body, encode_chunked=encode_chunked)
celery-worker3_1  |   File "/usr/local/lib/python3.9/http/client.py", line 1040, in _send_output
celery-worker3_1  |     self.send(msg)
celery-worker3_1  |   File "/usr/local/lib/python3.9/http/client.py", line 980, in send
celery-worker3_1  |     self.connect()
celery-worker3_1  |   File "/usr/local/lib/python3.9/site-packages/urllib3/connection.py", line 205, in connect
celery-worker3_1  |     conn = self._new_conn()
celery-worker3_1  |   File "/usr/local/lib/python3.9/site-packages/urllib3/connection.py", line 186, in _new_conn
celery-worker3_1  |     raise NewConnectionError(
celery-worker3_1  | urllib3.exceptions.NewConnectionError: <urllib3.connection.HTTPConnection object at 0x7f18a15ae850>: Failed to establish a new connection: [Errno 111] Connection refused
celery-worker3_1  | 
celery-worker3_1  | During handling of the above exception, another exception occurred:
celery-worker3_1  | 
celery-worker3_1  | Traceback (most recent call last):
celery-worker3_1  |   File "/usr/local/lib/python3.9/site-packages/requests/adapters.py", line 489, in send
celery-worker3_1  |     resp = conn.urlopen(
celery-worker3_1  |   File "/usr/local/lib/python3.9/site-packages/urllib3/connectionpool.py", line 787, in urlopen
celery-worker3_1  |     retries = retries.increment(
celery-worker3_1  |   File "/usr/local/lib/python3.9/site-packages/urllib3/util/retry.py", line 592, in increment
celery-worker3_1  |     raise MaxRetryError(_pool, url, error or ResponseError(cause))
celery-worker3_1  | urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='localhost', port=84): Max retries exceeded with url: /api/v1/auth/tokens (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f18a15ae850>: Failed to establish a new 
connection: [Errno 111] Connection refused'))
celery-worker3_1  | 
celery-worker3_1  | During handling of the above exception, another exception occurred:
celery-worker3_1  | 
celery-worker3_1  | Traceback (most recent call last):
celery-worker3_1  |   File "/usr/local/lib/python3.9/site-packages/celery/app/trace.py", line 450, in trace_task
celery-worker3_1  |     R = retval = fun(*args, **kwargs)
celery-worker3_1  |   File "/code/app/__init__.py", line 143, in __call__
celery-worker3_1  |     return self.run(*args, **kwargs)
celery-worker3_1  |   File "/code/app/extensions/prometheus/tasks.py", line 31, in prometheus_update
celery-worker3_1  |     response = prometheus.send_update(data)
celery-worker3_1  |   File "/code/app/extensions/prometheus/__init__.py", line 337, in send_update
celery-worker3_1  |     session.fetch_token(
celery-worker3_1  |   File "/usr/local/lib/python3.9/site-packages/requests_oauthlib/oauth2_session.py", line 219, in fetch_token
celery-worker3_1  |     r = self.post(token_url, data=dict(urldecode(body)),
celery-worker3_1  |   File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 635, in post
celery-worker3_1  |     return self.request("POST", url, data=data, json=json, **kwargs)
celery-worker3_1  |   File "/usr/local/lib/python3.9/site-packages/requests_oauthlib/oauth2_session.py", line 359, in request
celery-worker3_1  |     return super(OAuth2Session, self).request(method, url,
celery-worker3_1  |   File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 587, in request
celery-worker3_1  |     resp = self.send(prep, **send_kwargs)
celery-worker3_1  |   File "/usr/local/lib/python3.9/site-packages/requests/sessions.py", line 701, in send
celery-worker3_1  |     r = adapter.send(request, **kwargs)
celery-worker3_1  |   File "/usr/local/lib/python3.9/site-packages/requests/adapters.py", line 565, in send
celery-worker3_1  |     raise ConnectionError(e, request=request)
celery-worker3_1  | requests.exceptions.ConnectionError: HTTPConnectionPool(host='localhost', port=84): Max retries exceeded with url: /api/v1/auth/tokens (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f18a15ae850>: Failed to establish a new connection: [Errno 111] Connection refused'))

```
Suspecting it may be a local issue on my setup but not sure