### PR TITLE
DEX-1465: fixes from dry-run of EDM-removal

### DIFF
--- a/app/modules/progress/models.py
+++ b/app/modules/progress/models.py
@@ -149,6 +149,13 @@ class Progress(db.Model, Timestamp):
 
     @property
     def ahead(self):
+        try:
+            return self._attempt_ahead()
+        except Exception as ex:
+            log.warning(f'failed getting ahead on {self} due to {ex}')
+        return None
+
+    def _attempt_ahead(self):
         import json
 
         import redis

--- a/tasks/codex/edm.py
+++ b/tasks/codex/edm.py
@@ -381,7 +381,19 @@ def transfer_data_encounter():
             enc.taxonomy_guid = tx_id
 
         edm_custom_fields = edm_data.get('customFields', {})
-        enc.set_custom_field_values(edm_custom_fields)
+        try:
+            enc.set_custom_field_values(edm_custom_fields)
+        except ValueError as ve:
+            if str(ve).startswith('Value "" is not valid for'):
+                log.info(f'attempting to repair: {edm_custom_fields}')
+                for key in edm_custom_fields:
+                    if edm_custom_fields[key] == '':
+                        edm_custom_fields[key] = None
+                log.info(f'repaired candidate: {edm_custom_fields}')
+                enc.set_custom_field_values(edm_custom_fields)
+            else:
+                log.error(f'unrepairable fail on {edm_custom_fields} for {enc}')
+                raise ve
     db.session.flush()
     print('encounter edm data transfer complete')
 
@@ -437,7 +449,19 @@ def transfer_data_sighting():
             sighting.set_taxonomies(taxonomies)
 
         edm_custom_fields = edm_data.get('customFields', {})
-        sighting.set_custom_field_values(edm_custom_fields)
+        try:
+            sighting.set_custom_field_values(edm_custom_fields)
+        except ValueError as ve:
+            if str(ve).startswith('Value "" is not valid for'):
+                log.info(f'attempting to repair: {edm_custom_fields}')
+                for key in edm_custom_fields:
+                    if edm_custom_fields[key] == '':
+                        edm_custom_fields[key] = None
+                log.info(f'repaired candidate: {edm_custom_fields}')
+                sighting.set_custom_field_values(edm_custom_fields)
+            else:
+                log.error(f'unrepairable fail on {edm_custom_fields} for {sighting}')
+                raise ve
     db.session.flush()
     print('sighting edm data transfer complete')
 


### PR DESCRIPTION
## Pull Request Overview

**Improvements based on dry-run EDM removal**

- Name changes in some customFields
- Gracefully skip record missing on EDM
- Task to specifically do data-transfer _within_ `config` on AGS

**Note**

- There is a bug-fix in `progress/models.py` that I added to this PR because it showed up during my testing.  It basically is a bug that only shows up **when Sage is not running (or responding)** so probably would be rare in the wild, but effectively broke the `GET /api/v1/sightings/GUID` api call so is kind of nasty.