### PR TITLE
907/908: Individual search results to include most recent sighting fields

### DIFF
--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -372,6 +372,21 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin, ExportMixin):
         if encounter in self.get_encounters():
             self.encounters.remove(encounter)
 
+    def get_most_recent_encounter(self):
+        latest = None
+        latest_time = -2
+        for enc in self.encounters:
+            # note: enc.get_time() will fallback to sighting.time if needed
+            sv = enc.get_time().sort_value if enc.get_time() else -1
+            if sv > latest_time:
+                latest_time = sv
+                latest = enc
+        return latest
+
+    def get_most_recent_sighting(self):
+        enc = self.get_most_recent_encounter()
+        return enc.sighting if enc else None
+
     def get_sightings(self):
         sightings = set()  # force unique
         for enc in self.encounters:

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -408,8 +408,8 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin, ExportMixin):
         return sightings
 
     def get_most_recent_verbatim_locality(self):
-        # FIXME pending detailed definition
-        return None
+        mrs = self.get_most_recent_sighting()
+        return mrs.verbatim_locality if mrs else None
 
     def get_most_recent_location_name(self):
         mrs = self.get_most_recent_sighting()

--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -372,6 +372,7 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin, ExportMixin):
         if encounter in self.get_encounters():
             self.encounters.remove(encounter)
 
+    # "should never be None"
     def get_most_recent_encounter(self):
         latest = None
         latest_time = -2
@@ -383,6 +384,13 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin, ExportMixin):
                 latest = enc
         return latest
 
+    def get_encounters_chronological(self):
+        return sorted(
+            self.encounters,
+            key=lambda enc: enc.get_time().sort_value if enc.get_time() else -1,
+        )
+
+    # "should never be None"
     def get_most_recent_sighting(self):
         enc = self.get_most_recent_encounter()
         return enc.sighting if enc else None
@@ -392,6 +400,20 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin, ExportMixin):
         for enc in self.encounters:
             sightings.add(enc.sighting)
         return sightings
+
+    def get_sightings_chronological(self):
+        sightings = []
+        for enc in self.get_encounters_chronological():
+            sightings.append(enc.sighting)
+        return sightings
+
+    def get_most_recent_verbatim_locality(self):
+        # FIXME pending detailed definition
+        return None
+
+    def get_most_recent_location_name(self):
+        mrs = self.get_most_recent_sighting()
+        return mrs.get_location_id_value() if mrs else None
 
     def get_number_sightings(self):
         return len(self.get_sightings())

--- a/app/modules/individuals/schemas.py
+++ b/app/modules/individuals/schemas.py
@@ -264,6 +264,12 @@ class ElasticsearchIndividualReturnSchema(ModelSchema):
     last_seen_specificity = base_fields.Function(
         lambda ind: ind.get_last_seen_time_specificity(),
     )
+    last_seen_verbatimLocality = base_fields.Function(
+        lambda ind: ind.get_most_recent_verbatim_locality()
+    )
+    last_seen_location_name = base_fields.Function(
+        lambda ind: ind.get_most_recent_location_name()
+    )
     taxonomy_names = base_fields.Function(lambda ind: ind.get_taxonomy_names())
 
     encounters = base_fields.Function(lambda ind: ind.get_encounter_guids())
@@ -295,6 +301,8 @@ class ElasticsearchIndividualReturnSchema(ModelSchema):
             'has_annotations',
             'last_seen',
             'last_seen_specificity',
+            'last_seen_verbatimLocality',
+            'last_seen_location_name',
             'taxonomy_names',
         )
         dump_only = (

--- a/tests/modules/complex_date_time/test_basics.py
+++ b/tests/modules/complex_date_time/test_basics.py
@@ -42,6 +42,16 @@ def test_models(db, request):
     assert cdt
     assert cdt.datetime == dt.astimezone(tz.UTC)
     assert cdt.datetime == cdt.get_datetime_in_timezone()
+    assert cdt.lower_bound < cdt.datetime
+    assert cdt.upper_bound > cdt.datetime
+    assert (
+        cdt.sort_value
+        == (
+            datetime.datetime.timestamp(cdt.upper_bound)
+            + datetime.datetime.timestamp(cdt.lower_bound)
+        )
+        / 2
+    )
 
     with db.session.begin():
         db.session.add(cdt)


### PR DESCRIPTION
add some fields to api results for Individual search:
- `last_seen_location_name` - location (region) name for most recent sighting of individual
- `last_seen_verbatim_locality` - freeform location for most recent sighting

some supporting utility methods added to ComplexDateTime and Individual models