### PR TITLE
cdx-53: heatmap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apt update \
         # Needed for profiling
         graphviz \
         #: required by wait-for
-        netcat \
+        netcat-traditional \
         #: required for downloading 'wait-for'
         curl \
  && rm -rf /var/lib/apt/lists/*

--- a/app/modules/annotations/resources.py
+++ b/app/modules/annotations/resources.py
@@ -394,3 +394,21 @@ class AnnotationDebugByID(Resource):
         Get Annotation debug details by ID.
         """
         return annotation.get_debug_json()
+
+
+@api.route('/sage-heatmaps/src/<string:filename>')
+class AnnotationSageHeatmap(Resource):
+    def get(self, filename):
+        import os
+
+        from flask import current_app, send_file
+
+        # TODO make this a path in sightings (or etc) cuz it is duplicated there
+        filepath = os.path.join(
+            current_app.config.get('FILEUPLOAD_BASE_PATH', '/tmp'),
+            'sage-heatmaps',
+            filename,
+        )
+        if not os.path.exists(filepath):
+            abort(code=HTTPStatus.NOT_FOUND)
+        return send_file(filepath, 'image/jpeg')

--- a/app/modules/annotations/resources.py
+++ b/app/modules/annotations/resources.py
@@ -403,6 +403,7 @@ class AnnotationSageHeatmap(Resource):
 
         from flask import current_app, send_file
 
+        filename = os.path.normpath(filename)
         if '/' in filename:  # prevent dir-roaming
             abort(code=HTTPStatus.NOT_FOUND)
 

--- a/app/modules/annotations/resources.py
+++ b/app/modules/annotations/resources.py
@@ -403,6 +403,9 @@ class AnnotationSageHeatmap(Resource):
 
         from flask import current_app, send_file
 
+        if '/' in filename:  # prevent dir-roaming
+            abort(code=HTTPStatus.NOT_FOUND)
+
         # TODO make this a path in sightings (or etc) cuz it is duplicated there
         filepath = os.path.join(
             current_app.config.get('FILEUPLOAD_BASE_PATH', '/tmp'),

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -1556,7 +1556,7 @@ class Sighting(db.Model, HoustonModel, CustomFieldMixin):
                 log.error(f'error {str(err)} on fetching {sage_src} to {filepath}')
                 return
             open(filepath, 'wb').write(resp.content)
-        return f'/api/v1/annotations/sage-heatmaps/{filename}'
+        return f'/api/v1/annotations/sage-heatmaps/src/{filename}'
 
     # Helper to ensure that the required annot and individual data is present
     def _ensure_annot_data_in_response(self, annot, response):

--- a/docker-compose.codex.yml
+++ b/docker-compose.codex.yml
@@ -76,6 +76,7 @@ services:
       - discovery.seed_hosts=elasticsearch2,elasticsearch3
       - cluster.initial_master_nodes=elasticsearch,elasticsearch2,elasticsearch3
       - bootstrap.memory_lock=true
+      - cluster.routing.allocation.disk.threshold_enabled=false
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 
   elasticsearch2:
@@ -102,6 +103,7 @@ services:
       - discovery.seed_hosts=elasticsearch,elasticsearch3
       - cluster.initial_master_nodes=elasticsearch,elasticsearch2,elasticsearch3
       - bootstrap.memory_lock=true
+      - cluster.routing.allocation.disk.threshold_enabled=false
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 
   elasticsearch3:
@@ -128,6 +130,7 @@ services:
       - discovery.seed_hosts=elasticsearch,elasticsearch2
       - cluster.initial_master_nodes=elasticsearch,elasticsearch2,elasticsearch3
       - bootstrap.memory_lock=true
+      - cluster.routing.allocation.disk.threshold_enabled=false
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
 
   kibana:


### PR DESCRIPTION
## cdx-53: heatmap api endpoint
- Creates a cached "heatmap" image on houston for matches from sage
- Image is created per query/dictionary annotation pairs in the `id_result` api data (under both `scores_by_annotation` and `scores_by_individual` blocks) as `heatmap_src` property
- null/missing means there is no heatmap available

### Example api json:
in `/api/v1/sightings/SIGHTING-GUID/id_result` response:
```
...
algorithms: {
    hotspotter_nosv: {
        scores_by_annotation: [
        {
            guid: "fa2b066c-0c05-401c-bced-a59f0dfc0c84",
            score: 722.3327067179931,
            id_finish_time: "2023-07-07 17:28:11",
>>>>>       heatmap_src: "/api/v1/annotations/sage-heatmaps/src/sage-heatmap-dkriojsxkcufqdzz-e74968b6-9e34-4b45-bbf9-a00aafc8bdbb-cf6376f7-4f5e-4e3a-9009-395c280e534e.jpg"
        },
        ...
```