### PR TITLE
935: user lookup by email should be case-insensitive

### DIFF
--- a/app/modules/users/models.py
+++ b/app/modules/users/models.py
@@ -359,6 +359,7 @@ class User(db.Model, HoustonModel):
     @classmethod
     def find(cls, email=None, password=None):
         # Look-up via email
+        from sqlalchemy import func
 
         if email is None:
             return None
@@ -369,7 +370,9 @@ class User(db.Model, HoustonModel):
         ]
         for email_candidate in email_candidates:
 
-            user = cls.query.filter(User.email == email_candidate).first()
+            user = cls.query.filter(
+                func.lower(User.email) == func.lower(email_candidate)
+            ).first()
 
             if password is None:
                 # If no password was provided to check, return any user account we find

--- a/tests/modules/users/test_models.py
+++ b/tests/modules/users/test_models.py
@@ -152,6 +152,9 @@ def test_User_find_with_password(
         db.session.add(user2)
 
     assert models.User.find('user1@localhost', 'user1password') == user1
+    assert (
+        models.User.find('USeR1@locALHOst', 'user1password') == user1
+    )  # case insensitive issue #935
     assert models.User.find('user1@localhost', 'wrong-user1password') is None
     assert models.User.find('user2@localhost', 'user1password') is None
     assert models.User.find('user2@localhost', 'user2password') == user2


### PR DESCRIPTION
- `User.find(email=email)` is now case-insensitive on `email` value
- Allows auth/login to be case-insensitive on email
- Addresses #935 