### PR TITLE
886: Add feature to count keyword occurrences

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
         name: pyupgrade
         description: Run PyUpgrade on Python code.
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.13.2
     hooks:
       - id: isort
         args: [--settings-path setup.cfg]
@@ -39,7 +39,7 @@ repos:
         entry: brunette --config=setup.cfg
         language: system
         types: [python]
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.8.3
     hooks:
       - id: flake8

--- a/app/modules/keywords/resources.py
+++ b/app/modules/keywords/resources.py
@@ -28,7 +28,7 @@ class Keywords(Resource):
     Manipulations with Keywords.
     """
 
-    @api.response(schemas.BaseKeywordSchema(many=True))
+    @api.response(schemas.DetailedKeywordSchema(many=True))
     @api.paginate()
     def get(self, args):
         """

--- a/app/modules/keywords/schemas.py
+++ b/app/modules/keywords/schemas.py
@@ -15,10 +15,6 @@ class BaseKeywordSchema(ModelSchema):
     """
     Base Keyword schema exposes only the most general fields.
     """
-    usageCount = base_fields.Function(
-                    lambda kw: kw.number_referenced_dependencies(), 
-                    dump_only=True # This is a read-only field
-                    )
 
     class Meta:
         # pylint: disable=missing-docstring
@@ -27,7 +23,6 @@ class BaseKeywordSchema(ModelSchema):
             Keyword.guid.key,
             Keyword.value.key,
             Keyword.source.key,
-            'usageCount', 
 
         )
         dump_only = (Keyword.guid.key,)
@@ -37,13 +32,15 @@ class DetailedKeywordSchema(BaseKeywordSchema):
     """
     Detailed Keyword schema exposes all useful fields.
     """
+    usageCount = base_fields.Function(
+                    lambda kw: kw.number_referenced_dependencies(), 
+                    dump_only=True # This is a read-only field
+                    )
+
 
     class Meta(BaseKeywordSchema.Meta):
         fields = BaseKeywordSchema.Meta.fields + (
-            Keyword.created.key,
-            Keyword.updated.key,
+            'usageCount', 
         )
         dump_only = BaseKeywordSchema.Meta.dump_only + (
-            Keyword.created.key,
-            Keyword.updated.key,
         )

--- a/app/modules/keywords/schemas.py
+++ b/app/modules/keywords/schemas.py
@@ -40,7 +40,11 @@ class DetailedKeywordSchema(BaseKeywordSchema):
 
     class Meta(BaseKeywordSchema.Meta):
         fields = BaseKeywordSchema.Meta.fields + (
+            Keyword.created.key,
+            Keyword.updated.key,
             'usageCount', 
         )
         dump_only = BaseKeywordSchema.Meta.dump_only + (
+            Keyword.created.key,
+            Keyword.updated.key,
         )

--- a/app/modules/keywords/schemas.py
+++ b/app/modules/keywords/schemas.py
@@ -6,7 +6,7 @@ Serialization schemas for Keywords resources RESTful API
 
 
 from flask_restx_patched import ModelSchema
-from flask_marshmallow import base_fields 
+from flask_marshmallow import base_fields
 
 from .models import Keyword
 
@@ -32,17 +32,14 @@ class DetailedKeywordSchema(BaseKeywordSchema):
     """
     Detailed Keyword schema exposes all useful fields.
     """
-    usageCount = base_fields.Function(
-                    lambda kw: kw.number_referenced_dependencies(), 
-                    dump_only=True # This is a read-only field
-                    )
-
+    usageCount = base_fields.Function(lambda kw: kw.number_referenced_dependencies(),
+                                      dump_only=True)
 
     class Meta(BaseKeywordSchema.Meta):
         fields = BaseKeywordSchema.Meta.fields + (
             Keyword.created.key,
             Keyword.updated.key,
-            'usageCount', 
+            'usageCount',  # This is a read-only field
         )
         dump_only = BaseKeywordSchema.Meta.dump_only + (
             Keyword.created.key,

--- a/app/modules/keywords/schemas.py
+++ b/app/modules/keywords/schemas.py
@@ -5,8 +5,9 @@ Serialization schemas for Keywords resources RESTful API
 """
 
 
-from flask_restx_patched import ModelSchema
 from flask_marshmallow import base_fields
+
+from flask_restx_patched import ModelSchema
 
 from .models import Keyword
 
@@ -23,7 +24,6 @@ class BaseKeywordSchema(ModelSchema):
             Keyword.guid.key,
             Keyword.value.key,
             Keyword.source.key,
-
         )
         dump_only = (Keyword.guid.key,)
 
@@ -32,8 +32,10 @@ class DetailedKeywordSchema(BaseKeywordSchema):
     """
     Detailed Keyword schema exposes all useful fields.
     """
-    usageCount = base_fields.Function(lambda kw: kw.number_referenced_dependencies(),
-                                      dump_only=True)
+
+    usageCount = base_fields.Function(
+        lambda kw: kw.number_referenced_dependencies(), dump_only=True
+    )
 
     class Meta(BaseKeywordSchema.Meta):
         fields = BaseKeywordSchema.Meta.fields + (

--- a/app/modules/keywords/schemas.py
+++ b/app/modules/keywords/schemas.py
@@ -6,6 +6,7 @@ Serialization schemas for Keywords resources RESTful API
 
 
 from flask_restx_patched import ModelSchema
+from flask_marshmallow import base_fields 
 
 from .models import Keyword
 
@@ -14,6 +15,10 @@ class BaseKeywordSchema(ModelSchema):
     """
     Base Keyword schema exposes only the most general fields.
     """
+    usageCount = base_fields.Function(
+                    lambda kw: kw.number_referenced_dependencies(), 
+                    dump_only=True # This is a read-only field
+                    )
 
     class Meta:
         # pylint: disable=missing-docstring
@@ -22,6 +27,8 @@ class BaseKeywordSchema(ModelSchema):
             Keyword.guid.key,
             Keyword.value.key,
             Keyword.source.key,
+            'usageCount', 
+
         )
         dump_only = (Keyword.guid.key,)
 

--- a/tests/modules/keywords/resources/test_keywords.py
+++ b/tests/modules/keywords/resources/test_keywords.py
@@ -72,7 +72,6 @@ def test_modify_keyword(db, flask_app_client, researcher_1, staff_user):
     assert response.json.get('value', None) == val2
     assert response.json.get('usageCount', None) == 0
 
-
     # both of these should not be allowed (403)
     response = keyword_utils.patch_keyword(
         flask_app_client, researcher_1, guid, patch, 403

--- a/tests/modules/keywords/resources/test_keywords.py
+++ b/tests/modules/keywords/resources/test_keywords.py
@@ -70,6 +70,8 @@ def test_modify_keyword(db, flask_app_client, researcher_1, staff_user):
     # doublecheck by reading back in
     response = keyword_utils.read_keyword(flask_app_client, researcher_1, guid)
     assert response.json.get('value', None) == val2
+    assert response.json.get('usageCount', None) == 0
+
 
     # both of these should not be allowed (403)
     response = keyword_utils.patch_keyword(


### PR DESCRIPTION
addresses #886 
* uses Keyword method `number_referenced_dependencies()` to add field `usageCount` to DetailedKeywordSchema
* changed `GET /api/v1/keywords` to use DetailedKeywordSchema (rather than BaseKeywordSchema)
* added test for above