### PR TITLE
Fix for bulk-import sequential ID running bug

### DIFF
--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -492,6 +492,8 @@ class Annotation(db.Model, HoustonModel, SageModel):
                             'minimum_should_match': 1,
                             'should': viewpoint_data,
                         }
+                elif macro_name == 'annotation_git_store_guid':
+                    replaced[key] = self.get_git_store_guid_str()
                 elif macro_name == 'annotation_sighting_guid':
                     replaced[key] = self.get_sighting_guid_str()
                 elif macro_name == 'annotation_encounter_guid':

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -408,7 +408,20 @@ class Annotation(db.Model, HoustonModel, SageModel):
         log.info(
             f'annot.get_matching_set(): finding matching set for {self} using (resolved) query {query} => {len(matching_set)} annots'
         )
+        log.info(
+            f'annot.get_matching_set() checksum: {self.matching_set_checksum(matching_set)}'
+        )
         return matching_set
+
+    # this is really just a debugging thing that is a "thumbprint" of a matchingset
+    def matching_set_checksum(self, matching_set):
+        import hashlib
+
+        guids = [str(a.guid) for a in matching_set]
+        guids.sort()
+        return (
+            f"{len(matching_set)}:{hashlib.sha256(''.join(guids).encode()).hexdigest()}"
+        )
 
     def get_matching_set_default_query(self):
         # n.b. default will not take any locationId or ownership into consideration

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -417,7 +417,9 @@ class Annotation(db.Model, HoustonModel, SageModel):
     def matching_set_checksum(self, matching_set):
         import hashlib
 
-        guids = [str(a.guid) for a in matching_set]
+        guids = [
+            str(a.guid) if isinstance(a, Annotation) else str(a) for a in matching_set
+        ]
         guids.sort()
         return (
             f"{len(matching_set)}:{hashlib.sha256(''.join(guids).encode()).hexdigest()}"

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -534,6 +534,9 @@ class Annotation(db.Model, HoustonModel, SageModel):
             return None
         return self.encounter.get_sighting_guid_str()
 
+    def get_git_store_guid_str(self):
+        return str(self.asset.git_store.guid)
+
     def get_keyword_values(self):
         if not self.keyword_refs:
             return []

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -409,7 +409,7 @@ class Annotation(db.Model, HoustonModel, SageModel):
             f'annot.get_matching_set(): finding matching set for {self} using (resolved) query {query} => {len(matching_set)} annots'
         )
         log.info(
-            f'annot.get_matching_set() checksum: {self.matching_set_checksum(matching_set)}'
+            f'annot.get_matching_set() [annot {str(self.guid)}] checksum: {self.matching_set_checksum(matching_set)}'
         )
         return matching_set
 

--- a/app/modules/annotations/schemas.py
+++ b/app/modules/annotations/schemas.py
@@ -75,6 +75,7 @@ class AnnotationElasticsearchSchema(BaseAnnotationSchema):
     encounter_guid = base_fields.Function(lambda ann: ann.get_encounter_guid_str())
     sighting_guid = base_fields.Function(lambda ann: ann.get_sighting_guid_str())
     time = base_fields.Function(lambda ann: ann.get_time_isoformat_in_timezone())
+    git_store_guid = base_fields.Function(lambda ann: ann.get_git_store_guid_str())
 
     class Meta(BaseAnnotationSchema.Meta):
         fields = BaseAnnotationSchema.Meta.fields + (
@@ -88,6 +89,7 @@ class AnnotationElasticsearchSchema(BaseAnnotationSchema):
             'taxonomy_guid',
             'encounter_guid',
             'sighting_guid',
+            'git_store_guid',
             'time',
         )
         dump_only = BaseAnnotationSchema.Meta.dump_only + (

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -1186,6 +1186,7 @@ class AssetGroupSighting(db.Model, HoustonModel):
                         log, annotation, 'from Sage detection response'
                     )
                     db.session.add(annotation)
+                    annotation.index()
 
                 for asset in assets:
                     db.session.merge(asset)


### PR DESCRIPTION
## Pull Request Overview

When a Bulk Import is done, the user (usually) commits the related sightings one at a time in sequence. Each commit (usually) triggers an ID job. The problem is, each ID jobs is matching against _one (or more) additional_ Annotation than the previous, which is a nightmare for caching on Sage.

Proposed solution in this PR is to modify the matching-set query such that it will include all Annotations _within the same AssetGroup_ so as to hopefully have a better chance of having cache-hits in Sage.

- Modify Annotation Elasticsearch schema to include AssetGroup (aka GitStore) guid
- Adjust matching-set query to including Annotations in same AssetGroup even when they have no Encounter (yet)

## Related

- **Frontend** query needs to be similarly modified (see [ frontend PR472](https://github.com/WildMeOrg/codex-frontend/pull/472))
- Match Results need to ignore(?) matching Annotations with no Encounter - this is saved for **subsequent PR if needed**