### PR TITLE
account-request fix(es?)

### DIFF
--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -1542,7 +1542,7 @@ class Sighting(db.Model, HoustonModel, CustomFieldMixin):
         )
         if not os.path.exists(filepath):  # not already cached
             os.makedirs(os.path.dirname(filepath), exist_ok=True)
-            sage_src = f'{uri}api/query/graph/match/thumb/?extern_reference={extern_ref}&query_annot_uuid={q_annot_content_uuid}&database_annot_uuid={d_annot_content_uuid}&version=heatmask'
+            sage_src = f'{uri}/api/query/graph/match/thumb/?extern_reference={extern_ref}&query_annot_uuid={q_annot_content_uuid}&database_annot_uuid={d_annot_content_uuid}&version=heatmask'
             resp = requests.get(sage_src)
             if not resp.headers['content-type'].lower().startswith('image/'):
                 log.error(

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -138,6 +138,7 @@ else:
         ('Notification', AccessOperation.READ_PRIVILEGED): ['is_user_manager'],
         ('Keyword', AccessOperation.READ): ['is_active'],
         ('Keyword', AccessOperation.WRITE): ['is_active'],
+        ('AccountRequest', AccessOperation.READ): ['is_admin'],
         ('AuditLog', AccessOperation.READ): ['is_admin'],
         ('SocialGroup', AccessOperation.READ): ['is_researcher'],
         ('SocialGroup', AccessOperation.WRITE): ['is_researcher'],


### PR DESCRIPTION
## Misc fixes:
* Allow _administrators_ to do `/api/v1/account-requests` endpoint
* heatmap sage url was missing a `/`