### PR TITLE
cdx-21 & cdx-22: extend Elasticsearch fields on Individuals

### DIFF
--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -215,6 +215,22 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin):
     def get_custom_fields(self):
         return self.custom_fields
 
+    def get_custom_fields_strict(self):
+        from app.modules.site_settings.helpers import SiteSettingCustomFields
+
+        cf = self.custom_fields
+        cf_strict = {}
+        for cfd_id in cf:
+            if not SiteSettingCustomFields.is_valid_value_for_class(
+                'Individual', cfd_id, cf[cfd_id]
+            ):
+                log.warning(
+                    f'skipping custom field definition {cfd_id} with invalid value "{cf[cfd_id]}" on {self}'
+                )
+            else:
+                cf_strict[cfd_id] = cf[cfd_id]
+        return cf_strict
+
     def get_taxonomy_guid(self):
         return self.taxonomy_guid
 

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -215,22 +215,6 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin):
     def get_custom_fields(self):
         return self.custom_fields
 
-    def get_custom_fields_strict(self):
-        from app.modules.site_settings.helpers import SiteSettingCustomFields
-
-        cf = self.custom_fields
-        cf_strict = {}
-        for cfd_id in cf:
-            if not SiteSettingCustomFields.is_valid_value_for_class(
-                'Individual', cfd_id, cf[cfd_id]
-            ):
-                log.warning(
-                    f'skipping custom field definition {cfd_id} with invalid value "{cf[cfd_id]}" on {self}'
-                )
-            else:
-                cf_strict[cfd_id] = cf[cfd_id]
-        return cf_strict
-
     def get_taxonomy_guid(self):
         return self.taxonomy_guid
 

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -1045,3 +1045,19 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin):
                 }
             )
         return es
+
+    def get_relationships_elasticsearch(self):
+        rels = []
+        for mem in self.relationship_memberships:
+            rel = mem.relationship
+            rels.append(
+                {
+                    'guid': str(rel.guid),
+                    'type_guid': str(rel.type_guid),
+                    'type_label': rel.type_label,
+                    'role_label': mem.individual_role_label,
+                    'role_guid': str(mem.individual_role_guid),
+                    'other_individual_guid': str(rel.other_individual(self.guid).guid),
+                }
+            )
+        return rels

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -174,6 +174,10 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin):
         }
         mappings['firstName'] = {'type': 'keyword'}
         mappings['comments'] = {'type': 'text'}
+        if 'customFields' in mappings:
+            mappings['customFields'] = cls.custom_field_elasticsearch_mappings(
+                mappings['customFields']
+            )
         return mappings
 
     def __repr__(self):

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -181,6 +181,9 @@ class ElasticsearchIndividualSchema(ModelSchema):
     social_groups = base_fields.Function(
         lambda ind: ind.get_social_groups_elasticsearch()
     )
+    relationships = base_fields.Function(
+        lambda ind: ind.get_relationships_elasticsearch()
+    )
     sex = base_fields.Function(lambda ind: ind.get_sex())
     birth = base_fields.Function(lambda ind: ind.get_time_of_birth())
     death = base_fields.Function(lambda ind: ind.get_time_of_death())
@@ -214,6 +217,7 @@ class ElasticsearchIndividualSchema(ModelSchema):
             'adoptionName',
             'taxonomy_guid',
             'social_groups',
+            'relationships',
             'sex',
             'encounters',
             'birth',

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -188,7 +188,7 @@ class ElasticsearchIndividualSchema(ModelSchema):
     birth = base_fields.Function(lambda ind: ind.get_time_of_birth())
     death = base_fields.Function(lambda ind: ind.get_time_of_death())
     comments = base_fields.Function(lambda ind: ind.get_comments())
-    customFields = base_fields.Function(lambda ind: ind.get_custom_fields_strict())
+    customFields = base_fields.Function(lambda ind: ind.get_custom_fields_elasticsearch())
     taxonomy_guid = base_fields.Function(lambda ind: ind.get_taxonomy_guid())
     has_annotations = base_fields.Function(lambda ind: ind.has_annotations())
     num_encounters = base_fields.Function(lambda ind: ind.num_encounters())

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -188,7 +188,7 @@ class ElasticsearchIndividualSchema(ModelSchema):
     birth = base_fields.Function(lambda ind: ind.get_time_of_birth())
     death = base_fields.Function(lambda ind: ind.get_time_of_death())
     comments = base_fields.Function(lambda ind: ind.get_comments())
-    customFields = base_fields.Function(lambda ind: ind.get_custom_fields())
+    customFields = base_fields.Function(lambda ind: ind.get_custom_fields_strict())
     taxonomy_guid = base_fields.Function(lambda ind: ind.get_taxonomy_guid())
     has_annotations = base_fields.Function(lambda ind: ind.has_annotations())
     num_encounters = base_fields.Function(lambda ind: ind.num_encounters())

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -178,23 +178,25 @@ class ElasticsearchIndividualSchema(ModelSchema):
     firstName_keyword = base_fields.Function(lambda ind: ind.get_first_name_keyword())
     adoptionName = base_fields.Function(lambda ind: ind.get_adoption_name())
     encounters = base_fields.Nested(ElasticsearchEncounterSchema, many=True)
-    # see DEX-1457 for why this was (temporarily?) disabled
-    # social_groups = base_fields.Function(lambda ind: ind.get_social_groups_json())
+    social_groups = base_fields.Function(
+        lambda ind: ind.get_social_groups_elasticsearch()
+    )
     sex = base_fields.Function(lambda ind: ind.get_sex())
     birth = base_fields.Function(lambda ind: ind.get_time_of_birth())
     death = base_fields.Function(lambda ind: ind.get_time_of_death())
     comments = base_fields.Function(lambda ind: ind.get_comments())
     customFields = base_fields.Function(lambda ind: ind.get_custom_fields())
-    taxonomy_guid = base_fields.Function(
-        lambda ind: ind.get_taxonomy_guid_inherit_encounters()
-    )
+    taxonomy_guid = base_fields.Function(lambda ind: ind.get_taxonomy_guid())
     has_annotations = base_fields.Function(lambda ind: ind.has_annotations())
     num_encounters = base_fields.Function(lambda ind: ind.num_encounters())
     last_seen = base_fields.Function(lambda ind: ind.get_last_seen_time_isoformat())
     last_seen_specificity = base_fields.Function(
         lambda ind: ind.get_last_seen_time_specificity()
     )
-    taxonomy_names = base_fields.Function(lambda ind: ind.get_taxonomy_names())
+    taxonomy_names = base_fields.Function(
+        lambda ind: ind.get_taxonomy_names(inherit_encounters=False)
+    )
+    numberSightings = base_fields.Function(lambda s: s.get_number_sightings())
 
     class Meta:
         # pylint: disable=missing-docstring
@@ -223,6 +225,7 @@ class ElasticsearchIndividualSchema(ModelSchema):
             'last_seen',
             'last_seen_specificity',
             'taxonomy_names',
+            'numberSightings',
         )
         dump_only = (
             Individual.guid.key,
@@ -241,8 +244,7 @@ class ElasticsearchIndividualReturnSchema(ModelSchema):
     firstName = base_fields.Function(lambda ind: ind.get_first_name())
     firstName_keyword = base_fields.Function(lambda ind: ind.get_first_name_keyword())
     adoptionName = base_fields.Function(lambda ind: ind.get_adoption_name())
-    # see DEX-1457 for why this was (temporarily?) disabled
-    # social_groups = base_fields.Function(lambda ind: ind.get_social_groups_json())
+    social_groups = base_fields.Function(lambda ind: ind.get_social_groups_json())
     sex = base_fields.Function(lambda ind: ind.get_sex())
     birth = base_fields.Function(lambda ind: ind.get_time_of_birth())
     death = base_fields.Function(lambda ind: ind.get_time_of_death())

--- a/app/modules/relationships/models.py
+++ b/app/modules/relationships/models.py
@@ -162,6 +162,14 @@ class Relationship(db.Model, HoustonModel):
             return True
         return False
 
+    def other_individual(self, individual_guid):
+        if not self.has_individual(individual_guid):
+            return None
+        for individual_member in self.individual_members:
+            if individual_member.individual_guid != individual_guid:
+                return individual_member.individual
+        return None
+
     def get_relationship_role_for_individual(self, individual_guid):
         membership = self._get_membership_for_guid(individual_guid)
         if membership:


### PR DESCRIPTION
### Custom Fields
For details on searching on Custom Fields, see [PR853](https://github.com/WildMeOrg/houston/pull/853).

### Elasticsearch Queries on Relationships / SocialGroups
ES schema for `relationships` and `social_groups` are pretty complex:
```
          "relationships" : [
            {
              "guid" : "6bdd8000-fc69-443c-8a0b-42e522386124",
              "type_guid" : "c3e8e92b-7c18-44aa-929d-19e354ed9d2f",
              "type_label" : "sibling",
              "role_label" : "brother/sister",
              "role_guid" : "d7779688-5703-48ba-8a09-064ef6e61b3b",
              "other_individual_guid" : "342d44a3-6f66-4817-801a-5cc31d92b70e"
            }
          ],
```

```
          "social_groups" : [
            {
              "guid" : "8794d7f2-ca0d-4809-ab45-928151c87f9c",
              "name" : "softball team",
              "role_guids" : [
                "6eea9ed8-2a0d-476f-bebd-204a517784e1"
              ],
              "role_names" : [
                "Pitcher"
              ]
            }
          ],
```
And yet, one can just use the _field_ `social_groups.role_guids` or `relationships.role_guid` in an ES query, and it should match an individual if any object _in the list_ matches.