### PR TITLE
set a 5-second timeout on waiting for sage

### DIFF
--- a/app/modules/progress/models.py
+++ b/app/modules/progress/models.py
@@ -198,7 +198,7 @@ class Progress(db.Model, Timestamp):
                     pass
 
         if self.sage_guid:
-            passthrough_kwargs = {'timeout': 5}
+            passthrough_kwargs = {'timeout': 15}
             jobs = current_app.sage.request_passthrough_result(
                 'engine.list',
                 'get',

--- a/app/modules/progress/models.py
+++ b/app/modules/progress/models.py
@@ -198,8 +198,12 @@ class Progress(db.Model, Timestamp):
                     pass
 
         if self.sage_guid:
+            passthrough_kwargs = {'timeout': 5}
             jobs = current_app.sage.request_passthrough_result(
-                'engine.list', 'get', target='default'
+                'engine.list',
+                'get',
+                target='default',
+                passthrough_kwargs=passthrough_kwargs,
             )['json_result']
             statuses, sage_jobs = current_app.sage.get_job_status(jobs, exclude_done=True)
 


### PR DESCRIPTION
## Pull Request Overview

- calling `progress.ahead` can make a call to Sage, which can hang (a long time) if Sage happens to be down.  This blocks a couple api calls.  This reduces the timeout on this to 5 seconds.