### PR TITLE
906: deletion of Annotation also removes it from AssetGroupSightings

### DIFF
--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -570,7 +570,7 @@ class Annotation(db.Model, HoustonModel, SageModel):
         for ags in self.asset.git_store.asset_group_sightings:
             ags.remove_annotation(str(self.guid))
             ags.config = ags.config
-            with db.session.begin():
+            with db.session.begin(subtransactions=True):
                 db.session.merge(ags)
         with db.session.begin(subtransactions=True):
             while self.keyword_refs:

--- a/app/modules/annotations/models.py
+++ b/app/modules/annotations/models.py
@@ -566,6 +566,12 @@ class Annotation(db.Model, HoustonModel, SageModel):
         return sorted(ref.keyword.value for ref in self.keyword_refs)
 
     def delete(self):
+        # first we remove annot from any AGS it might be in (issue houston#906)
+        for ags in self.asset.git_store.asset_group_sightings:
+            ags.remove_annotation(str(self.guid))
+            ags.config = ags.config
+            with db.session.begin():
+                db.session.merge(ags)
         with db.session.begin(subtransactions=True):
             while self.keyword_refs:
                 ref = self.keyword_refs.pop()


### PR DESCRIPTION
`annot.delete()` also removes (references to) annotation from AssetGroupSighting(s) as applicable.