### PR TITLE
911: normalize adoptionName in ElasticSearch

### DIFF
--- a/app/modules/individuals/models.py
+++ b/app/modules/individuals/models.py
@@ -199,6 +199,10 @@ class Individual(db.Model, HoustonModel, CustomFieldMixin, ExportMixin):
                 'type': 'keyword',
                 'normalizer': 'codex_keyword_normalizer',
             }
+            mappings['adoptionName'] = {
+                'type': 'keyword',
+                'normalizer': 'codex_keyword_normalizer',
+            }
             mappings['comments'] = {'type': 'text'}
 
         if 'customFields' in mappings:


### PR DESCRIPTION
use standard case normalizer for `adoptionName` in Individual ES schema