### PR TITLE
cdx-15: bugfix around customField setting of "atypical" values

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -95,6 +95,8 @@ jobs:
         run: |
           set -ex
           docker-compose up -d db redis elasticsearch elasticsearch2 elasticsearch3 sage sage-sync houston celery-beat celery-worker
+        env:
+          ES_THRESHOLD: false
 
       - name: Check docker-compose status
         run: |

--- a/app/extensions/__init__.py
+++ b/app/extensions/__init__.py
@@ -575,6 +575,21 @@ class CustomFieldMixin(object):
             self.custom_fields = cf
             db.session.merge(self)
 
+    # does above, but assumes values are serialized, so deserializes first
+    def set_custom_field_values_json(self, set_dict):
+        from app.modules.site_settings.helpers import SiteSettingCustomFields
+
+        assert isinstance(set_dict, dict), 'must pass dict'
+        for cfd_id in set_dict:
+            value = set_dict[cfd_id]
+            if value is not None:
+                defn = SiteSettingCustomFields.get_definition(
+                    self.__class__.__name__, cfd_id
+                )
+                assert defn
+                set_dict[cfd_id] = SiteSettingCustomFields.deserialize_value(defn, value)
+        self.set_custom_field_values(set_dict)
+
     def reset_custom_field_value(self, cfd_id):
         from app.modules.site_settings.helpers import SiteSettingCustomFields
 

--- a/app/modules/asset_groups/models.py
+++ b/app/modules/asset_groups/models.py
@@ -244,8 +244,10 @@ class AssetGroupSighting(db.Model, HoustonModel):
         cf_dict = self.sighting_config.get('customFields', {})
         invalid = {}
         for cfd_id in cf_dict:
+            defn = SiteSettingCustomFields.get_definition('Sighting', cfd_id)
+            deser_value = SiteSettingCustomFields.deserialize_value(defn, cf_dict[cfd_id])
             valid = SiteSettingCustomFields.is_valid_value_for_class(
-                'Sighting', cfd_id, cf_dict[cfd_id]
+                'Sighting', cfd_id, deser_value
             )
             if not valid:
                 invalid[cfd_id] = cf_dict[cfd_id]

--- a/app/modules/encounters/parameters.py
+++ b/app/modules/encounters/parameters.py
@@ -99,7 +99,7 @@ class PatchEncounterDetailsParameters(PatchJSONParameters):
             # possible backstory: DEX-753
             assert isinstance(value, dict), 'customFields must be passed a json object'
             if value.get('id'):
-                assert value.get('value'), 'customFields id/value format needs both'
+                assert 'value' in value, 'customFields id/value format needs both'
                 value = {value['id']: value['value']}
             obj.set_custom_field_values_json(value)  # does all the validation etc
             ret_val = True

--- a/app/modules/encounters/parameters.py
+++ b/app/modules/encounters/parameters.py
@@ -101,7 +101,7 @@ class PatchEncounterDetailsParameters(PatchJSONParameters):
             if value.get('id'):
                 assert value.get('value'), 'customFields id/value format needs both'
                 value = {value['id']: value['value']}
-            obj.set_custom_field_values(value)  # does all the validation etc
+            obj.set_custom_field_values_json(value)  # does all the validation etc
             ret_val = True
         elif field == 'decimalLatitude':
             if value is not None and not util.is_valid_latitude(value):

--- a/app/modules/individuals/parameters.py
+++ b/app/modules/individuals/parameters.py
@@ -274,7 +274,7 @@ class PatchIndividualDetailsParameters(PatchJSONParameters):
             # see explanation on encounter patch
             assert isinstance(value, dict), 'customFields must be passed a json object'
             if value.get('id'):
-                assert value.get('value'), 'customFields id/value format needs both'
+                assert 'value' in value, 'customFields id/value format needs both'
                 value = {value['id']: value['value']}
             obj.set_custom_field_values_json(value)  # does all the validation etc
             ret_val = True

--- a/app/modules/individuals/parameters.py
+++ b/app/modules/individuals/parameters.py
@@ -276,7 +276,7 @@ class PatchIndividualDetailsParameters(PatchJSONParameters):
             if value.get('id'):
                 assert value.get('value'), 'customFields id/value format needs both'
                 value = {value['id']: value['value']}
-            obj.set_custom_field_values(value)  # does all the validation etc
+            obj.set_custom_field_values_json(value)  # does all the validation etc
             ret_val = True
         elif field == 'names':
             from app.modules.names.models import Name

--- a/app/modules/sightings/parameters.py
+++ b/app/modules/sightings/parameters.py
@@ -133,7 +133,7 @@ class PatchSightingDetailsParameters(PatchJSONParameters):
                 if value.get('id'):
                     assert value.get('value'), 'customFields id/value format needs both'
                     value = {value['id']: value['value']}
-                obj.set_custom_field_values(value)  # does all the validation etc
+                obj.set_custom_field_values_json(value)  # does all the validation etc
                 ret_val = True
             elif field == 'decimalLatitude':
                 if value and not util.is_valid_latitude(value):

--- a/app/modules/sightings/parameters.py
+++ b/app/modules/sightings/parameters.py
@@ -131,7 +131,7 @@ class PatchSightingDetailsParameters(PatchJSONParameters):
                     value, dict
                 ), 'customFields must be passed a json object'
                 if value.get('id'):
-                    assert value.get('value'), 'customFields id/value format needs both'
+                    assert 'value' in value, 'customFields id/value format needs both'
                     value = {value['id']: value['value']}
                 obj.set_custom_field_values_json(value)  # does all the validation etc
                 ret_val = True

--- a/docker-compose.codex.yml
+++ b/docker-compose.codex.yml
@@ -76,7 +76,7 @@ services:
       - discovery.seed_hosts=elasticsearch2,elasticsearch3
       - cluster.initial_master_nodes=elasticsearch,elasticsearch2,elasticsearch3
       - bootstrap.memory_lock=true
-      - cluster.routing.allocation.disk.threshold_enabled=false
+      - cluster.routing.allocation.disk.threshold_enabled=${ES_THRESHOLD:-true}
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 
   elasticsearch2:
@@ -103,7 +103,7 @@ services:
       - discovery.seed_hosts=elasticsearch,elasticsearch3
       - cluster.initial_master_nodes=elasticsearch,elasticsearch2,elasticsearch3
       - bootstrap.memory_lock=true
-      - cluster.routing.allocation.disk.threshold_enabled=false
+      - cluster.routing.allocation.disk.threshold_enabled=${ES_THRESHOLD:-true}
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 
   elasticsearch3:
@@ -130,7 +130,7 @@ services:
       - discovery.seed_hosts=elasticsearch,elasticsearch2
       - cluster.initial_master_nodes=elasticsearch,elasticsearch2,elasticsearch3
       - bootstrap.memory_lock=true
-      - cluster.routing.allocation.disk.threshold_enabled=false
+      - cluster.routing.allocation.disk.threshold_enabled=${ES_THRESHOLD:-true}
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 
   kibana:

--- a/tests/extensions/custom_fields/test_custom_fields_ext.py
+++ b/tests/extensions/custom_fields/test_custom_fields_ext.py
@@ -517,6 +517,7 @@ def test_set_and_reset_values(
         admin_user,
         'test_cfd_daterange',
         displayType='daterange',
+        multiple=True,
     )
     assert _set_and_reset_test(db, sight, cfd_id, [dt_old, dt]) == 0
 

--- a/tests/modules/account_requests/resources/test_account_requests.py
+++ b/tests/modules/account_requests/resources/test_account_requests.py
@@ -17,6 +17,8 @@ log = logging.getLogger(__name__)
 def test_create(
     flask_app_client,
 ):
+    from app.modules.account_requests.models import AccountRequest
+
     data = {
         'name': None,
         'email': 'test@example.com',
@@ -32,12 +34,15 @@ def test_create(
     result = req_utils.create_account_request(flask_app_client, data)
     assert result.json['name'] == data['name']
     assert result.json['email'] == data['email']
+    AccountRequest.query.delete()
 
 
 @pytest.mark.skipif(
     module_unavailable('account_requests'), reason='AccountRequest module disabled'
 )
 def test_read_all(flask_app_client, staff_user, regular_user):
+    from app.modules.account_requests.models import AccountRequest
+
     data = {
         'name': 'test name',
         'email': 'test@example.com',
@@ -50,3 +55,4 @@ def test_read_all(flask_app_client, staff_user, regular_user):
     test = reqs.json.pop()
     assert test['name'] == data['name']
     assert test['email'] == data['email']
+    AccountRequest.query.delete()

--- a/tests/modules/sightings/resources/test_custom_fields.py
+++ b/tests/modules/sightings/resources/test_custom_fields.py
@@ -26,6 +26,18 @@ def test_custom_fields_on_sighting(
         flask_app_client, admin_user, 'test_cfd', cls='Sighting'
     )
     assert cfd_id is not None
+    cfd_date_id = setting_utils.custom_field_create(
+        flask_app_client, admin_user, 'test_cfd_date', displayType='date', cls='Sighting'
+    )
+    assert cfd_date_id is not None
+    cfd_int_id = setting_utils.custom_field_create(
+        flask_app_client,
+        admin_user,
+        'test_cfd_integer',
+        displayType='integer',
+        cls='Sighting',
+    )
+    assert cfd_int_id is not None
     cfd_multi_id = setting_utils.custom_field_create(
         flask_app_client, admin_user, 'test_multi_cfd', multiple=True, cls='Sighting'
     )
@@ -35,6 +47,8 @@ def test_custom_fields_on_sighting(
     # transaction_id, test_filename = sighting_utils.prep_tus_dir(test_root)
     cfd_test_value = 'CFD_TEST_VALUE'
     cfd_multi_value = ['one', 'two']
+    cfd_date_value = '2000-01-02T03:04:05+00:00'
+    cfd_int_value = 123456
     data_in = {
         'time': timestamp,
         'timeSpecificity': 'time',
@@ -42,6 +56,8 @@ def test_custom_fields_on_sighting(
         'customFields': {
             cfd_id: cfd_test_value,
             cfd_multi_id: cfd_multi_value,
+            cfd_date_id: cfd_date_value,
+            cfd_int_id: cfd_int_value,
         },
         'encounters': [{}],
     }
@@ -116,6 +132,8 @@ def test_custom_fields_on_sighting(
             'customFields': {
                 cfd_id: cfd_test_value,
                 cfd_multi_id: cfd_multi_value,
+                cfd_date_id: cfd_date_value,
+                cfd_int_id: cfd_int_value,
             },
             # Only asserting that these fields exist
             'time': full_sighting.json['time'],
@@ -128,11 +146,17 @@ def test_custom_fields_on_sighting(
     assert 'customFields' in full_sighting.json
     assert cfd_id in full_sighting.json['customFields']
     assert cfd_multi_id in full_sighting.json['customFields']
+    assert cfd_int_id in full_sighting.json['customFields']
+    assert cfd_date_id in full_sighting.json['customFields']
     assert full_sighting.json['customFields'][cfd_id] == cfd_test_value
     assert full_sighting.json['customFields'][cfd_multi_id] == cfd_multi_value
+    assert full_sighting.json['customFields'][cfd_int_id] == cfd_int_value
+    assert full_sighting.json['customFields'][cfd_date_id] == cfd_date_value
 
     # test patch on customFields
     new_cfd_test_value = 'NEW_CFD_TEST_VALUE'
+    new_cfd_date_value = '2022-02-22T02:02:02.003000+02:00'  # the returned value gets these trailing zeroes added (003000), so we do same here
+    new_cfd_int_value = 99999
     new_cfd_multi_value = ['A', 'B']
     sighting_utils.patch_sighting(
         flask_app_client,
@@ -143,6 +167,15 @@ def test_custom_fields_on_sighting(
                 'op': 'replace',
                 'path': '/customFields',
                 'value': {'id': cfd_id, 'value': new_cfd_test_value},
+            },
+            # tests value flavor: { cfd_id1: value1, cfd_id2: value2 } which is what frontend actually uses
+            {
+                'op': 'replace',
+                'path': '/customFields',
+                'value': {
+                    cfd_date_id: new_cfd_date_value,
+                    cfd_int_id: new_cfd_int_value,
+                },
             },
             {
                 'op': 'replace',
@@ -164,6 +197,10 @@ def test_custom_fields_on_sighting(
     assert full_sighting.json['customFields'][cfd_id] == new_cfd_test_value
     assert cfd_multi_id in full_sighting.json['customFields']
     assert full_sighting.json['customFields'][cfd_multi_id] == new_cfd_multi_value
+    assert cfd_int_id in full_sighting.json['customFields']
+    assert full_sighting.json['customFields'][cfd_int_id] == new_cfd_int_value
+    assert cfd_date_id in full_sighting.json['customFields']
+    assert full_sighting.json['customFields'][cfd_date_id] == new_cfd_date_value
 
     # now since we have some values in use, lets make sure we cannot delete the definition
     res = setting_utils.patch_main_setting(


### PR DESCRIPTION
## Pull Request Overview (cdx-15)

- handles better _customField_ values which are stored internally different than serialized (e.g. `date`)
- some tests for same
- bugfix around setting customFields in original AssetGroupSighting