### PR TITLE
930: Animal/Encounter export

### DIFF
--- a/app/modules/encounters/resources.py
+++ b/app/modules/encounters/resources.py
@@ -237,11 +237,15 @@ class EncounterExport(Resource):
 
         from app.extensions.export.models import Export
 
+        added = set()
         export = Export()
         for enc in encs:
             export.add(enc)
-            export.add(enc.sighting)
-            if enc.individual_guid:
+            if enc.sighting_guid not in added:
+                added.add(enc.sighting_guid)
+                export.add(enc.sighting)
+            if enc.individual_guid and enc.individual_guid not in added:
+                added.add(enc.individual_guid)
                 export.add(enc.individual)
         export.save()
         return send_file(

--- a/app/modules/users/permissions/rules.py
+++ b/app/modules/users/permissions/rules.py
@@ -121,6 +121,7 @@ else:
         ],
         ('Encounter', AccessOperation.READ): ['is_researcher'],
         ('Encounter', AccessOperation.WRITE): ['is_active'],  # TODO is this still correct
+        ('Encounter', AccessOperation.EXPORT): ['is_admin', 'is_exporter'],
         ('Sighting', AccessOperation.READ): ['is_researcher'],
         ('Sighting', AccessOperation.WRITE): ['is_active'],
         ('Sighting', AccessOperation.DELETE): ['is_admin'],

--- a/tests/extensions/export/resources/test_export_api.py
+++ b/tests/extensions/export/resources/test_export_api.py
@@ -53,6 +53,12 @@ def test_export_api(
     # ok, cuz... exporter
     resp = export_utils.export_search(flask_app_client, exporter, query)
     assert resp.content_type == 'application/vnd.ms-excel'
+    # now lets test encounter export too
+    resp = export_utils.export_search(
+        flask_app_client, admin_user, {}, class_name='encounters'
+    )
+    assert resp.content_type == 'application/vnd.ms-excel'
+    assert resp.content_length > 1000
     export_utils.clear_files()
 
 


### PR DESCRIPTION
- fulfills #930 
- adds `/api/v1/encounters/export` endpoint, which takes same `POST` payload as `/search` does, and returns xls file
- exports Encounter data, as well as related Sighting and (if applicable) Individual sheets