### PR TITLE
overhaul Sighting.stage usage

### DIFF
--- a/app/modules/sightings/models.py
+++ b/app/modules/sightings/models.py
@@ -487,14 +487,6 @@ class Sighting(db.Model, HoustonModel, CustomFieldMixin, ExportMixin):
                 enc_data['customFields'][cfd_id].append(cf[cfd_id])
         return enc_data
 
-    def reviewed(self):
-        ret_val = False
-        if self.stage == SightingStage.un_reviewed:
-            self.set_stage(SightingStage.processed)
-            self.review_time = datetime.datetime.utcnow()
-            ret_val = True
-        return ret_val
-
     def get_time_isoformat_in_timezone(self):
         return self.time.isoformat_in_timezone() if self.time else None
 

--- a/app/modules/sightings/parameters.py
+++ b/app/modules/sightings/parameters.py
@@ -86,6 +86,8 @@ class PatchSightingDetailsParameters(PatchJSONParameters):
     @classmethod
     def replace(cls, obj, field, value, state):
 
+        from datetime import datetime
+
         from app.modules.assets.models import Asset
         from app.modules.complex_date_time.models import ComplexDateTime
 
@@ -173,6 +175,11 @@ class PatchSightingDetailsParameters(PatchJSONParameters):
                         log, f'match_state value passed ({value}) is invalid'
                     )
                 obj.match_state = value
+                if (
+                    value == SightingMatchState.reviewed
+                    or value == SightingMatchState.unidentifiable
+                ):
+                    obj.review_time = datetime.utcnow()
                 ret_val = True
 
         return ret_val

--- a/app/modules/sightings/resources.py
+++ b/app/modules/sightings/resources.py
@@ -577,26 +577,6 @@ class SightingDebugByID(Resource):
         return sighting
 
 
-@api.route('/<uuid:sighting_guid>/reviewed', doc=False)
-@api.login_required(oauth_scopes=['sightings:write'])
-@api.response(
-    code=HTTPStatus.NOT_FOUND,
-    description='Sighting not found.',
-)
-@api.resolve_object_by_model(Sighting, 'sighting')
-class SightingReviewedByID(Resource):
-    @api.permission_required(
-        permissions.ObjectAccessPermission,
-        kwargs_on_request=lambda kwargs: {
-            'obj': kwargs['sighting'],
-            'action': AccessOperation.WRITE,
-        },
-    )
-    def post(self, sighting):
-        if sighting.reviewed():
-            AuditLog.audit_log_object(log, sighting, 'Reviewed')
-
-
 @api.route('/jobs/<uuid:sighting_guid>')
 @api.response(
     code=HTTPStatus.NOT_FOUND,

--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -588,12 +588,15 @@ class User(db.Model, HoustonModel):
 
     @module_required('sightings', resolve='warn', default=[])
     def unprocessed_sightings(self):
-        from app.modules.sightings.models import SightingStage
+        from app.modules.sightings.models import SightingMatchState
 
         return [
             sighting.guid
             for sighting in self.get_sightings()
-            if not sighting.stage == SightingStage.processed
+            if not (
+                sighting.match_state == SightingMatchState.reviewed
+                or sighting.match_state == SightingMatchState.unidentifiable
+            )
         ]
 
     @module_required('sightings', resolve='warn', default=[])

--- a/tests/modules/annotations/resources/test_annotation_identification.py
+++ b/tests/modules/annotations/resources/test_annotation_identification.py
@@ -4,7 +4,6 @@ import uuid
 import pytest
 
 import tests.modules.asset_groups.resources.utils as asset_group_utils
-import tests.modules.sightings.resources.utils as sighting_utils
 import tests.utils as test_utils
 from tests.utils import (
     extension_unavailable,
@@ -56,9 +55,10 @@ def test_annotation_identification(
     sighting_uuid = commit_response.json['guid']
 
     # mark it as processed or it won't be valid in the matching set
-    sighting_utils.write_sighting_path(
-        flask_app_client, researcher_1, f'{sighting_uuid}/reviewed', {}
-    )
+    # NOTE this api is deprecated and doesnt seem to affect matching set
+    # sighting_utils.write_sighting_path(
+    # flask_app_client, researcher_1, f'{sighting_uuid}/reviewed', {}
+    # )
 
     # Second sighting, the one we'll use for testing, Create with annotation but don't commit.... yet
     (

--- a/tests/modules/sightings/resources/test_identify_sighting.py
+++ b/tests/modules/sightings/resources/test_identify_sighting.py
@@ -86,9 +86,10 @@ def test_sighting_identification(
     sighting_uuid = commit_response.json['guid']
 
     # mark it as processed or it won't be valid in the matching set
-    sighting_utils.write_sighting_path(
-        flask_app_client, researcher_1, f'{sighting_uuid}/reviewed', {}
-    )
+    # NOTE this api is deprecated and doesnt seem to affect matching set
+    # sighting_utils.write_sighting_path(
+    # flask_app_client, researcher_1, f'{sighting_uuid}/reviewed', {}
+    # )
 
     # Second sighting, the one we'll use for testing, Create with annotation but don't commit.... yet
     (


### PR DESCRIPTION
### deprecate the use of Sighting `stage` to have user-initiated _processed_ value, leaving this concept to recently added `match_state`.

- Addresses #887 
- Sighting `review_time` altered via `PATCH` on `match_state`
- retire `/api/v1/sightings/GUID/reviewed`
- update User `unprocessed_sightings()` to use `match_state` instead
- tests adjustments