### PR TITLE
cdx-19 & cdx-20: extend Elasticsearch fields on Sightings

### DIFF
--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -606,8 +606,16 @@ class CustomFieldMixin(object):
                     self.__class__.__name__, cfd_id
                 )
                 val = cf[cfd_id]
-                if defn['type'] == 'geo' and val:
-                    val = {'lat': val[0], 'lon': val[1]}
+                if defn['type'] == 'geo':
+                    if (
+                        isinstance(val, list)
+                        and len(val) == 2
+                        and val[0] is not None
+                        and val[1] is not None
+                    ):
+                        val = {'lat': val[0], 'lon': val[1]}
+                    else:
+                        val = None
                 cf_es[cfd_id] = val
         return cf_es
 

--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -589,11 +589,11 @@ class CustomFieldMixin(object):
 
     # TODO we probably want one to ADD values to a multiple=TRUE list-type
 
-    def get_custom_fields_strict(self):
+    def get_custom_fields_elasticsearch(self):
         from app.modules.site_settings.helpers import SiteSettingCustomFields
 
         cf = self.custom_fields
-        cf_strict = {}
+        cf_es = {}
         for cfd_id in cf:
             if not SiteSettingCustomFields.is_valid_value_for_class(
                 self.__class__.__name__, cfd_id, cf[cfd_id]
@@ -602,8 +602,14 @@ class CustomFieldMixin(object):
                     f'skipping custom field definition {cfd_id} with invalid value "{cf[cfd_id]}" on {self}'
                 )
             else:
-                cf_strict[cfd_id] = cf[cfd_id]
-        return cf_strict
+                defn = SiteSettingCustomFields.get_definition(
+                    self.__class__.__name__, cfd_id
+                )
+                val = cf[cfd_id]
+                if defn['type'] == 'geo' and val:
+                    val = {'lat': val[0], 'lon': val[1]}
+                cf_es[cfd_id] = val
+        return cf_es
 
     @classmethod
     def custom_field_elasticsearch_mappings(cls, mapping):

--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -605,6 +605,28 @@ class CustomFieldMixin(object):
                 cf_strict[cfd_id] = cf[cfd_id]
         return cf_strict
 
+    @classmethod
+    def custom_field_elasticsearch_mappings(cls, mapping):
+        from app.modules.site_settings.models import SiteSetting
+
+        if not mapping or 'properties' not in mapping:
+            return mapping
+
+        es_type_map = {
+            'date': 'date',
+            'float': 'float',
+            'feetmeters': 'float',
+            'integer': 'integer',
+            'geo': 'geo_point',
+            'boolean': 'boolean',
+        }
+        data = SiteSetting.get_value(f'site.custom.customFields.{cls.__name__}') or {}
+        definitions = data.get('definitions', [])
+        for defn in definitions:
+            es_type = es_type_map.get(defn['type'], 'text')
+            mapping['properties'][defn['id']] = {'type': es_type}
+        return mapping
+
 
 ##########################################################################################
 

--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -589,6 +589,22 @@ class CustomFieldMixin(object):
 
     # TODO we probably want one to ADD values to a multiple=TRUE list-type
 
+    def get_custom_fields_strict(self):
+        from app.modules.site_settings.helpers import SiteSettingCustomFields
+
+        cf = self.custom_fields
+        cf_strict = {}
+        for cfd_id in cf:
+            if not SiteSettingCustomFields.is_valid_value_for_class(
+                self.__class__.__name__, cfd_id, cf[cfd_id]
+            ):
+                log.warning(
+                    f'skipping custom field definition {cfd_id} with invalid value "{cf[cfd_id]}" on {self}'
+                )
+            else:
+                cf_strict[cfd_id] = cf[cfd_id]
+        return cf_strict
+
 
 ##########################################################################################
 

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -155,6 +155,10 @@ class Sighting(db.Model, HoustonModel, CustomFieldMixin):
         mappings['location_geo_point'] = {
             'type': 'geo_point',
         }
+        if 'customFields' in mappings:
+            mappings['customFields'] = cls.custom_field_elasticsearch_mappings(
+                mappings['customFields']
+            )
 
         return mappings
 

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -301,6 +301,22 @@ class Sighting(db.Model, HoustonModel, CustomFieldMixin):
     def get_custom_fields(self):
         return self.custom_fields
 
+    def get_custom_fields_strict(self):
+        from app.modules.site_settings.helpers import SiteSettingCustomFields
+
+        cf = self.custom_fields
+        cf_strict = {}
+        for cfd_id in cf:
+            if not SiteSettingCustomFields.is_valid_value_for_class(
+                'Sighting', cfd_id, cf[cfd_id]
+            ):
+                log.warning(
+                    f'skipping custom field definition {cfd_id} with invalid value "{cf[cfd_id]}" on {self}'
+                )
+            else:
+                cf_strict[cfd_id] = cf[cfd_id]
+        return cf_strict
+
     def init_progress_identification(self, overwrite=False):
         from app.modules.progress.models import Progress
 

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -318,22 +318,6 @@ class Sighting(db.Model, HoustonModel, CustomFieldMixin):
     def get_custom_fields(self):
         return self.custom_fields
 
-    def get_custom_fields_strict(self):
-        from app.modules.site_settings.helpers import SiteSettingCustomFields
-
-        cf = self.custom_fields
-        cf_strict = {}
-        for cfd_id in cf:
-            if not SiteSettingCustomFields.is_valid_value_for_class(
-                'Sighting', cfd_id, cf[cfd_id]
-            ):
-                log.warning(
-                    f'skipping custom field definition {cfd_id} with invalid value "{cf[cfd_id]}" on {self}'
-                )
-            else:
-                cf_strict[cfd_id] = cf[cfd_id]
-        return cf_strict
-
     def init_progress_identification(self, overwrite=False):
         from app.modules.progress.models import Progress
 

--- a/app/modules/sightings/schemas.py
+++ b/app/modules/sightings/schemas.py
@@ -73,7 +73,7 @@ class ElasticsearchSightingSchema(BaseSightingSchema):
     taxonomy_guids = base_fields.Function(
         lambda s: s.get_taxonomy_guids_with_encounters()
     )
-    customFields = base_fields.Function(lambda s: s.get_custom_fields_strict())
+    customFields = base_fields.Function(lambda s: s.get_custom_fields_elasticsearch())
     submissionTime = base_fields.Function(lambda s: s.get_submission_time_isoformat())
     pipelineState = base_fields.Function(lambda s: s.get_pipeline_state())
     numberEncounters = base_fields.Function(lambda s: s.get_number_encounters())

--- a/app/modules/sightings/schemas.py
+++ b/app/modules/sightings/schemas.py
@@ -64,6 +64,7 @@ class ElasticsearchSightingSchema(BaseSightingSchema):
     locationId = base_fields.UUID(attribute='location_guid')
     locationId_value = base_fields.Function(lambda s: s.get_location_id_value())
     locationId_keyword = base_fields.Function(lambda s: s.get_location_id_keyword())
+    location_geo_point = base_fields.Function(lambda s: s.get_geo_point())
     owners = base_fields.Nested(
         'PublicUserSchema',
         attribute='get_owners',
@@ -95,6 +96,7 @@ class ElasticsearchSightingSchema(BaseSightingSchema):
             'locationId',
             'locationId_value',
             'locationId_keyword',
+            'location_geo_point',
             'owners',
             'taxonomy_guids',
             'customFields',

--- a/app/modules/sightings/schemas.py
+++ b/app/modules/sightings/schemas.py
@@ -72,7 +72,7 @@ class ElasticsearchSightingSchema(BaseSightingSchema):
     taxonomy_guids = base_fields.Function(
         lambda s: s.get_taxonomy_guids_with_encounters()
     )
-    customFields = base_fields.Function(lambda s: s.get_custom_fields())
+    customFields = base_fields.Function(lambda s: s.get_custom_fields_strict())
     submissionTime = base_fields.Function(lambda s: s.get_submission_time_isoformat())
     pipelineState = base_fields.Function(lambda s: s.get_pipeline_state())
     numberEncounters = base_fields.Function(lambda s: s.get_number_encounters())

--- a/app/modules/sightings/schemas.py
+++ b/app/modules/sightings/schemas.py
@@ -69,9 +69,15 @@ class ElasticsearchSightingSchema(BaseSightingSchema):
         attribute='get_owners',
         many=True,
     )
-    taxonomy_guids = base_fields.Function(lambda s: s.get_taxonomy_guids())
+    taxonomy_guids = base_fields.Function(
+        lambda s: s.get_taxonomy_guids_with_encounters()
+    )
     customFields = base_fields.Function(lambda s: s.get_custom_fields())
     submissionTime = base_fields.Function(lambda s: s.get_submission_time_isoformat())
+    pipelineState = base_fields.Function(lambda s: s.get_pipeline_state())
+    numberEncounters = base_fields.Function(lambda s: s.get_number_encounters())
+    numberImages = base_fields.Function(lambda s: s.get_number_assets())
+    numberAnnotations = base_fields.Function(lambda s: s.get_number_annotations())
 
     class Meta:
         # pylint: disable=missing-docstring
@@ -93,6 +99,11 @@ class ElasticsearchSightingSchema(BaseSightingSchema):
             'taxonomy_guids',
             'customFields',
             'submissionTime',
+            'stage',
+            'pipelineState',
+            'numberEncounters',
+            'numberImages',
+            'numberAnnotations',
         )
         dump_only = (
             Sighting.guid.key,
@@ -176,6 +187,7 @@ class DetailedSightingSchema(TimedSightingSchema):
     locationId_value = base_fields.Function(lambda s: s.get_location_id_value())
     locationId_keyword = base_fields.Function(lambda s: s.get_location_id_keyword())
     pipeline_status = base_fields.Function(lambda s: s.get_pipeline_status())
+    pipeline_state = base_fields.Function(lambda s: s.get_pipeline_state())
 
     class Meta(TimedSightingSchema.Meta):
         """
@@ -207,6 +219,7 @@ class DetailedSightingSchema(TimedSightingSchema):
             'locationId',
             'locationId_keyword',
             'pipeline_status',
+            'pipeline_state',
         )
 
 

--- a/integration_tests/test_asset_group_sightings.py
+++ b/integration_tests/test_asset_group_sightings.py
@@ -376,6 +376,7 @@ def test_asset_group_sightings(session, login, codex_url, test_root):
         'idConfigs': [{'algorithms': ['hotspotter_nosv']}],
         'unreviewed_start_time': response.json()['unreviewed_start_time'],
         'pipeline_status': response.json()['pipeline_status'],
+        'pipeline_state': response.json()['pipeline_state'],
         'verbatimLocality': None,
     }
     # due to task timing, both are valid


### PR DESCRIPTION
## Note on searching Custom Fields

Custom Fields can be searched with a very similar syntax to other ("standard") fields.  The `query` value is treated the same: the value to match on. However, for the field-name in the `fields: [ ]` array should be of the form: `customFields.DEFN_GUID` where `DEFN_GUID` is the **customField Definition ID**.

For example, if there is a customField with Definition ID `736d8b8f-7abb-404f-9da8-0c1507185baa`, searching for _"fish"_ would include something like this in the search payload:
```
...
       "query_string" : {
          "query" : "*fish*",
          "fields" : [
             "customFields.736d8b8f-7abb-404f-9da8-0c1507185baa"
          ],
...
```