### PR TITLE
882, 883: AutogeneratedName - Sighting/Individual search support

### DIFF
--- a/app/extensions/elasticsearch/__init__.py
+++ b/app/extensions/elasticsearch/__init__.py
@@ -56,7 +56,6 @@ class ElasticsearchModel(object):
 
     @classmethod
     def get_elasticsearch_settings(cls):
-        return None
         settings = {
             'analysis': {
                 'normalizer': {

--- a/app/extensions/elasticsearch/__init__.py
+++ b/app/extensions/elasticsearch/__init__.py
@@ -56,7 +56,18 @@ class ElasticsearchModel(object):
 
     @classmethod
     def get_elasticsearch_settings(cls):
-        return None
+        settings = {
+            'analysis': {
+                'normalizer': {
+                    'codex_keyword_normalizer': {
+                        'type': 'custom',
+                        'char_filter': [],
+                        'filter': ['lowercase', 'asciifolding'],
+                    }
+                }
+            }
+        }
+        return settings
 
     @classmethod
     def patch_elasticsearch_mappings(cls, mappings):

--- a/app/extensions/elasticsearch/__init__.py
+++ b/app/extensions/elasticsearch/__init__.py
@@ -56,6 +56,7 @@ class ElasticsearchModel(object):
 
     @classmethod
     def get_elasticsearch_settings(cls):
+        return None
         settings = {
             'analysis': {
                 'normalizer': {

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -267,7 +267,7 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin):
     #    return tx.get_all_names()
 
     def get_name_values(self):
-        name_vals = [name.value for name in self.names]
+        name_vals = [name.value_resolved for name in self.names]
         return name_vals
 
     def get_first_name(self):

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -166,18 +166,26 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin):
     @classmethod
     def patch_elasticsearch_mappings(cls, mappings):
         mappings = super(Individual, cls).patch_elasticsearch_mappings(mappings)
-        mappings['death'] = {'type': 'date'}
-        mappings['birth'] = {'type': 'date'}
-        mappings['names'] = {
-            'fields': {'keyword': {'ignore_above': 256, 'type': 'keyword'}},
-            'type': 'text',
-        }
-        mappings['firstName'] = {'type': 'keyword'}
-        mappings['comments'] = {'type': 'text'}
+
+        # ensures these get added only at top-level
+        if '_schema' in mappings:
+            mappings['death'] = {'type': 'date'}
+            mappings['birth'] = {'type': 'date'}
+            mappings['names'] = {
+                'fields': {'keyword': {'ignore_above': 256, 'type': 'keyword'}},
+                'type': 'text',
+            }
+            mappings['firstName'] = {'type': 'keyword'}
+            mappings['comments'] = {'type': 'text'}
+
         if 'customFields' in mappings:
             mappings['customFields'] = cls.custom_field_elasticsearch_mappings(
                 mappings['customFields']
             )
+
+        if 'namesWithContexts' in mappings:
+            for context in mappings['namesWithContexts']['properties']:
+                mappings['namesWithContexts']['properties'][context] = {'type': 'keyword'}
         return mappings
 
     def __repr__(self):

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -270,6 +270,9 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin):
         name_vals = [name.value_resolved for name in self.names]
         return name_vals
 
+    def get_names_with_contexts(self):
+        return {name.context: name.value_resolved for name in self.names}
+
     def get_first_name(self):
         first_name = None
         for name in self.names:

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -172,10 +172,19 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin):
             mappings['death'] = {'type': 'date'}
             mappings['birth'] = {'type': 'date'}
             mappings['names'] = {
-                'fields': {'keyword': {'ignore_above': 256, 'type': 'keyword'}},
+                'fields': {
+                    'keyword': {
+                        'ignore_above': 256,
+                        'type': 'keyword',
+                        'normalizer': 'codex_keyword_normalizer',
+                    }
+                },
                 'type': 'text',
             }
-            mappings['firstName'] = {'type': 'keyword'}
+            mappings['firstName'] = {
+                'type': 'keyword',
+                'normalizer': 'codex_keyword_normalizer',
+            }
             mappings['comments'] = {'type': 'text'}
 
         if 'customFields' in mappings:
@@ -185,7 +194,10 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin):
 
         if 'namesWithContexts' in mappings:
             for context in mappings['namesWithContexts']['properties']:
-                mappings['namesWithContexts']['properties'][context] = {'type': 'keyword'}
+                mappings['namesWithContexts']['properties'][context] = {
+                    'type': 'keyword',
+                    'normalizer': 'codex_keyword_normalizer',
+                }
         return mappings
 
     def __repr__(self):

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -192,7 +192,10 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin):
                 mappings['customFields']
             )
 
-        if 'namesWithContexts' in mappings:
+        if (
+            'namesWithContexts' in mappings
+            and 'properties' in mappings['namesWithContexts']
+        ):
             for context in mappings['namesWithContexts']['properties']:
                 mappings['namesWithContexts']['properties'][context] = {
                     'type': 'keyword',

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -174,6 +174,7 @@ class ElasticsearchIndividualSchema(ModelSchema):
 
     featuredAssetGuid = base_fields.Function(lambda ind: ind.get_featured_asset_guid())
     names = base_fields.Function(lambda ind: ind.get_name_values())
+    namesWithContexts = base_fields.Function(lambda ind: ind.get_names_with_contexts())
     firstName = base_fields.Function(lambda ind: ind.get_first_name())
     firstName_keyword = base_fields.Function(lambda ind: ind.get_first_name_keyword())
     adoptionName = base_fields.Function(lambda ind: ind.get_adoption_name())
@@ -212,6 +213,7 @@ class ElasticsearchIndividualSchema(ModelSchema):
             Individual.updated.key,
             'featuredAssetGuid',
             'names',
+            'namesWithContexts',
             'firstName',
             'firstName_keyword',
             'adoptionName',

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -167,7 +167,10 @@ class Sighting(db.Model, HoustonModel, CustomFieldMixin):
                 'normalizer': 'codex_keyword_normalizer',
             }
 
-        if 'individualNamesWithContexts' in mappings:
+        if (
+            'individualNamesWithContexts' in mappings
+            and 'properties' in mappings['individualNamesWithContexts']
+        ):
             for context in mappings['individualNamesWithContexts']['properties']:
                 mappings['individualNamesWithContexts']['properties'][context] = {
                     'type': 'keyword',

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -152,13 +152,23 @@ class Sighting(db.Model, HoustonModel, CustomFieldMixin):
     def patch_elasticsearch_mappings(cls, mappings):
         mappings = super(Sighting, cls).patch_elasticsearch_mappings(mappings)
 
-        mappings['location_geo_point'] = {
-            'type': 'geo_point',
-        }
+        # this *adds* location_geo_point - but only at top-level
+        if '_schema' in mappings:
+            mappings['location_geo_point'] = {'type': 'geo_point'}
+
         if 'customFields' in mappings:
             mappings['customFields'] = cls.custom_field_elasticsearch_mappings(
                 mappings['customFields']
             )
+
+        if 'individualNames' in mappings:
+            mappings['individualNames'] = {'type': 'keyword'}
+
+        if 'individualNamesWithContexts' in mappings:
+            for context in mappings['individualNamesWithContexts']['properties']:
+                mappings['individualNamesWithContexts']['properties'][context] = {
+                    'type': 'keyword'
+                }
 
         return mappings
 

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -860,6 +860,29 @@ class Sighting(db.Model, HoustonModel, CustomFieldMixin):
 
         return job_data
 
+    @property
+    def individuals(self):
+        indivs = set()
+        for enc in self.encounters:
+            if enc.individual_guid:
+                indivs.add(enc.individual)
+        return indivs
+
+    def get_individual_names(self):
+        names = set()
+        for indiv in self.individuals:
+            names.update(indiv.get_name_values())
+        return names
+
+    def get_individual_names_with_contexts(self):
+        nwc = {}
+        for indiv in self.individuals:
+            for name in indiv.names:
+                if name.context not in nwc:
+                    nwc[name.context] = set()
+                nwc[name.context].add(name.value_resolved)
+        return nwc
+
     def delete(self):
         AuditLog.delete_object(log, self)
         with db.session.begin(subtransactions=True):

--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -162,12 +162,16 @@ class Sighting(db.Model, HoustonModel, CustomFieldMixin):
             )
 
         if 'individualNames' in mappings:
-            mappings['individualNames'] = {'type': 'keyword'}
+            mappings['individualNames'] = {
+                'type': 'keyword',
+                'normalizer': 'codex_keyword_normalizer',
+            }
 
         if 'individualNamesWithContexts' in mappings:
             for context in mappings['individualNamesWithContexts']['properties']:
                 mappings['individualNamesWithContexts']['properties'][context] = {
-                    'type': 'keyword'
+                    'type': 'keyword',
+                    'normalizer': 'codex_keyword_normalizer',
                 }
 
         return mappings

--- a/app/modules/sightings/schemas.py
+++ b/app/modules/sightings/schemas.py
@@ -79,9 +79,13 @@ class ElasticsearchSightingSchema(BaseSightingSchema):
     numberEncounters = base_fields.Function(lambda s: s.get_number_encounters())
     numberImages = base_fields.Function(lambda s: s.get_number_assets())
     numberAnnotations = base_fields.Function(lambda s: s.get_number_annotations())
-    individualNames = base_fields.Function(lambda s: s.get_individual_names())
-    individualNameWithContexts = base_fields.Function(
-        lambda s: s.get_individual_names_with_contexts()
+    # apparently sets do NOT work well, so we need to name-sets to lists here
+    individualNames = base_fields.Function(lambda s: list(s.get_individual_names()))
+    individualNamesWithContexts = base_fields.Function(
+        lambda s: {
+            item: list(val)
+            for (item, val) in s.get_individual_names_with_contexts().items()
+        }
     )
 
     class Meta:

--- a/app/modules/sightings/schemas.py
+++ b/app/modules/sightings/schemas.py
@@ -55,7 +55,7 @@ class CreateSightingSchema(BaseSightingSchema):
 
 class ElasticsearchSightingSchema(BaseSightingSchema):
     """
-    Base Sighting schema exposes only the most general fields.
+    Sighting schema for ElasticSearch
     """
 
     time = base_fields.Function(lambda s: s.get_time_isoformat_in_timezone())
@@ -79,6 +79,10 @@ class ElasticsearchSightingSchema(BaseSightingSchema):
     numberEncounters = base_fields.Function(lambda s: s.get_number_encounters())
     numberImages = base_fields.Function(lambda s: s.get_number_assets())
     numberAnnotations = base_fields.Function(lambda s: s.get_number_annotations())
+    individualNames = base_fields.Function(lambda s: s.get_individual_names())
+    individualNameWithContexts = base_fields.Function(
+        lambda s: s.get_individual_names_with_contexts()
+    )
 
     class Meta:
         # pylint: disable=missing-docstring
@@ -106,6 +110,8 @@ class ElasticsearchSightingSchema(BaseSightingSchema):
             'numberEncounters',
             'numberImages',
             'numberAnnotations',
+            'individualNames',
+            'individualNamesWithContexts',
         )
         dump_only = (
             Sighting.guid.key,

--- a/tests/modules/individuals/resources/test_individual_names.py
+++ b/tests/modules/individuals/resources/test_individual_names.py
@@ -75,6 +75,15 @@ def test_get_set_individual_names(
         flask_app_client, researcher_1, individual_id
     ).json
 
+    assert len(sighting.individuals) == 1
+    test_ind = next(iter(sighting.individuals))
+    assert individual_json['guid'] == str(test_ind.guid)
+    assert sighting.get_individual_names() == {'value-A', 'value-B'}
+    assert sighting.get_individual_names_with_contexts() == {
+        'A': {'value-A'},
+        'B': {'value-B'},
+    }
+
     # invalid value
     patch_data = [
         utils.patch_add_op('names', 'FAIL'),
@@ -145,6 +154,15 @@ def test_get_set_individual_names(
         flask_app_client, researcher_1, individual_id, patch_data
     )
     assert len(patch_individual_response.json['names']) == 4
+
+    # "test-value" is duplicated across 2 names, but only appears here once:
+    assert sighting.get_individual_names() == {'test-value', 'value-A', 'value-B'}
+    assert sighting.get_individual_names_with_contexts() == {
+        'A': {'value-A'},
+        'B': {'value-B'},
+        'test-context': {'test-value'},
+        'context2': {'test-value'},
+    }
 
     # now this should conflict (409) due to duplicate context
     patch_data = [


### PR DESCRIPTION
Addresses #882 and #883

Adds to **Sighting** Elasticsearch schema:
```
"individualNames": [ "nameA", "nameB", "nameC" ]
"individualNamesWithContexts": {
    "contextX": [ "nameA", "nameB" ],
    "contextY": [ "nameC" ]
}, ....
```

Adds to **Individual** Elasticsearch schema:
```
"namesWithContexts": {
    "contextX": "nameA",
    "contextY": "nameB"
}, ....
```

Elastic search query will use something along these lines:
```
  "filter" : [
    {
      "wildcard": {
        "individualNamesWithContexts.autogen-0e24896c-c7d9-421b-bca8-8aa39a95a525": "*ELDS-001*"
      }
    }
  ],
```
