### PR TITLE
new tasks for running detection

### DIFF
--- a/tasks/codex/sightings.py
+++ b/tasks/codex/sightings.py
@@ -65,3 +65,83 @@ def print_sighting_id_resullt(context, sighting_guid):
     if not sighting:
         print(f'Sighting {sighting_guid} not found')
     pprint.pprint(sighting.get_id_result())
+
+
+@app_context_task
+def send_one_to_detection(context, model, guid):
+    """
+    Send Assets from this Sighting to detection (--model MODEL, like seals_v1)
+
+    """
+
+    from app.modules.sightings.models import Sighting
+
+    sighting = Sighting.query.get(guid)
+
+    if sighting is None:
+        print(f'Sighting {guid} not found')
+        return
+    _send_sighting_to_detection(sighting, model)
+
+
+def _send_sighting_to_detection(sighting, model):
+    from app.extensions import db
+    from app.modules.asset_groups.models import (
+        AssetGroupSighting,
+        AssetGroupSightingStage,
+    )
+
+    if sighting.asset_group_sighting:
+        ags = sighting.asset_group_sighting
+        ags.config['detections'] = [model]
+        ags.config['sighting']['speciesDetectionModel'] = [model]
+        ags.config = ags.config
+        ags.stage = AssetGroupSightingStage.detection
+        db.session.merge(ags)
+        db.session.refresh(ags)
+        ags.start_detection(True)
+
+    else:
+        if not sighting.get_assets():
+            print('No assets to find AssetGroup')
+        ag = sighting.get_assets()[0].git_store
+        ag.init_progress_detection()
+        sconf = {'assetReferences': []}
+        for asset in sighting.get_assets():
+            sconf['assetReferences'].append(asset.filename)
+        # note: this AGS does *not* get persisted to db, but thats how we started?
+        ags = AssetGroupSighting(
+            asset_group=ag,
+            sighting_config=sconf,
+            detection_configs=[model],
+        )
+        ags.stage = AssetGroupSightingStage.detection
+        db.session.merge(ags)
+        db.session.refresh(ags)
+        ags.start_detection(True)
+
+
+@app_context_task
+def send_batch_to_detection(context, model, batchsize=10):
+    """
+    Send Assets from N Sightings to detection (--model MODEL, like seals_v1)
+
+    """
+
+    from app.extensions import db
+    from app.modules.sightings.models import Sighting
+
+    sighting_guids = []
+    res = db.session.execute(
+        f'SELECT DISTINCT(sighting.guid) FROM sighting JOIN sighting_assets ON (sighting.guid=sighting_guid) JOIN asset ON (sighting_assets.asset_guid=asset.guid) JOIN git_store ON (git_store_guid=git_store.guid) WHERE progress_detection_guid IS NULL ORDER BY sighting.guid LIMIT {batchsize}'
+    )
+    for row in res:
+        sighting_guids.append(row[0])
+
+    ct = 1
+    for guid in sighting_guids:
+        sighting = Sighting.query.get(guid)
+        assert sighting
+        print(f'[{ct} of {batchsize}] processing {guid}')
+        ct += 1
+        _send_sighting_to_detection(sighting, model)


### PR DESCRIPTION
## Pull Request Overview

- Two new _invoke tasks_ for running detections:
  - `invoke codex.sightings.send-one-to-detection --model MODEL --guid GUID`
  - `invoke codex.sightings.send-batch-to-detection --model MODEL [--batchsize 10]`

**Notes**
- The second task will attempt to find Sightings which _have not had detection run_ and process them in `batchsize` batches, sorted by guid.